### PR TITLE
Run `spotless:check` before verify actions in CI

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,7 +28,7 @@ jobs:
   build:
     name: Java ${{ matrix.jdk }} / ${{ matrix.os }} ${{ matrix.args }}
     # Wait until after we check that you ran mvn spotless:apply, otherwise will fail with a cryptic error message
-    needs: format
+    needs: lint
     strategy:
       fail-fast: false
       matrix:
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     # Wait until after we check that you ran mvn spotless:apply, otherwise will fail with a cryptic error message
-    needs: format
+    needs: lint
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 17

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,9 +8,27 @@ on:
     branches: [ main ]
 
 jobs:
-  # TODO: add format/checkstyle
+  # When spotless:apply fails, the error message is a bit cryptic, so try to make it obvious that
+  # is the problem by putting the check into a standalone job
+  lint:
+    name: Check formatted with mvn spotless:apply
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          java-version: 17
+          distribution: 'temurin'
+          cache: 'maven'
+      - name: Ensure code formatted with mvn spotless:apply
+        run: ./mvnw -DskipTests --batch-mode -no-transfer-progress spotless:check
+
   build:
     name: Java ${{ matrix.jdk }} / ${{ matrix.os }} ${{ matrix.args }}
+    # Wait until after we check that you ran mvn spotless:apply, otherwise will fail with a cryptic error message
+    needs: format
     strategy:
       fail-fast: false
       matrix:
@@ -44,6 +62,8 @@ jobs:
     name: Regenerate
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # Wait until after we check that you ran mvn spotless:apply, otherwise will fail with a cryptic error message
+    needs: format
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 17

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -11,7 +11,7 @@ jobs:
   # When spotless:apply fails, the error message is a bit cryptic, so try to make it obvious that
   # is the problem by putting the check into a standalone job
   lint:
-    name: Check formatted with mvn spotless:apply
+    name: Check formatting
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
@@ -58,7 +58,7 @@ import org.slf4j.LoggerFactory;
 @SuppressWarnings("UnusedReturnValue")
 public class Planetiler {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(Planetiler.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(Planetiler.class);
   private final List<Stage> stages = new ArrayList<>();
   private final List<ToDownload> toDownload = new ArrayList<>();
   private final List<InputPath> inputPaths = new ArrayList<>();

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
@@ -58,7 +58,7 @@ import org.slf4j.LoggerFactory;
 @SuppressWarnings("UnusedReturnValue")
 public class Planetiler {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(Planetiler.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(Planetiler.class);
   private final List<Stage> stages = new ArrayList<>();
   private final List<ToDownload> toDownload = new ArrayList<>();
   private final List<InputPath> inputPaths = new ArrayList<>();


### PR DESCRIPTION
When there's a spotless violation all of the tests on different platforms fail with a cryptic error message. Try to make this more obvious by pulling into an initial `lint` task that runs before them.