### PR TITLE
Update adoptium links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Pull requests are welcome! To set up your development environment:
 
 - Fork the repo
-- [Install Java 16 or later](https://adoptium.net/installation.html)
+- Install Java 16 or later. You can download Java manually from [Adoptium](https://adoptium.net/installation.html) or use their installers for [Windows](https://adoptium.net/installation.html#windows-msi), [macOS](https://adoptium.net/installation.html#macos-pkg), and [Linux](https://github.com/adoptium/website-v2/blob/main/src/asciidoc-pages/installation/linux.adoc).
 - Build and run the tests ([mvnw](https://github.com/takari/maven-wrapper) automatically downloads maven the first time
   you run it):
   - on max/linux: `./mvnw clean test`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,12 @@
 Pull requests are welcome! To set up your development environment:
 
 - Fork the repo
-- Install Java 16 or later. You can download Java manually from [Adoptium](https://adoptium.net/installation.html) or use their installers for [Windows](https://adoptium.net/installation.html#windows-msi), [macOS](https://adoptium.net/installation.html#macos-pkg), and [Linux](https://github.com/adoptium/website-v2/blob/main/src/asciidoc-pages/installation/linux.adoc).
+- Install Java 16 or later. You can download Java manually from [Adoptium](https://adoptium.net/installation.html) or
+  use:
+  - [Windows installer](https://adoptium.net/installation.html#windows-msi)
+  - [macOS installer](https://adoptium.net/installation.html#macos-pkg) (or `brew install --cask temurin`)
+  - [Linux installer](https://github.com/adoptium/website-v2/blob/main/src/asciidoc-pages/installation/linux.adoc)
+    (or `apt-get install openjdk-17-jdk`)
 - Build and run the tests ([mvnw](https://github.com/takari/maven-wrapper) automatically downloads maven the first time
   you run it):
   - on max/linux: `./mvnw clean test`

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Style [© OpenMapTiles](https://www.openmaptiles.org/)
 
 To generate a map of an area using the [basemap profile](planetiler-basemap), you will need:
 
-- [Java 16+](https://adoptium.net/installation.html) or [Docker](https://docs.docker.com/get-docker/)
+- Java 16+ (see [CONTIRBUTING.md](CONTRIBUTING.md)) or [Docker](https://docs.docker.com/get-docker/)
 - at least 1GB of free disk space plus 5-10x the size of the `.osm.pbf` file
 - at least 1.5x as much free RAM as the input `.osm.pbf` file size
 

--- a/planetiler-examples/README.md
+++ b/planetiler-examples/README.md
@@ -4,7 +4,7 @@ This is a minimal example project that shows how to create custom maps with Plan
 
 Requirements:
 
-- [Java 16 or later](https://adoptium.net/installation.html)
+- Java 16+ (see [CONTIRBUTING.md](../CONTRIBUTING.md))
   - on mac: `brew install --cask temurin`
 - [Maven](https://maven.apache.org/install.html)
   - on mac: `brew install maven`


### PR DESCRIPTION
Expands adoptium java install links to directly point to win, mac, and linux installers.﻿
