### PR TITLE
Add unit tests for XOR and XNOR MultiExpression tests

### DIFF
--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/expression/MultiExpressionTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/expression/MultiExpressionTest.java
@@ -272,6 +272,56 @@ class MultiExpressionTest {
   }
 
   @Test
+  void testXor() {
+    var index = MultiExpression.of(List.of(
+      entry("a",
+        or(
+          and(
+            not(matchAny("key1", "val1")),
+            matchAny("key2", "val2")
+          ),
+          and(
+            matchAny("key1", "val1"),
+            not(matchAny("key2", "val2"))
+          ))
+      )
+    )).index();
+    assertSameElements(List.of(), index.getMatches(featureWithTags("key1", "val1", "key2", "val2")));
+    assertSameElements(List.of(), index.getMatches(featureWithTags("key1", "val1", "key2", "val2", "key3", "val3")));
+    assertSameElements(List.of("a"), index.getMatches(featureWithTags("key1", "no", "key2", "val2")));
+    assertSameElements(List.of("a"), index.getMatches(featureWithTags("key1", "val1", "key2", "no")));
+    assertSameElements(List.of("a"), index.getMatches(featureWithTags("key1", "val1")));
+    assertSameElements(List.of("a"), index.getMatches(featureWithTags("key2", "val2")));
+    assertSameElements(List.of(), index.getMatches(featureWithTags("key1", "no", "key2", "no")));
+    assertSameElements(List.of(), index.getMatches(featureWithTags()));
+  }
+
+  @Test
+  void testXnor() {
+    var index = MultiExpression.of(List.of(
+      entry("a",
+        or(
+          and(
+            not(matchAny("key1", "val1")),
+            not(matchAny("key2", "val2"))
+          ),
+          and(
+            matchAny("key1", "val1"),
+            matchAny("key2", "val2")
+          ))
+      )
+    )).index();
+    assertSameElements(List.of("a"), index.getMatches(featureWithTags("key1", "val1", "key2", "val2")));
+    assertSameElements(List.of("a"), index.getMatches(featureWithTags("key1", "val1", "key2", "val2", "key3", "val3")));
+    assertSameElements(List.of(), index.getMatches(featureWithTags("key1", "no", "key2", "val2")));
+    assertSameElements(List.of(), index.getMatches(featureWithTags("key1", "val1", "key2", "no")));
+    assertSameElements(List.of(), index.getMatches(featureWithTags("key1", "val1")));
+    assertSameElements(List.of(), index.getMatches(featureWithTags("key2", "val2")));
+    assertSameElements(List.of("a"), index.getMatches(featureWithTags("key1", "no", "key2", "no")));
+    assertSameElements(List.of("a"), index.getMatches(featureWithTags()));
+  }
+
+  @Test
   void testMatchesMultiple() {
     var index = MultiExpression.of(List.of(
       entry("a", or(


### PR DESCRIPTION
This PR adds unit tests to verify that XOR and XNOR logic combinations within `MultiExpression`s produce the expected logical outcome.