### PR TITLE
Review thread local warnings

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/mbtiles/MbtilesWriter.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/mbtiles/MbtilesWriter.java
@@ -123,9 +123,10 @@ public class MbtilesWriter {
       WorkQueue<TileBatch> writerQueue = new WorkQueue<>("mbtiles_writer_queue", queueSize, 1, stats);
       encodeBranch = pipeline
         .<TileBatch>fromGenerator("read", next -> {
+          var writerEnqueuer = writerQueue.threadLocalWriter();
           writer.readFeaturesAndBatch(batch -> {
             next.accept(batch);
-            writerQueue.accept(batch); // also send immediately to writer
+            writerEnqueuer.accept(batch); // also send immediately to writer
           });
           writerQueue.close();
           // use only 1 thread since readFeaturesAndBatch needs to be single-threaded

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/osm/OsmReader.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/osm/OsmReader.java
@@ -188,9 +188,10 @@ public class OsmReader implements Closeable, MemoryEstimator.HasEstimate {
       var parsedBatches = new WorkQueue<WeightedHandoffQueue<OsmElement>>("elements", pendingBlocks, 1, stats);
       var readBranch = pipeline
         .<BlockWithResult>fromGenerator("read", next -> {
+          var parsedBatchEnqueuer = parsedBatches.threadLocalWriter();
           osmBlockSource.forEachBlock((block) -> {
             WeightedHandoffQueue<OsmElement> result = new WeightedHandoffQueue<>(handoffQueueBatches, 10_000);
-            parsedBatches.accept(result);
+            parsedBatchEnqueuer.accept(result);
             next.accept(new BlockWithResult(block, result));
           });
           parsedBatches.close();

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/stats/Counter.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/stats/Counter.java
@@ -79,6 +79,9 @@ public interface Counter {
     // keep track of all counters that have been handed out to threads so far
     // and on read, add up the counts from each
     private final List<SingleThreadCounter> all = new CopyOnWriteArrayList<>();
+    // Ignore warnings about not removing thread local values since planetiler uses dedicated worker threads that release
+    // values when a task is finished and are not re-used.
+    @SuppressWarnings("java:S5164")
     private final ThreadLocal<SingleThreadCounter> thread = ThreadLocal.withInitial(() -> {
       SingleThreadCounter counter = new SingleThreadCounter();
       all.add(counter);

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/util/LayerStats.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/util/LayerStats.java
@@ -30,6 +30,9 @@ public class LayerStats implements Consumer<RenderedFeature> {
    */
 
   private final List<ThreadLocalHandler> threadLocals = new CopyOnWriteArrayList<>();
+  // Ignore warnings about not removing thread local values since planetiler uses dedicated worker threads that release
+  // values when a task is finished and are not re-used.
+  @SuppressWarnings("java:S5164")
   private final ThreadLocal<ThreadLocalHandler> layerStats = ThreadLocal
     .withInitial(ThreadLocalHandler::new);
 

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/worker/WorkQueue.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/worker/WorkQueue.java
@@ -30,6 +30,9 @@ import java.util.function.Consumer;
  *
  * @param <T> the type of elements held in this queue
  */
+// Ignore warnings about not removing thread local values since planetiler uses dedicated worker threads that release
+// values when a task is finished and are not re-used.
+@SuppressWarnings("java:S5164")
 public class WorkQueue<T> implements AutoCloseable, IterableOnce<T>, Consumer<T> {
 
   private final BlockingQueue<Queue<T>> itemQueue;


### PR DESCRIPTION
Determined that these warnings are not a concern since we don't reuse threads.