### PR TITLE
Allow using label grid on lines and polygons in addition to points

### DIFF
--- a/planetiler-basemap/src/main/java/com/onthegomap/planetiler/basemap/layers/MountainPeak.java
+++ b/planetiler-basemap/src/main/java/com/onthegomap/planetiler/basemap/layers/MountainPeak.java
@@ -100,7 +100,7 @@ public class MountainPeak implements
         // any label grid squares which could lead to inconsistent label ranks for a feature
         // in adjacent tiles. postProcess() will remove anything outside the desired buffer.
         .setBufferPixels(100)
-        .setPointLabelGridSizeAndLimit(13, 100, 5);
+        .setLabelGridSizeAndLimit(13, 100, 5);
     }
   }
 

--- a/planetiler-basemap/src/main/java/com/onthegomap/planetiler/basemap/layers/Park.java
+++ b/planetiler-basemap/src/main/java/com/onthegomap/planetiler/basemap/layers/Park.java
@@ -115,7 +115,7 @@ public class Park implements
         features.centroid(LAYER_NAME).setBufferPixels(256)
           .setAttr(Fields.CLASS, clazz)
           .putAttrs(LanguageUtils.getNames(element.source().tags(), translations))
-          .setPointLabelGridPixelSize(14, 100)
+          .setLabelGridPixelSize(14, 100)
           .setSortKey(SortKey
             .orderByTruesFirst("national_park".equals(clazz))
             .thenByTruesFirst(element.source().hasTag("wikipedia") || element.source().hasTag("wikidata"))

--- a/planetiler-basemap/src/main/java/com/onthegomap/planetiler/basemap/layers/Place.java
+++ b/planetiler-basemap/src/main/java/com/onthegomap/planetiler/basemap/layers/Place.java
@@ -350,10 +350,10 @@ public class Place implements
       .setAttr(Fields.RANK, rank)
       .setMinZoom(minzoom)
       .setSortKey(getSortKey(rank, placeType, element.population(), element.name()))
-      .setPointLabelGridPixelSize(12, 128);
+      .setLabelGridPixelSize(12, 128);
 
     if (rank == null) {
-      feature.setPointLabelGridLimit(LABEL_GRID_LIMITS);
+      feature.setLabelGridLimit(LABEL_GRID_LIMITS);
     }
 
     if ("2".equals(capital) || "yes".equals(capital)) {

--- a/planetiler-basemap/src/main/java/com/onthegomap/planetiler/basemap/layers/Poi.java
+++ b/planetiler-basemap/src/main/java/com/onthegomap/planetiler/basemap/layers/Poi.java
@@ -174,7 +174,7 @@ public class Poi implements
       .setAttr(Fields.LEVEL, Parse.parseLongOrNull(element.source().getTag("level")))
       .setAttr(Fields.INDOOR, element.indoor() ? 1 : null)
       .putAttrs(LanguageUtils.getNames(element.source().tags(), translations))
-      .setPointLabelGridPixelSize(14, 64)
+      .setLabelGridPixelSize(14, 64)
       .setSortKey(rankOrder)
       .setMinZoom(minzoom(element.subclass(), element.mappingKey()));
   }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureCollector.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureCollector.java
@@ -512,11 +512,11 @@ public class FeatureCollector implements Iterable<FeatureCollector.Feature> {
     }
 
     /**
-     * Returns the size in pixels of the grid used to group or limit output points.
+     * Returns the size in pixels of the grid used to group or limit output features.
      *
      * @throws AssertionError when assertions are enabled and the returned value is smaller than the buffer pixel size
      */
-    public double getPointLabelGridPixelSizeAtZoom(int zoom) {
+    public double getLabelGridPixelSizeAtZoom(int zoom) {
       double result = ZoomFunction.applyAsDoubleOrElse(labelGridPixelSize, zoom, DEFAULT_LABEL_GRID_SIZE);
       // TODO is this enough? what about a grid square that ends just before the start of the tile
       assert result <= getBufferPixelsAtZoom(zoom) :
@@ -526,20 +526,22 @@ public class FeatureCollector implements Iterable<FeatureCollector.Feature> {
     }
 
     /**
-     * Returns the maximum number of lowest-sort-key points to include in the output vector tile in each square of a
-     * grid with size {@link #getPointLabelGridPixelSizeAtZoom(int)}.
+     * Returns the maximum number of lowest-sort-key feature to include in the output vector tile in each square of a
+     * grid with size {@link #getLabelGridPixelSizeAtZoom(int)}.
      */
-    public int getPointLabelGridLimitAtZoom(int zoom) {
+    public int getLabelGridLimitAtZoom(int zoom) {
       return ZoomFunction.applyAsIntOrElse(labelGridLimit, zoom, DEFAULT_LABEL_GRID_LIMIT);
     }
 
     /**
-     * Sets the size of a grid in tile pixels that will be used to compute a "location hash" of points rendered in each
-     * zoom-level for limiting the density of features in the output tile, or computing a "rank" key that clients can
-     * use to control label density.
+     * Sets the size of a grid in tile pixels that will be used to compute a "location hash" of features rendered in
+     * each zoom-level for limiting the density of features in the output tile, or computing a "rank" key that clients
+     * can use to control label density.
      * <p>
      * If limit is set, features will be dropped automatically before encoding the vector tile, but "rank" must be added
      * explicitly in {@link Profile#postProcessLayerFeatures(String, int, List)}.
+     * <p>
+     * If used for a line or polygon, it computes the grid hash ID based on an arbitrary point from that feature.
      * <p>
      * Replaces any previous values set for label grid pixel size.
      * <p>
@@ -552,27 +554,27 @@ public class FeatureCollector implements Iterable<FeatureCollector.Feature> {
      * @see <a href="https://github.com/mapbox/postgis-vt-util/blob/master/src/LabelGrid.sql">LabelGrid postgis
      * function</a>
      */
-    public Feature setPointLabelGridPixelSize(ZoomFunction<Number> labelGridSize) {
+    public Feature setLabelGridPixelSize(ZoomFunction<Number> labelGridSize) {
       this.labelGridPixelSize = labelGridSize;
       return this;
     }
 
     /**
-     * Sets the size of a grid in tile pixels that will be used to compute a "location hash" of points rendered in each
-     * zoom-level at and below {@code maxzoom}.
+     * Sets the size of a grid in tile pixels that will be used to compute a "location hash" of features rendered in
+     * each zoom-level at and below {@code maxzoom}.
      * <p>
-     * This is a thin wrapper around {@link #setPointLabelGridPixelSize(ZoomFunction)}. It replaces any previous value
-     * set for label grid size. To set multiple thresholds, use the other method directly.
+     * This is a thin wrapper around {@link #setLabelGridPixelSize(ZoomFunction)}. It replaces any previous value set
+     * for label grid size. To set multiple thresholds, use the other method directly.
      *
      * @see <a href="https://github.com/mapbox/postgis-vt-util/blob/master/src/LabelGrid.sql">LabelGrid postgis
      * function</a>
      */
-    public Feature setPointLabelGridPixelSize(int maxzoom, double size) {
-      return setPointLabelGridPixelSize(ZoomFunction.maxZoom(maxzoom, size));
+    public Feature setLabelGridPixelSize(int maxzoom, double size) {
+      return setLabelGridPixelSize(ZoomFunction.maxZoom(maxzoom, size));
     }
 
     /**
-     * Sets the maximum number of points with the lowest sort-key to include with the same label grid hash in a tile.
+     * Sets the maximum number of features with the lowest sort-key to include with the same label grid hash in a tile.
      * <p>
      * Replaces any previous values set for label grid limit.
      *
@@ -581,17 +583,17 @@ public class FeatureCollector implements Iterable<FeatureCollector.Feature> {
      * @see <a href="https://github.com/mapbox/postgis-vt-util/blob/master/src/LabelGrid.sql">LabelGrid postgis
      * function</a>
      */
-    public Feature setPointLabelGridLimit(ZoomFunction<Number> labelGridLimit) {
+    public Feature setLabelGridLimit(ZoomFunction<Number> labelGridLimit) {
       this.labelGridLimit = labelGridLimit;
       return this;
     }
 
     /**
-     * Limits the density of points on an output tile at and below {@code maxzoom} by only emitting the {@code limit}
+     * Limits the density of features on an output tile at and below {@code maxzoom} by only emitting the {@code limit}
      * features with lowest sort-key in each square of a {@code size x size} pixel grid.
      * <p>
-     * This is a thin wrapper around {@link #setPointLabelGridPixelSize(ZoomFunction)} and {@link
-     * #setPointLabelGridLimit(ZoomFunction)}. It replaces any previous value set for label grid size or limit. To set
+     * This is a thin wrapper around {@link #setLabelGridPixelSize(ZoomFunction)} and {@link
+     * #setLabelGridLimit(ZoomFunction)}. It replaces any previous value set for label grid size or limit. To set
      * multiple thresholds, use the other methods directly.
      * <p>
      * NOTE: the label grid is computed within each tile independently of its neighbors, so to ensure consistent limits
@@ -604,9 +606,9 @@ public class FeatureCollector implements Iterable<FeatureCollector.Feature> {
      * @see <a href="https://github.com/mapbox/postgis-vt-util/blob/master/src/LabelGrid.sql">LabelGrid postgis
      * function</a>
      */
-    public Feature setPointLabelGridSizeAndLimit(int maxzoom, double size, int limit) {
-      return setPointLabelGridPixelSize(ZoomFunction.maxZoom(maxzoom, size))
-        .setPointLabelGridLimit(ZoomFunction.maxZoom(maxzoom, limit));
+    public Feature setLabelGridSizeAndLimit(int maxzoom, double size, int limit) {
+      return setLabelGridPixelSize(ZoomFunction.maxZoom(maxzoom, size))
+        .setLabelGridLimit(ZoomFunction.maxZoom(maxzoom, limit));
     }
 
     // could be expensive, so cache results

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/FeatureCollectorTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/FeatureCollectorTest.java
@@ -57,7 +57,7 @@ public class FeatureCollectorTest {
       .setAttr("attr1", 2)
       .setBufferPixels(10d)
       .setBufferPixelOverrides(ZoomFunction.maxZoom(12, 100d))
-      .setPointLabelGridSizeAndLimit(12, 100, 10);
+      .setLabelGridSizeAndLimit(12, 100, 10);
     assertFeatures(14, List.of(
       Map.of(
         "_layer", "layername",

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/TestUtils.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/TestUtils.java
@@ -381,8 +381,8 @@ public class TestUtils {
     result.put("_layer", feature.getLayer());
     result.put("_sortkey", feature.getSortKey());
     result.put("_geom", new NormGeometry(geom));
-    result.put("_labelgrid_limit", feature.getPointLabelGridLimitAtZoom(zoom));
-    result.put("_labelgrid_size", feature.getPointLabelGridPixelSizeAtZoom(zoom));
+    result.put("_labelgrid_limit", feature.getLabelGridLimitAtZoom(zoom));
+    result.put("_labelgrid_size", feature.getLabelGridPixelSizeAtZoom(zoom));
     result.put("_minpixelsize", feature.getMinPixelSizeAtZoom(zoom));
     result.put("_type", geom instanceof Puntal ? "point" : geom instanceof Lineal ? "line" : "polygon");
     result.put("_numpointsattr", feature.getNumPointsAttr());

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/render/FeatureRendererTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/render/FeatureRendererTest.java
@@ -227,7 +227,7 @@ public class FeatureRendererTest {
       newPoint(0.25, 0.25),
       newPoint(0.25 + 1d / 256, 0.25 + 1d / 256)
     ))
-      .setPointLabelGridPixelSize(10, 10)
+      .setLabelGridPixelSize(10, 10)
       .setZoomRange(0, 1)
       .setBufferPixels(10);
     assertSameNormalizedFeatures(Map.of(
@@ -245,18 +245,18 @@ public class FeatureRendererTest {
   @Test
   public void testLabelGridRequiresBufferPixelsGreaterThanGridSize() {
     assertThrows(AssertionError.class, () -> renderFeatures(pointFeature(newPoint(0.75, 0.75))
-      .setPointLabelGridSizeAndLimit(10, 10, 2)
+      .setLabelGridSizeAndLimit(10, 10, 2)
       .setBufferPixels(9)));
 
     renderFeatures(pointFeature(newPoint(0.75, 0.75))
-      .setPointLabelGridSizeAndLimit(10, 10, 2)
+      .setLabelGridSizeAndLimit(10, 10, 2)
       .setBufferPixels(10));
   }
 
   @Test
   public void testLabelGrid() {
     var feature = pointFeature(newPoint(0.75, 0.75))
-      .setPointLabelGridSizeAndLimit(10, 256, 2)
+      .setLabelGridSizeAndLimit(10, 256, 2)
       .setZoomRange(0, 1)
       .setBufferPixels(256);
     var rendered = renderFeatures(feature);
@@ -269,7 +269,7 @@ public class FeatureRendererTest {
   @Test
   public void testWrapLabelGrid() {
     var feature = pointFeature(newPoint(1.1, -0.1))
-      .setPointLabelGridSizeAndLimit(10, 256, 2)
+      .setLabelGridSizeAndLimit(10, 256, 2)
       .setZoomRange(0, 1)
       .setBufferPixels(256);
     var rendered = renderFeatures(feature);

--- a/planetiler-examples/src/main/java/com/onthegomap/planetiler/examples/ToiletsOverlay.java
+++ b/planetiler-examples/src/main/java/com/onthegomap/planetiler/examples/ToiletsOverlay.java
@@ -42,7 +42,7 @@ public class ToiletsOverlay implements Profile {
         .setSortKey(toiletNumber.incrementAndGet())
         // 2) at lower zoom levels, divide each 256x256 px tile into 32x32 px squares and in each square only include
         // the toilets with the lowest sort key within that square
-        .setPointLabelGridSizeAndLimit(
+        .setLabelGridSizeAndLimit(
           12, // only limit at z12 and below
           32, // break the tile up into 32x32 px squares
           4 // any only keep the 4 nodes with lowest sort-key in each 32px square

--- a/planetiler-examples/src/test/java/com/onthegomap/planetiler/examples/ToiletsProfileTest.java
+++ b/planetiler-examples/src/test/java/com/onthegomap/planetiler/examples/ToiletsProfileTest.java
@@ -39,13 +39,13 @@ public class ToiletsProfileTest {
     assertEquals(1, feature.getSortKey());
 
     // at z12 - use label grid to limit output
-    assertEquals(4, feature.getPointLabelGridLimitAtZoom(12));
-    assertEquals(32, feature.getPointLabelGridPixelSizeAtZoom(12));
+    assertEquals(4, feature.getLabelGridLimitAtZoom(12));
+    assertEquals(32, feature.getLabelGridPixelSizeAtZoom(12));
     assertEquals(32, feature.getBufferPixelsAtZoom(12));
 
     // at z13 - no label grid (0 disables filtering)
-    assertEquals(0, feature.getPointLabelGridLimitAtZoom(13));
-    assertEquals(0, feature.getPointLabelGridPixelSizeAtZoom(13));
+    assertEquals(0, feature.getLabelGridLimitAtZoom(13));
+    assertEquals(0, feature.getLabelGridPixelSizeAtZoom(13));
     assertEquals(4, feature.getBufferPixelsAtZoom(13));
   }
 


### PR DESCRIPTION
Needed by #49 for `mountain_peak` linestring limiting.