### PR TITLE
Download automatically from quickstart

### DIFF
--- a/quickstart-from-source.sh
+++ b/quickstart-from-source.sh
@@ -3,10 +3,14 @@
 set -e
 
 AREA="${1:-monaco}"
-shift || echo "using area=monaco"
+shift || echo ""
+
+echo "Will build planetiler, download sources for ${AREA}, and make a map."
+echo "This requires at least 1GB of disk space. Press Ctrl+C to exit..."
+sleep 5
 
 echo "Building..."
 ./mvnw -DskipTests=true --projects planetiler-dist -am package
 
 echo "Running..."
-java -jar planetiler-dist/target/*with-deps.jar --force=true --area="${AREA}" $*
+java -jar planetiler-dist/target/*with-deps.jar --force --download --area="${AREA}" $*


### PR DESCRIPTION
Include `--download` flag from quickstart script and warn before it starts. Fixes #90 