### PR TITLE
Offload multipolygon storage to disk (reduce memory usage by 10-15gb)

### DIFF
--- a/planetiler-basemap/src/main/java/com/onthegomap/planetiler/basemap/BasemapProfile.java
+++ b/planetiler-basemap/src/main/java/com/onthegomap/planetiler/basemap/BasemapProfile.java
@@ -195,8 +195,8 @@ public class BasemapProfile extends ForwardingProfile {
 
   @Override
   public long estimateRamRequired(long osmFileSize) {
-    // 30gb for a 60gb OSM file is generally safe, although less might be OK too
-    return osmFileSize / 2;
+    // 20gb for a 67gb OSM file is safe, although less might be OK too
+    return osmFileSize * 20 / 67;
   }
 
   /**

--- a/planetiler-benchmarks/src/main/java/com/onthegomap/planetiler/benchmarks/BenchmarkOsmRead.java
+++ b/planetiler-benchmarks/src/main/java/com/onthegomap/planetiler/benchmarks/BenchmarkOsmRead.java
@@ -2,6 +2,7 @@ package com.onthegomap.planetiler.benchmarks;
 
 import com.onthegomap.planetiler.Profile;
 import com.onthegomap.planetiler.collection.LongLongMap;
+import com.onthegomap.planetiler.collection.LongLongMultimap;
 import com.onthegomap.planetiler.config.Arguments;
 import com.onthegomap.planetiler.config.PlanetilerConfig;
 import com.onthegomap.planetiler.reader.osm.OsmInputFile;
@@ -23,7 +24,8 @@ public class BenchmarkOsmRead {
       Timer timer = Timer.start();
       try (
         var nodes = LongLongMap.noop();
-        var reader = new OsmReader("osm", file, nodes, profile, stats)
+        var multipolygons = LongLongMultimap.noop();
+        var reader = new OsmReader("osm", file, nodes, multipolygons, profile, stats)
       ) {
         reader.pass1(config);
       }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
@@ -177,7 +177,8 @@ public class Planetiler {
           var nodeLocations =
             LongLongMap.from(config.nodeMapType(), config.nodeMapStorage(), nodeDbPath, config.nodeMapMadvise());
           var multipolygonGeometries =
-            LongLongMultimap.newDensedOrderedMultimap(Storage.MMAP, new Storage.Params(multipolygonPath, false));
+            LongLongMultimap.newDensedOrderedMultimap(Storage.MMAP,
+              new Storage.Params(multipolygonPath, config.nodeMapMadvise()));
           var osmReader = new OsmReader(name, thisInputFile, nodeLocations, multipolygonGeometries, profile(), stats)
         ) {
           osmReader.pass1(config);

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
@@ -176,9 +176,8 @@ public class Planetiler {
         try (
           var nodeLocations =
             LongLongMap.from(config.nodeMapType(), config.nodeMapStorage(), nodeDbPath, config.nodeMapMadvise());
-          var multipolygonGeometries =
-            LongLongMultimap.newDensedOrderedMultimap(Storage.MMAP,
-              new Storage.Params(multipolygonPath, config.nodeMapMadvise()));
+          var multipolygonGeometries = LongLongMultimap.newReplaceableMultimap(Storage.MMAP,
+            new Storage.Params(multipolygonPath, config.nodeMapMadvise()));
           var osmReader = new OsmReader(name, thisInputFile, nodeLocations, multipolygonGeometries, profile(), stats)
         ) {
           osmReader.pass1(config);

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/collection/LongLongMultimap.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/collection/LongLongMultimap.java
@@ -64,6 +64,11 @@ public interface LongLongMultimap extends MemoryEstimator.HasEstimate, DiskBacke
   @Override
   void close();
 
+  @Override
+  default long diskUsageBytes() {
+    return 0L;
+  }
+
   /**
    * A map from long to list of longs where you can use {@link #replaceValues(long, LongArrayList)} to set replace the
    * previous list of values with a new one.
@@ -221,11 +226,6 @@ public interface LongLongMultimap extends MemoryEstimator.HasEstimate, DiskBacke
       keys.release();
       values.release();
     }
-  }
-
-  @Override
-  default long diskUsageBytes() {
-    return 0L;
   }
 
   /**

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/config/Arguments.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/config/Arguments.java
@@ -155,12 +155,12 @@ public class Arguments {
     });
   }
 
-  private String getArg(String key) {
+  String getArg(String key) {
     String value = get(key);
     return value == null ? null : value.trim();
   }
 
-  private String getArg(String key, String defaultValue) {
+  String getArg(String key, String defaultValue) {
     String value = getArg(key);
     return value == null ? defaultValue : value;
   }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/osm/OsmReader.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/osm/OsmReader.java
@@ -119,7 +119,7 @@ public class OsmReader implements Closeable, MemoryEstimator.HasEstimate {
       "ways", pass1Phaser::ways,
       "relations", pass1Phaser::relations
     ));
-    multipolygonGeometries = multipolygonGeometries;
+    this.multipolygonWayGeometries = multipolygonGeometries;
   }
 
   /**
@@ -310,7 +310,7 @@ public class OsmReader implements Closeable, MemoryEstimator.HasEstimate {
 
     var pipeline = WorkerPipeline.start("osm_pass2", stats)
       .fromGenerator("read", osmBlockSource::forEachBlock)
-      .addBuffer("pbf_blocks", 100)
+      .addBuffer("pbf_blocks", Math.max(10, threads / 2))
       .<SortableFeature>addWorker("process", processThreads, (prev, next) -> {
         // avoid contention trying to get the thread-local counters by getting them once when thread starts
         Counter blocks = blocksProcessed.counterForThread();

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/osm/OsmReader.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/osm/OsmReader.java
@@ -15,6 +15,7 @@ import com.onthegomap.planetiler.collection.Hppc;
 import com.onthegomap.planetiler.collection.LongLongMap;
 import com.onthegomap.planetiler.collection.LongLongMultimap;
 import com.onthegomap.planetiler.collection.SortableFeature;
+import com.onthegomap.planetiler.collection.Storage;
 import com.onthegomap.planetiler.config.PlanetilerConfig;
 import com.onthegomap.planetiler.geo.GeoUtils;
 import com.onthegomap.planetiler.geo.GeometryException;
@@ -26,12 +27,14 @@ import com.onthegomap.planetiler.stats.ProgressLoggers;
 import com.onthegomap.planetiler.stats.Stats;
 import com.onthegomap.planetiler.util.Format;
 import com.onthegomap.planetiler.util.MemoryEstimator;
+import com.onthegomap.planetiler.util.ResourceUsage;
 import com.onthegomap.planetiler.worker.Distributor;
 import com.onthegomap.planetiler.worker.WeightedHandoffQueue;
 import com.onthegomap.planetiler.worker.WorkQueue;
 import com.onthegomap.planetiler.worker.WorkerPipeline;
 import java.io.Closeable;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -120,6 +123,15 @@ public class OsmReader implements Closeable, MemoryEstimator.HasEstimate {
       "relations", pass1Phaser::relations
     ));
     this.multipolygonWayGeometries = multipolygonGeometries;
+  }
+
+  /**
+   * Alias for {@link #OsmReader(String, Supplier, LongLongMap, LongLongMultimap.Replaceable, Profile, Stats)} that sets
+   * the multipolygon geometry multimap to a default in-memory implementation.
+   */
+  public OsmReader(String name, Supplier<OsmBlockSource> osmSourceProvider, LongLongMap nodeLocationDb, Profile profile,
+    Stats stats) {
+    this(name, osmSourceProvider, nodeLocationDb, LongLongMultimap.newInMemoryReplaceableMultimap(), profile, stats);
   }
 
   /**
@@ -368,7 +380,8 @@ public class OsmReader implements Closeable, MemoryEstimator.HasEstimate {
       .addRatePercentCounter("blocks", PASS1_BLOCKS.get(), blocksProcessed, false)
       .newLine()
       .addProcessStats()
-      .addInMemoryObject("hppc", this)
+      .addInMemoryObject("relInfo", this)
+      .addFileSizeAndRam("mpGeoms", multipolygonWayGeometries)
       .newLine()
       .addPipelineStats(pipeline);
 
@@ -386,6 +399,57 @@ public class OsmReader implements Closeable, MemoryEstimator.HasEstimate {
     } catch (Exception e) {
       LOGGER.error("Error calling profile.finish", e);
     }
+  }
+
+  /** Estimates the resource requirements for a nodemap but parses the type/storage from strings. */
+  public static ResourceUsage estimateNodeLocationUsage(String type, String storage, long osmFileSize, Path path) {
+    return estimateNodeLocationUsage(LongLongMap.Type.from(type), Storage.from(storage), osmFileSize, path);
+  }
+
+  /** Estimates the resource requirements for a nodemap for a given OSM input file. */
+  public static ResourceUsage estimateNodeLocationUsage(LongLongMap.Type type, Storage storage, long osmFileSize,
+    Path path) {
+    long nodes = estimateNumNodes(osmFileSize);
+    long maxNodeId = estimateMaxNodeId(osmFileSize);
+
+    ResourceUsage check = new ResourceUsage("nodemap");
+
+    return switch (type) {
+      case NOOP -> check;
+      case SPARSE_ARRAY -> check.addMemory(300_000_000L, "sparsearray node location in-memory index")
+        .add(path, storage, 9 * nodes, "sparsearray node location cache");
+      case SORTED_TABLE -> check.addMemory(300_000_000L, "sortedtable node location in-memory index")
+        .add(path, storage, 12 * nodes, "sortedtable node location cache");
+      case ARRAY -> check.add(path, storage, 8 * maxNodeId,
+        "array node location cache (switch to sparsearray to reduce size)");
+    };
+  }
+
+  /**
+   * Estimates the resource requirements for a multipolygon geometry multimap but parses the type/storage from strings.
+   */
+  public static ResourceUsage estimateMultipolygonGeometryUsage(String storage, long osmFileSize, Path path) {
+    return estimateMultipolygonGeometryUsage(Storage.from(storage), osmFileSize, path);
+  }
+
+  /** Estimates the resource requirements for a multipolygon geometry multimap for a given OSM input file. */
+  public static ResourceUsage estimateMultipolygonGeometryUsage(Storage storage, long osmFileSize, Path path) {
+    // Massachusetts extract (260MB) requires about 20MB for way geometries
+    long estimatedSize = 20_000_000L * osmFileSize / 260_000_000L;
+
+    return new ResourceUsage("way geometry multipolygon")
+      .add(path, storage, estimatedSize, "multipolygon way geometries");
+  }
+
+  private static long estimateNumNodes(long osmFileSize) {
+    // On 2/14/2022, planet.pbf was 66691979646 bytes with ~7.5b nodes, so scale from there
+    return Math.round(7_500_000_000d * (osmFileSize / 66_691_979_646d));
+  }
+
+  private static long estimateMaxNodeId(long osmFileSize) {
+    // On 2/14/2022, planet.pbf was 66691979646 bytes and max node ID was ~9.5b, so scale from there
+    // but don't go less than 9.5b in case it's an extract
+    return Math.round(9_500_000_000d * Math.max(1, osmFileSize / 66_691_979_646d));
   }
 
   private void render(FeatureCollector.Factory featureCollectors, FeatureRenderer renderer, OsmElement element,
@@ -468,7 +532,7 @@ public class OsmReader implements Closeable, MemoryEstimator.HasEstimate {
   public long estimateMemoryUsageBytes() {
     long size = 0;
     size += estimateSize(waysInMultipolygon);
-    size += estimateSize(multipolygonWayGeometries);
+    // multipolygonWayGeometries is reported separately
     size += estimateSize(wayToRelations);
     size += estimateSize(relationInfo);
     size += estimateSize(roleIdsReverse);

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/stats/ProgressLoggers.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/stats/ProgressLoggers.java
@@ -227,11 +227,16 @@ public class ProgressLoggers {
     return add(() -> " " + padRight(format.storage(longSupplier.diskUsageBytes(), false), 5));
   }
 
-  /** Adds the total of disk and memory usage of {@code thing}. */
+  /** Adds the name and total of disk and memory usage of {@code thing}. */
   public <T extends DiskBacked & MemoryEstimator.HasEstimate> ProgressLoggers addFileSizeAndRam(T thing) {
+    return addFileSizeAndRam("", thing);
+  }
+
+  /** Adds the total of disk and memory usage of {@code thing}. */
+  public <T extends DiskBacked & MemoryEstimator.HasEstimate> ProgressLoggers addFileSizeAndRam(String name, T thing) {
     return add(() -> {
       long bytes = thing.diskUsageBytes() + thing.estimateMemoryUsageBytes();
-      return " " + padRight(format.storage(bytes, false), 5);
+      return " " + name + (name.isBlank() ? "" : ": ") + padRight(format.storage(bytes, false), 5);
     });
   }
 

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.onthegomap.planetiler.collection.FeatureGroup;
 import com.onthegomap.planetiler.collection.LongLongMap;
+import com.onthegomap.planetiler.collection.LongLongMultimap;
 import com.onthegomap.planetiler.config.Arguments;
 import com.onthegomap.planetiler.config.MbtilesMetadata;
 import com.onthegomap.planetiler.config.PlanetilerConfig;
@@ -104,7 +105,8 @@ public class PlanetilerTests {
       next.accept(OsmBlockSource.Block.of(osmElements.stream().filter(e -> e instanceof OsmElement.Relation).toList()));
     };
     var nodeMap = LongLongMap.newInMemorySortedTable();
-    try (var reader = new OsmReader("osm", () -> elems, nodeMap, profile, Stats.inMemory())) {
+    var multipolygons = LongLongMultimap.newInMemoryDenseOrderedMultimap();
+    try (var reader = new OsmReader("osm", () -> elems, nodeMap, multipolygons, profile, Stats.inMemory())) {
       reader.pass1(config);
       reader.pass2(featureGroup, config);
     }
@@ -777,7 +779,8 @@ public class PlanetilerTests {
             OsmBlockSource.Block.of(osmElements.stream().filter(e -> e instanceof OsmElement.Relation).toList()));
         };
         var nodeMap = LongLongMap.newInMemorySortedTable();
-        try (var reader = new OsmReader("osm", () -> elems, nodeMap, profile, Stats.inMemory())) {
+        var multipolygons = LongLongMultimap.newInMemoryDenseOrderedMultimap();
+        try (var reader = new OsmReader("osm", () -> elems, nodeMap, multipolygons, profile, Stats.inMemory())) {
           // skip pass 1
           reader.pass2(featureGroup, config);
         }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
@@ -105,7 +105,7 @@ public class PlanetilerTests {
       next.accept(OsmBlockSource.Block.of(osmElements.stream().filter(e -> e instanceof OsmElement.Relation).toList()));
     };
     var nodeMap = LongLongMap.newInMemorySortedTable();
-    var multipolygons = LongLongMultimap.newInMemoryDenseOrderedMultimap();
+    var multipolygons = LongLongMultimap.newInMemoryReplaceableMultimap();
     try (var reader = new OsmReader("osm", () -> elems, nodeMap, multipolygons, profile, Stats.inMemory())) {
       reader.pass1(config);
       reader.pass2(featureGroup, config);
@@ -779,7 +779,7 @@ public class PlanetilerTests {
             OsmBlockSource.Block.of(osmElements.stream().filter(e -> e instanceof OsmElement.Relation).toList()));
         };
         var nodeMap = LongLongMap.newInMemorySortedTable();
-        var multipolygons = LongLongMultimap.newInMemoryDenseOrderedMultimap();
+        var multipolygons = LongLongMultimap.newInMemoryReplaceableMultimap();
         try (var reader = new OsmReader("osm", () -> elems, nodeMap, multipolygons, profile, Stats.inMemory())) {
           // skip pass 1
           reader.pass2(featureGroup, config);

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/collection/LongLongMapTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/collection/LongLongMapTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.onthegomap.planetiler.reader.osm.OsmReader;
 import com.onthegomap.planetiler.util.Format;
 import com.onthegomap.planetiler.util.ResourceUsage;
 import java.nio.file.Path;
@@ -127,7 +128,7 @@ public abstract class LongLongMapTest {
         for (LongLongMap.Type type : LongLongMap.Type.values()) {
           var variant = storage + "-" + type;
           var params = new Storage.Params(path.resolve(variant), true);
-          var estimatedSize = LongLongMap.estimateStorageRequired(type, storage, 70_000_000_000L, params.path());
+          var estimatedSize = OsmReader.estimateNodeLocationUsage(type, storage, 70_000_000_000L, params.path());
           var usage = storage == Storage.MMAP ? estimatedSize.diskUsage() :
             estimatedSize.get(
               storage == Storage.DIRECT ? ResourceUsage.DIRECT_MEMORY : ResourceUsage.HEAP

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/collection/LongLongMultimapTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/collection/LongLongMultimapTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.carrotsearch.hppc.LongArrayList;
+import java.nio.file.Path;
 import java.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -158,7 +159,8 @@ public abstract class LongLongMultimapTest {
     @BeforeEach
     public void setup() {
       retainInputOrder = true;
-      this.map = LongLongMultimap.newDensedOrderedMultimap();
+      this.map =
+        LongLongMultimap.newDensedOrderedMultimap(Storage.RAM, new Storage.Params(Path.of("/dev/null"), false));
     }
   }
 }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/reader/osm/OsmReaderTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/reader/osm/OsmReaderTest.java
@@ -29,7 +29,7 @@ public class OsmReaderTest {
   private final Stats stats = Stats.inMemory();
   private final Profile profile = new Profile.NullProfile();
   private final LongLongMap nodeMap = LongLongMap.newInMemorySortedTable();
-  private final LongLongMultimap multipolygons = LongLongMultimap.newInMemoryDenseOrderedMultimap();
+  private final LongLongMultimap.Replaceable multipolygons = LongLongMultimap.newInMemoryReplaceableMultimap();
 
   private void processPass1Block(OsmReader reader, Iterable<OsmElement> block) {
     reader.processPass1Blocks(List.of(block));

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/reader/osm/OsmReaderTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/reader/osm/OsmReaderTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.onthegomap.planetiler.Profile;
 import com.onthegomap.planetiler.TestUtils;
 import com.onthegomap.planetiler.collection.LongLongMap;
+import com.onthegomap.planetiler.collection.LongLongMultimap;
 import com.onthegomap.planetiler.geo.GeoUtils;
 import com.onthegomap.planetiler.geo.GeometryException;
 import com.onthegomap.planetiler.reader.SourceFeature;
@@ -28,6 +29,7 @@ public class OsmReaderTest {
   private final Stats stats = Stats.inMemory();
   private final Profile profile = new Profile.NullProfile();
   private final LongLongMap nodeMap = LongLongMap.newInMemorySortedTable();
+  private final LongLongMultimap multipolygons = LongLongMultimap.newInMemoryDenseOrderedMultimap();
 
   private void processPass1Block(OsmReader reader, Iterable<OsmElement> block) {
     reader.processPass1Blocks(List.of(block));
@@ -608,7 +610,7 @@ public class OsmReaderTest {
   public void testWayInRelation() {
     record OtherRelInfo(long id) implements OsmRelationInfo {}
     record TestRelInfo(long id, String name) implements OsmRelationInfo {}
-    OsmReader reader = new OsmReader("osm", () -> osmSource, nodeMap, new Profile.NullProfile() {
+    OsmReader reader = new OsmReader("osm", () -> osmSource, nodeMap, multipolygons, new Profile.NullProfile() {
       @Override
       public List<OsmRelationInfo> preprocessOsmRelation(OsmElement.Relation relation) {
         return List.of(new TestRelInfo(1, "name"));
@@ -635,7 +637,7 @@ public class OsmReaderTest {
   @Test
   public void testNodeOrWayRelationInRelationDoesntTriggerWay() {
     record TestRelInfo(long id, String name) implements OsmRelationInfo {}
-    OsmReader reader = new OsmReader("osm", () -> osmSource, nodeMap, new Profile.NullProfile() {
+    OsmReader reader = new OsmReader("osm", () -> osmSource, nodeMap, multipolygons, new Profile.NullProfile() {
       @Override
       public List<OsmRelationInfo> preprocessOsmRelation(OsmElement.Relation relation) {
         return List.of(new TestRelInfo(1, "name"));
@@ -659,6 +661,6 @@ public class OsmReaderTest {
   }
 
   private OsmReader newOsmReader() {
-    return new OsmReader("osm", () -> osmSource, nodeMap, profile, stats);
+    return new OsmReader("osm", () -> osmSource, nodeMap, multipolygons, profile, stats);
   }
 }

--- a/planetiler-examples/src/main/java/com/onthegomap/planetiler/examples/ToiletsOverlayLowLevelApi.java
+++ b/planetiler-examples/src/main/java/com/onthegomap/planetiler/examples/ToiletsOverlayLowLevelApi.java
@@ -4,6 +4,7 @@ import com.onthegomap.planetiler.Planetiler;
 import com.onthegomap.planetiler.Profile;
 import com.onthegomap.planetiler.collection.FeatureGroup;
 import com.onthegomap.planetiler.collection.LongLongMap;
+import com.onthegomap.planetiler.collection.LongLongMultimap;
 import com.onthegomap.planetiler.config.Arguments;
 import com.onthegomap.planetiler.config.MbtilesMetadata;
 import com.onthegomap.planetiler.config.PlanetilerConfig;
@@ -88,7 +89,8 @@ public class ToiletsOverlayLowLevelApi {
        * any node locations.
        */
       var nodeLocations = LongLongMap.noop();
-      var osmReader = new OsmReader("osm", new OsmInputFile(input), nodeLocations, profile, stats)
+      var multipolygons = LongLongMultimap.noop();
+      var osmReader = new OsmReader("osm", new OsmInputFile(input), nodeLocations, multipolygons, profile, stats)
     ) {
       // Normally you need to run OsmReader.pass1(config) first which stores node locations and preprocesses relations for
       // way processing, and counts elements. But since this profile only processes nodes we can skip pass 1.


### PR DESCRIPTION
The next biggest object held in memory after node locations is multipolygon way geometries. This was storing node IDs in an HPPC `LongLongMap` which makes a copy every time it expands. The list was getting up to 5-7GB, which requires an extra 5-7GB each time it expands.  This change moves that to a more memory-efficient `AppendStore` that doesn't require an extra 5-7GB memory to expand, and can also be offloaded to disk save another 5-7GB.

I tested this out on the planet twice:

- `-Xmx32g` on a 16 cpu/64GB digitalocean droplet: finished in 2h19m (osm_pass2 took 1h36m)
- `-Xmx20g` on a 16 cpu/32GB digitalocean droplet: finished in 2h58m (osm_pass2 took 2h5m)

Checklist:

- [x] expose settings so you can switch the append store implementation
- [x] estimate memory usage
- [x] report memory usage in logs