### PR TITLE
Don't get transportation_name ref values from minor networks

### DIFF
--- a/planetiler-basemap/src/main/java/com/onthegomap/planetiler/basemap/layers/TransportationName.java
+++ b/planetiler-basemap/src/main/java/com/onthegomap/planetiler/basemap/layers/TransportationName.java
@@ -213,16 +213,8 @@ public class TransportationName implements
       .findFirst()
       .orElse(null);
 
-    // first choice is to set ref from a major network this way is a pary of
     if (firstRelationWithNetwork != null && nullIfEmpty(firstRelationWithNetwork.ref()) != null) {
       ref = firstRelationWithNetwork.ref();
-    }
-
-    // second choice is to set ref from the element itself
-
-    // third choice is to fall back to a minor network the way exists in
-    if (ref == null) {
-      ref = relations.stream().map(rel -> rel.ref()).findFirst().orElse(null);
     }
 
     String name = nullIfEmpty(element.name());

--- a/planetiler-basemap/src/main/java/com/onthegomap/planetiler/basemap/layers/TransportationName.java
+++ b/planetiler-basemap/src/main/java/com/onthegomap/planetiler/basemap/layers/TransportationName.java
@@ -244,7 +244,7 @@ public class TransportationName implements
       .setAttr(Fields.REF, ref)
       .setAttr(Fields.REF_LENGTH, ref != null ? ref.length() : null)
       .setAttr(Fields.NETWORK,
-        (firstRelationWithNetwork != null && firstRelationWithNetwork.networkType() != null) ?
+        firstRelationWithNetwork != null ?
           firstRelationWithNetwork.networkType().name :
           !nullOrEmpty(ref) ? "road" : null)
       .setAttr(Fields.CLASS, highwayClass)

--- a/planetiler-basemap/src/main/java/com/onthegomap/planetiler/basemap/layers/TransportationName.java
+++ b/planetiler-basemap/src/main/java/com/onthegomap/planetiler/basemap/layers/TransportationName.java
@@ -121,6 +121,7 @@ public class TransportationName implements
   private final boolean sizeForShield;
   private final boolean limitMerge;
   private final PlanetilerConfig config;
+  private final boolean minorRefs;
   private Transportation transportation;
   private final LongByteMap motorwayJunctionHighwayClasses = Hppc.newLongByteHashMap();
 
@@ -139,6 +140,11 @@ public class TransportationName implements
     this.limitMerge = config.arguments().getBoolean(
       "transportation_name_limit_merge",
       "transportation_name layer: limit merge so we don't combine different relations to help merge long highways",
+      false
+    );
+    this.minorRefs = config.arguments().getBoolean(
+      "transportation_name_minor_refs",
+      "transportation_name layer: include name and refs from minor road networks if not present on a way",
       false
     );
   }
@@ -213,8 +219,17 @@ public class TransportationName implements
       .findFirst()
       .orElse(null);
 
-    if (firstRelationWithNetwork != null && nullIfEmpty(firstRelationWithNetwork.ref()) != null) {
+    if (firstRelationWithNetwork != null && !nullOrEmpty(firstRelationWithNetwork.ref())) {
       ref = firstRelationWithNetwork.ref();
+    }
+
+    // if transportation_name_minor_refs flag set and we don't have a ref yet, then pull it from any network
+    if (nullOrEmpty(ref) && minorRefs && !relations.isEmpty()) {
+      ref = relations.stream()
+        .map(r -> r.ref())
+        .filter(r -> !nullOrEmpty(r))
+        .findFirst()
+        .orElse(null);
     }
 
     String name = nullIfEmpty(element.name());
@@ -244,9 +259,8 @@ public class TransportationName implements
       .setAttr(Fields.REF, ref)
       .setAttr(Fields.REF_LENGTH, ref != null ? ref.length() : null)
       .setAttr(Fields.NETWORK,
-        firstRelationWithNetwork != null ?
-          firstRelationWithNetwork.networkType().name :
-          !nullOrEmpty(ref) ? "road" : null)
+        firstRelationWithNetwork != null ? firstRelationWithNetwork.networkType().name : !nullOrEmpty(ref) ? "road" :
+          null)
       .setAttr(Fields.CLASS, highwayClass)
       .setAttr(Fields.SUBCLASS, highwaySubclass(highwayClass, null, highway))
       .setMinPixelSize(0)

