### PR TITLE
Gracefully handle exceptions from profiles

### DIFF
--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
@@ -1607,4 +1607,19 @@ public class PlanetilerTests {
       assertEquals(2146, features, "num buildings");
     }
   }
+
+  @Test
+  public void testHandleProfileException() throws Exception {
+    var results = runWithOsmElements(
+      Map.of("threads", "1"),
+      List.of(
+        with(new ReaderNode(1, 0, 0), t -> t.setTag("attr", "value"))
+      ),
+      (in, features) -> {
+        throw new IllegalStateException("intentional exception!");
+      }
+    );
+
+    assertSubmap(Map.of(), results.tiles);
+  }
 }


### PR DESCRIPTION
If a profile throws an exception, the whole process exits. Instead it should log the error and the element that it failed on to make it easier to debug, then continue processing the rest of the input.