### PR TITLE
Include route relations without a network type

### DIFF
--- a/planetiler-basemap/src/main/java/com/onthegomap/planetiler/basemap/layers/Transportation.java
+++ b/planetiler-basemap/src/main/java/com/onthegomap/planetiler/basemap/layers/Transportation.java
@@ -288,7 +288,7 @@ public class Transportation implements
         default -> (relation.hasTag("osmc:symbol") || relation.hasTag("colour")) ? 2 : 3;
       };
 
-      if (networkType != null || rank < 3) {
+      if (network != null || rank < 3) {
         return List.of(new RouteRelation(coalesce(ref, ""), network, networkType, (byte) rank, relation.id()));
       }
     }

--- a/planetiler-basemap/src/test/java/com/onthegomap/planetiler/basemap/layers/TransportationTest.java
+++ b/planetiler-basemap/src/test/java/com/onthegomap/planetiler/basemap/layers/TransportationTest.java
@@ -340,6 +340,38 @@ public class TransportationTest extends AbstractLayerTest {
   }
 
   @Test
+  public void testRouteWithoutNetworkType() {
+    var rel = new OsmElement.Relation(1);
+    rel.setTag("type", "route");
+    rel.setTag("route", "road");
+    rel.setTag("network", "US:NJ:NJTP");
+    rel.setTag("ref", "NJTP");
+    rel.setTag("name", "New Jersey Turnpike (mainline)");
+
+    FeatureCollector rendered = process(lineFeatureWithRelation(
+      profile.preprocessOsmRelation(rel),
+      Map.of(
+        "highway", "motorway",
+        "name", "New Jersey Turnpike",
+        "ref", "I 95;NJTP"
+      )));
+
+    assertFeatures(13, List.of(mapOf(
+      "_layer", "transportation",
+      "class", "motorway",
+      "_minzoom", 4
+    ), Map.of(
+      "_layer", "transportation_name",
+      "class", "motorway",
+      "name", "New Jersey Turnpike",
+      "ref", "NJTP",
+      "ref_length", 4,
+      "route_1", "US:NJ:NJTP=NJTP",
+      "_minzoom", 6
+    )), rendered);
+  }
+
+  @Test
   public void testMotorwayJunction() {
     var otherNode1 = new OsmElement.Node(1, 1, 1);
     var junctionNode = new OsmElement.Node(2, 1, 2);


### PR DESCRIPTION
Loosen the check on which route relations to include routes with a network but no network type. Fixes #67 