--- a/planetiler-basemap/src/main/java/com/onthegomap/planetiler/basemap/layers/TransportationName.java
+++ b/planetiler-basemap/src/main/java/com/onthegomap/planetiler/basemap/layers/TransportationName.java
@@ -213,14 +213,14 @@ public class TransportationName implements
       .findFirst()
       .orElse(null);
 
-    // first choice is to set ref from a
+    // first choice is to set ref from a major network this way is a pary of
     if (firstRelationWithNetwork != null && nullIfEmpty(firstRelationWithNetwork.ref()) != null) {
       ref = firstRelationWithNetwork.ref();
     }
 
     // second choice is to set ref from the element itself
 
-    // third choice is to fall back to another relation the way exists in
+    // third choice is to fall back to a minor network the way exists in
     if (ref == null) {
       ref = relations.stream().map(rel -> rel.ref()).findFirst().orElse(null);
     }

--- a/planetiler-basemap/src/test/java/com/onthegomap/planetiler/basemap/layers/TransportationTest.java
+++ b/planetiler-basemap/src/test/java/com/onthegomap/planetiler/basemap/layers/TransportationTest.java
@@ -391,16 +391,35 @@ public class TransportationTest extends AbstractLayerTest {
     rel1.setTag("ref", "GFW");
     rel1.setTag("name", "Georg-Fahrbach-Weg");
 
-    FeatureCollector rendered = process(lineFeatureWithRelation(
-      profile.preprocessOsmRelation(rel1),
-      Map.of(
-        "highway", "tertiary"
-      )));
-
     assertFeatures(13, List.of(mapOf(
       "_layer", "transportation",
       "class", "tertiary"
-    )), rendered);
+    )), process(lineFeatureWithRelation(
+      profile.preprocessOsmRelation(rel1),
+      Map.of(
+        "highway", "tertiary"
+      ))));
+
+    var profileWithMinorRefs = new BasemapProfile(translations, PlanetilerConfig.from(Arguments.of(Map.of(
+      "transportation_name_minor_refs", "true"
+    ))), Stats.inMemory());
+
+    SourceFeature feature = lineFeatureWithRelation(
+      profileWithMinorRefs.preprocessOsmRelation(rel1),
+      Map.of(
+        "highway", "tertiary"
+      ));
+    var collector = featureCollectorFactory.get(feature);
+    profileWithMinorRefs.processFeature(feature, collector);
+    assertFeatures(13, List.of(mapOf(
+      "_layer", "transportation",
+      "class", "tertiary"
+    ), mapOf(
+      "_layer", "transportation_name",
+      "class", "tertiary",
+      "ref", "GFW",
+      "network", "road"
+    )), collector);
   }
 
   @Test

