### PR TITLE
Check disk space and memory only with OSM input file

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
@@ -495,10 +495,9 @@ public class Planetiler {
       return; // exit only if just fetching wikidata or downloading sources
     }
 
-    checkDiskSpace();
-    checkMemory();
-
     if (osmInputFile != null) {
+      checkDiskSpace();
+      checkMemory();
       config.bounds().setFallbackProvider(osmInputFile);
     }
 


### PR DESCRIPTION
`checkDiskSpace()` and `checkMemory()` estimate resouce requirements based on an OSM input file.
Currently, if no OSM input file is present, e.g., because only a shapefile input is used, Planetiler crashes complaining about the absence of a OSM input file for the resource checks.

With this pull request, the resource checks only run if an OSM file is present.﻿
