### PR TITLE
Implement matchField testing for Expression.not

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/expression/MultiExpression.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/expression/MultiExpression.java
@@ -68,8 +68,8 @@ public record MultiExpression<T> (List<Entry<T>> expressions) {
       and.children().forEach(child -> getRelevantKeys(child, acceptKey));
     } else if (exp instanceof Expression.Or or) {
       or.children().forEach(child -> getRelevantKeys(child, acceptKey));
-    } else if (exp instanceof Expression.Not) {
-      // ignore anything that's purely used as a filter
+    } else if (exp instanceof Expression.Not not) {
+      getRelevantMissingKeys(not.child(), acceptKey);
     } else if (exp instanceof Expression.MatchField field) {
       acceptKey.accept(field.field());
     } else if (exp instanceof Expression.MatchAny any) {
@@ -86,8 +86,8 @@ public record MultiExpression<T> (List<Entry<T>> expressions) {
       and.children().forEach(child -> getRelevantMissingKeys(child, acceptKey));
     } else if (exp instanceof Expression.Or or) {
       or.children().forEach(child -> getRelevantMissingKeys(child, acceptKey));
-    } else if (exp instanceof Expression.Not) {
-      // ignore anything that's purely used as a filter
+    } else if (exp instanceof Expression.Not not) {
+      getRelevantKeys(not.child(), acceptKey);
     } else if (exp instanceof Expression.MatchAny any && any.matchWhenMissing()) {
       acceptKey.accept(any.field());
     }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/expression/MultiExpression.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/expression/MultiExpression.java
@@ -100,7 +100,7 @@ public record MultiExpression<T> (List<Entry<T>> expressions) {
     }
     boolean caresAboutGeometryType =
       expressions.stream().anyMatch(entry -> entry.expression.contains(exp -> exp instanceof Expression.MatchType));
-    return caresAboutGeometryType ? new GeometryTypeIndex<>(this) : new KeyIndex<>(this);
+    return caresAboutGeometryType ? new GeometryTypeIndex<>(this) : new KeyIndex<>(simplify());
   }
 
   /** Returns a copy of this multi-expression that replaces every expression using {@code mapper}. */

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/expression/MultiExpressionTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/expression/MultiExpressionTest.java
@@ -137,7 +137,7 @@ class MultiExpressionTest {
   @Test
   void testInverseMatchField() {
     var index = MultiExpression.of(List.of(
-      entry("a", Expression.not(matchField("key")))
+      entry("a", not(matchField("key")))
     )).index();
     assertSameElements(List.of(), index.getMatches(featureWithTags("key", "value")));
     assertSameElements(List.of(), index.getMatches(featureWithTags("key", "")));

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/expression/MultiExpressionTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/expression/MultiExpressionTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.onthegomap.planetiler.expression.MultiExpression.Index;
 import com.onthegomap.planetiler.reader.SimpleFeature;
 import com.onthegomap.planetiler.reader.SourceFeature;
 import com.onthegomap.planetiler.reader.WithTags;
@@ -124,6 +125,18 @@ class MultiExpressionTest {
     var index = MultiExpression.of(List.of(
       entry("a", matchField("key"))
     )).index();
+    matchFieldCheck(index);
+  }
+
+  @Test
+  void testDoubleInverseMatchField() {
+    var index = MultiExpression.of(List.of(
+      entry("a", not(not(matchField("key"))))
+    )).index();
+    matchFieldCheck(index);
+  }
+
+  private void matchFieldCheck(Index<String> index) {
     assertSameElements(List.of("a"), index.getMatches(featureWithTags("key", "value")));
     assertSameElements(List.of("a"), index.getMatches(featureWithTags("key", "")));
     assertSameElements(List.of("a"), index.getMatches(featureWithTags("key", "value2", "otherkey", "othervalue")));
@@ -132,7 +145,6 @@ class MultiExpressionTest {
     assertSameElements(List.of(), index.getMatches(featureWithTags("key2", "no")));
     assertSameElements(List.of(), index.getMatches(featureWithTags()));
   }
-
 
   @Test
   void testInverseMatchField() {

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/expression/MultiExpressionTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/expression/MultiExpressionTest.java
@@ -299,6 +299,56 @@ class MultiExpressionTest {
   }
 
   @Test
+  void testXor() {
+    var index = MultiExpression.of(List.of(
+      entry("a",
+        or(
+          and(
+            not(matchAny("key1", "val1")),
+            matchAny("key2", "val2")
+          ),
+          and(
+            matchAny("key1", "val1"),
+            not(matchAny("key2", "val2"))
+          ))
+      )
+    )).index();
+    assertSameElements(List.of(), index.getMatches(featureWithTags("key1", "val1", "key2", "val2")));
+    assertSameElements(List.of(), index.getMatches(featureWithTags("key1", "val1", "key2", "val2", "key3", "val3")));
+    assertSameElements(List.of("a"), index.getMatches(featureWithTags("key1", "no", "key2", "val2")));
+    assertSameElements(List.of("a"), index.getMatches(featureWithTags("key1", "val1", "key2", "no")));
+    assertSameElements(List.of("a"), index.getMatches(featureWithTags("key1", "val1")));
+    assertSameElements(List.of("a"), index.getMatches(featureWithTags("key2", "val2")));
+    assertSameElements(List.of(), index.getMatches(featureWithTags("key1", "no", "key2", "no")));
+    assertSameElements(List.of(), index.getMatches(featureWithTags()));
+  }
+
+  @Test
+  void testXnor() {
+    var index = MultiExpression.of(List.of(
+      entry("a",
+        or(
+          and(
+            not(matchAny("key1", "val1")),
+            not(matchAny("key2", "val2"))
+          ),
+          and(
+            matchAny("key1", "val1"),
+            matchAny("key2", "val2")
+          ))
+      )
+    )).index();
+    assertSameElements(List.of("a"), index.getMatches(featureWithTags("key1", "val1", "key2", "val2")));
+    assertSameElements(List.of("a"), index.getMatches(featureWithTags("key1", "val1", "key2", "val2", "key3", "val3")));
+    assertSameElements(List.of(), index.getMatches(featureWithTags("key1", "no", "key2", "val2")));
+    assertSameElements(List.of(), index.getMatches(featureWithTags("key1", "val1", "key2", "no")));
+    assertSameElements(List.of(), index.getMatches(featureWithTags("key1", "val1")));
+    assertSameElements(List.of(), index.getMatches(featureWithTags("key2", "val2")));
+    assertSameElements(List.of("a"), index.getMatches(featureWithTags("key1", "no", "key2", "no")));
+    assertSameElements(List.of("a"), index.getMatches(featureWithTags()));
+  }
+
+  @Test
   void testMatchesMultiple() {
     var index = MultiExpression.of(List.of(
       entry("a", or(

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/expression/MultiExpressionTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/expression/MultiExpressionTest.java
@@ -133,6 +133,21 @@ class MultiExpressionTest {
     assertSameElements(List.of(), index.getMatches(featureWithTags()));
   }
 
+
+  @Test
+  void testInverseMatchField() {
+    var index = MultiExpression.of(List.of(
+      entry("a", Expression.not(matchField("key")))
+    )).index();
+    assertSameElements(List.of(), index.getMatches(featureWithTags("key", "value")));
+    assertSameElements(List.of(), index.getMatches(featureWithTags("key", "")));
+    assertSameElements(List.of(), index.getMatches(featureWithTags("key", "value2", "otherkey", "othervalue")));
+    assertSameElements(List.of("a"), index.getMatches(featureWithTags("key2", "value", "key3", "value")));
+    assertSameElements(List.of("a"), index.getMatches(featureWithTags("key2", "value")));
+    assertSameElements(List.of("a"), index.getMatches(featureWithTags("key2", "no")));
+    assertSameElements(List.of("a"), index.getMatches(featureWithTags()));
+  }
+
   @Test
   void testStaticBooleanMatch() {
     var index = MultiExpression.of(List.of(entry("t", TRUE))).index();


### PR DESCRIPTION
Fixes #200

This PR implements missing matchField key testing for `Expression.not` tests.