--- a/planetiler-basemap/src/test/java/com/onthegomap/planetiler/basemap/layers/TransportationTest.java
+++ b/planetiler-basemap/src/test/java/com/onthegomap/planetiler/basemap/layers/TransportationTest.java
@@ -341,15 +341,25 @@ public class TransportationTest extends AbstractLayerTest {
 
   @Test
   public void testRouteWithoutNetworkType() {
-    var rel = new OsmElement.Relation(1);
-    rel.setTag("type", "route");
-    rel.setTag("route", "road");
-    rel.setTag("network", "US:NJ:NJTP");
-    rel.setTag("ref", "NJTP");
-    rel.setTag("name", "New Jersey Turnpike (mainline)");
+    var rel1 = new OsmElement.Relation(1);
+    rel1.setTag("type", "route");
+    rel1.setTag("route", "road");
+    rel1.setTag("network", "US:NJ:NJTP");
+    rel1.setTag("ref", "NJTP");
+    rel1.setTag("name", "New Jersey Turnpike (mainline)");
+
+    var rel2 = new OsmElement.Relation(1);
+    rel2.setTag("type", "route");
+    rel2.setTag("route", "road");
+    rel2.setTag("network", "US:I");
+    rel2.setTag("ref", "95");
+    rel2.setTag("name", "I 95 (NJ)");
 
     FeatureCollector rendered = process(lineFeatureWithRelation(
-      profile.preprocessOsmRelation(rel),
+      Stream.concat(
+        profile.preprocessOsmRelation(rel1).stream(),
+        profile.preprocessOsmRelation(rel2).stream()
+      ).toList(),
       Map.of(
         "highway", "motorway",
         "name", "New Jersey Turnpike",
@@ -364,10 +374,51 @@ public class TransportationTest extends AbstractLayerTest {
       "_layer", "transportation_name",
       "class", "motorway",
       "name", "New Jersey Turnpike",
-      "ref", "NJTP",
-      "ref_length", 4,
-      "route_1", "US:NJ:NJTP=NJTP",
+      "ref", "95",
+      "ref_length", 2,
+      "route_1", "US:I=95",
+      "route_2", "US:NJ:NJTP=NJTP",
       "_minzoom", 6
+    )), rendered);
+  }
+
+  @Test
+  public void testPolishHighwayIssue165() {
+    var rel1 = new OsmElement.Relation(1);
+    rel1.setTag("type", "route");
+    rel1.setTag("route", "road");
+    rel1.setTag("network", "e-road");
+    rel1.setTag("ref", "E 77");
+    rel1.setTag("name", "European route E 77");
+
+    var rel2 = new OsmElement.Relation(2);
+    rel2.setTag("type", "route");
+    rel2.setTag("route", "road");
+    rel2.setTag("network", "e-road");
+    rel2.setTag("ref", "E 28");
+    rel2.setTag("name", "European route E 28");
+
+    FeatureCollector rendered = process(lineFeatureWithRelation(
+      Stream.concat(
+        profile.preprocessOsmRelation(rel1).stream(),
+        profile.preprocessOsmRelation(rel2).stream()
+      ).toList(),
+      Map.of(
+        "highway", "trunk",
+        "ref", "S7"
+      )));
+
+    assertFeatures(13, List.of(mapOf(
+      "_layer", "transportation",
+      "class", "trunk"
+    ), Map.of(
+      "_layer", "transportation_name",
+      "class", "trunk",
+      "name", "<null>",
+      "ref", "S7",
+      "ref_length", 2,
+      "route_1", "e-road=E 28",
+      "route_2", "e-road=E 77"
     )), rendered);
   }
 

--- a/planetiler-basemap/src/test/java/com/onthegomap/planetiler/basemap/layers/TransportationTest.java
+++ b/planetiler-basemap/src/test/java/com/onthegomap/planetiler/basemap/layers/TransportationTest.java
@@ -383,6 +383,27 @@ public class TransportationTest extends AbstractLayerTest {
   }
 
   @Test
+  public void testMinorRouteRef() {
+    var rel1 = new OsmElement.Relation(1);
+    rel1.setTag("type", "route");
+    rel1.setTag("route", "road");
+    rel1.setTag("network", "rwn");
+    rel1.setTag("ref", "GFW");
+    rel1.setTag("name", "Georg-Fahrbach-Weg");
+
+    FeatureCollector rendered = process(lineFeatureWithRelation(
+      profile.preprocessOsmRelation(rel1),
+      Map.of(
+        "highway", "tertiary"
+      )));
+
+    assertFeatures(13, List.of(mapOf(
+      "_layer", "transportation",
+      "class", "tertiary"
+    )), rendered);
+  }
+
+  @Test
   public void testPolishHighwayIssue165() {
     var rel1 = new OsmElement.Relation(1);
     rel1.setTag("type", "route");


### PR DESCRIPTION
Fix #145 and #144 by only getting transportation_name `ref` values for a way from major networks that the way is a part of, not minor ones.

There might be cases where you do want refs from minor networks as a fallback, you can keep this behavior with `--transportation-name-minor-refs`.