### PR TITLE
Inline sonar token

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,7 +28,6 @@ jobs:
   build:
     name: Java ${{ matrix.jdk }} / ${{ matrix.os }} ${{ matrix.args }}
     # Wait until after we check that you ran mvn spotless:apply, otherwise will fail with a cryptic error message
-    needs: lint
     strategy:
       fail-fast: false
       matrix:
@@ -50,20 +49,19 @@ jobs:
           java-version: ${{ matrix.jdk }}
           distribution: 'temurin'
           cache: 'maven'
+      # Skip spotless since that gets checked in a separate task
       - name: Build with mvnw (linux/mac)
         if: ${{ !contains(matrix.os, 'windows') }}
-        run: ./mvnw ${{matrix.args}} --batch-mode -no-transfer-progress package verify jib:buildTar --file pom.xml
+        run: ./mvnw ${{matrix.args}} -Dspotless.check.skip --batch-mode -no-transfer-progress package verify jib:buildTar --file pom.xml
       - name: Build with mvnw.cmd (windows)
         if: ${{ contains(matrix.os, 'windows') }}
-        run: mvnw.cmd ${{matrix.args}} --batch-mode -no-transfer-progress package verify jib:buildTar --file pom.xml
+        run: mvnw.cmd ${{matrix.args}} -Dspotless.check.skip --batch-mode -no-transfer-progress package verify jib:buildTar --file pom.xml
         shell: cmd
 
   regenerate:
     name: Regenerate
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # Wait until after we check that you ran mvn spotless:apply, otherwise will fail with a cryptic error message
-    needs: lint
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 17
@@ -73,8 +71,9 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
       - run: ./scripts/regenerate-openmaptiles.sh
-      - run: ./mvnw -DskipTests --batch-mode -no-transfer-progress clean install -pl planetiler-basemap -am
-      - run: ./mvnw --batch-mode -no-transfer-progress verify -pl planetiler-basemap
+      # Skip spotless since that gets checked in a separate task
+      - run: ./mvnw -Dspotless.check.skip  -DskipTests --batch-mode -no-transfer-progress clean install -pl planetiler-basemap -am
+      - run: ./mvnw -Dspotless.check.skip --batch-mode -no-transfer-progress verify -pl planetiler-basemap
 
   examples:
     name: Example project

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -33,7 +33,7 @@ jobs:
           restore-keys: ${{ runner.os }}-sonar
       - name: Analyze with SonarCloud
         run: |
