### PR TITLE
Handle highways with man_made=bridge

### DIFF
--- a/planetiler-basemap/src/main/java/com/onthegomap/planetiler/basemap/layers/Transportation.java
+++ b/planetiler-basemap/src/main/java/com/onthegomap/planetiler/basemap/layers/Transportation.java
@@ -222,7 +222,7 @@ public class Transportation implements
       "highway", coalesce(highway, ""),
       "public_transport", coalesce(publicTransport, ""),
       "construction", coalesce(construction, "")
-    ), manMade) : manMade;
+    ), null) : manMade;
   }
 
   static String highwaySubclass(String highwayClass, String publicTransport, String highway) {

--- a/planetiler-basemap/src/test/java/com/onthegomap/planetiler/basemap/layers/TransportationTest.java
+++ b/planetiler-basemap/src/test/java/com/onthegomap/planetiler/basemap/layers/TransportationTest.java
@@ -445,6 +445,17 @@ public class TransportationTest extends AbstractLayerTest {
   }
 
   @Test
+  public void testBridgeConstruction() {
+    // https://www.openstreetmap.org/way/658335918 was returning class=bridge, should just ignore
+    assertFeatures(13, List.of(), process(lineFeature(Map.of(
+      "highway", "construction",
+      "construction", "bridge",
+      "man_made", "bridge",
+      "layer", "1"
+    ))));
+  }
+
+  @Test
   public void testRaceway() {
     assertFeatures(13, List.of(Map.of(
       "_layer", "transportation",


### PR DESCRIPTION
https://www.openstreetmap.org/way/658335918 has tags:

```
highway=construction
construction=bridge
man_made=bridge
```

Which made class=bridge.  This change just ignores cases like that.