### PR TITLE
Reduce forest/wood landcover min zoom to 7

### DIFF
--- a/planetiler-basemap/src/main/java/com/onthegomap/planetiler/basemap/layers/Landcover.java
+++ b/planetiler-basemap/src/main/java/com/onthegomap/planetiler/basemap/layers/Landcover.java
@@ -128,7 +128,7 @@ public class Landcover implements
         .setAttr(Fields.CLASS, clazz)
         .setAttr(Fields.SUBCLASS, subclass)
         .setNumPointsAttr(TEMP_NUM_POINTS_ATTR)
-        .setMinZoom(WOOD_OR_FOREST.contains(subclass) ? 9 : 7);
+        .setMinZoom(7);
     }
   }
 

--- a/planetiler-basemap/src/test/java/com/onthegomap/planetiler/basemap/layers/LandcoverTest.java
+++ b/planetiler-basemap/src/test/java/com/onthegomap/planetiler/basemap/layers/LandcoverTest.java
@@ -105,7 +105,7 @@ public class LandcoverTest extends AbstractLayerTest {
       "class", "wood",
       "_minpixelsize", 8d,
       "_numpointsattr", "_numpoints",
-      "_minzoom", 9,
+      "_minzoom", 7,
       "_maxzoom", 14
     )), process(polygonFeature(Map.of(
       "natural", "wood"
@@ -115,7 +115,7 @@ public class LandcoverTest extends AbstractLayerTest {
       "subclass", "forest",
       "class", "wood",
       "_minpixelsize", 8d,
-      "_minzoom", 9,
+      "_minzoom", 7,
       "_maxzoom", 14
     )), process(polygonFeature(Map.of(
       "landuse", "forest"


### PR DESCRIPTION
I misinterpreted the logic in https://github.com/openmaptiles/openmaptiles/blob/v3.13/layers/landcover/generalized.sql - it simplifies each landcover zoom level from 13 down to 7 without a filter on the subclass type so every landcover min zoom should be 7.