-          mvn -Dspotless.apply.skip -Pcoverage -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+          mvn -Dspotless.check.skip -Pcoverage -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
         env:
           # Needed to get some information about the pull request, if any
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -37,8 +37,8 @@ jobs:
         env:
           # Needed to get some information about the pull request, if any
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # SonarCloud access token should be generated from https://sonarcloud.io/account/security/
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          # Read-only user, use this token to link SonarLint to SonarCloud as well
+          SONAR_TOKEN: c2cfe8bd7368ced07e84a620b7c2487846e220eb
       - name: Wait for SonarCloud API to update...
         run: "sleep 10"
       - name: Upload annotations on PRs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,8 +35,6 @@ easier though.
 - [Install IntelliJ IDEA](https://www.jetbrains.com/help/idea/installation-guide.html)
 - Install
   the [Adapter for Eclipse Code Formatter plugin](https://plugins.jetbrains.com/plugin/6546-adapter-for-eclipse-code-formatter)
-- Install the [SonarLint plugin](https://plugins.jetbrains.com/plugin/7973-sonarlint) (recommended) to see static
-  analysis results while editing code.
 - In IntelliJ, click `Open`, navigate to the the `pom.xml` file in the local copy of this repo, and `Open`
   then `Open as Project`
   - If IntelliJ asks (and you trust the code) then click `Trust Project`
@@ -55,8 +53,6 @@ Troubleshooting:
 ### Visual Studio Code
 
 - Install the [Extension Pack for Java](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-pack)
-- Install the [SonarLint plugin](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarlint-vscode)
-  (recommended) to see static analysis results while editing code.
 - In VSCode, click `File -> Open` and navigate to Planetiler directory
   - If VSCode asks (and you trust the code) then click `Yes I trust the authors`
 - To verify everything works correctly, go to the `Testing` tab and click `Run Tests`
@@ -67,8 +63,6 @@ Learn more about using VSCode with Java [here](https://code.visualstudio.com/doc
 
 - In [Eclipse for Java Developers](https://www.eclipse.org/downloads/packages/), click `File -> Import ...`
   then `Maven -> Existing Maven Projects`, navigate to Planetiler directory, and click `Finish`
-- Install the [SonarLint plugin](https://marketplace.eclipse.org/content/sonarlint)
-  (recommended) to see static analysis results while editing code.
 - Under `Eclipse -> Preferences...`:
   - Under `Java -> Code Style -> Formatter` and choose `Import...`
     choose [`eclipse-formatter.xml`](eclipse-formatter.xml) from the root of this project. Then choose `Planetiler` as
@@ -82,3 +76,12 @@ Learn more about using VSCode with Java [here](https://code.visualstudio.com/doc
 - To verify everything works correctly, right click on `planetiler-core/src/test/java` folder and
   click `Run As -> JUnit Test`
 
+## SonarLint Plugin Setup (optional, but recommended)
+
+Planetiler uses [SonarCloud](https://sonarcloud.io/) to statically analyze pull requests to catch common bugs and
+security vulnerabilities. To preview Sonar warnings in VS Code, IntelliJ, or Eclipse:
+
+- Follow the directions on [sonarlint.org](https://www.sonarlint.org/) to install the plugin for your IDE
+- Then to synchronize your local configuration with the one used in SonarCloud,
+  enable [Connected Mode](https://www.sonarlint.org/bring-your-team-on-board) for your IDE using "SonarCloud"
+  connection type and the shared read-only API token used in GitHub CI: `c2cfe8bd7368ced07e84a620b7c2487846e220eb`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,10 +78,11 @@ Learn more about using VSCode with Java [here](https://code.visualstudio.com/doc
 
 ## SonarLint Plugin Setup (optional, but recommended)
 
-Planetiler uses [SonarCloud](https://sonarcloud.io/) to statically analyze pull requests to catch common bugs and
-security vulnerabilities. To preview Sonar warnings in VS Code, IntelliJ, or Eclipse:
+Planetiler uses [SonarCloud](https://sonarcloud.io/project/overview?id=onthegomap_planetiler) to statically analyze pull
+requests to catch common bugs and security vulnerabilities. To preview Sonar warnings in VS Code, IntelliJ, or Eclipse:
 
 - Follow the directions on [sonarlint.org](https://www.sonarlint.org/) to install the plugin for your IDE
 - Then to synchronize your local configuration with the one used in SonarCloud,
   enable [Connected Mode](https://www.sonarlint.org/bring-your-team-on-board) for your IDE using "SonarCloud"
   connection type and the shared read-only API token used in GitHub CI: `c2cfe8bd7368ced07e84a620b7c2487846e220eb`
+

--- a/planetiler-basemap/src/main/java/com/onthegomap/planetiler/basemap/Generate.java
+++ b/planetiler-basemap/src/main/java/com/onthegomap/planetiler/basemap/Generate.java
@@ -52,8 +52,6 @@ import org.yaml.snakeyaml.Yaml;
  */
 public class Generate {
 
-  private final long unused = 0;
-
   private static final Logger LOGGER = LoggerFactory.getLogger(Generate.class);
   private static final ObjectMapper mapper = new ObjectMapper();
   private static final Yaml yaml;

--- a/planetiler-basemap/src/main/java/com/onthegomap/planetiler/basemap/Generate.java
+++ b/planetiler-basemap/src/main/java/com/onthegomap/planetiler/basemap/Generate.java
@@ -52,6 +52,8 @@ import org.yaml.snakeyaml.Yaml;
  */
 public class Generate {
 
+  private final long unused = 0;
+
   private static final Logger LOGGER = LoggerFactory.getLogger(Generate.class);
   private static final ObjectMapper mapper = new ObjectMapper();
   private static final Yaml yaml;


### PR DESCRIPTION
Storing SONAR_TOKEN in secrets prevented sonar analysis from running against PRs from someone who's not a member of the project, and SonarLint needed an API token to enable connected mode to share configuration. There don't seem to be any clear workarounds, so I created a machine  GitHub user with minimum permissions and generated a sonar cloud API token for it with only "execute analysis" permissions and embedded that token in the repo. 