### PR TITLE
Parallel temp feature writes using `--write-threads` argument

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -72,14 +72,14 @@ jobs:
 
       - name: 'Run branch'
         run: |
-          rm -f data/out.mbtiles data/tmp
+          rm -rf data/out.mbtiles data/tmp
           cp branch/planetiler-dist/target/*with-deps.jar run.jar
           java -Xms${{ env.RAM }} -Xmx${{ env.RAM }} -jar run.jar --area="${{ env.AREA }}" "${{ env.BOUNDS_ARG }}" --mbtiles=data/out.mbtiles 2>&1 | tee log
           ls -alh run.jar | tee -a log
           cat log | strip-ansi > build-info/branchlogs.txt
       - name: 'Run base'
         run: |
-          rm -f data/out.mbtiles data/tmp
+          rm -rf data/out.mbtiles data/tmp
           cp base/planetiler-dist/target/*with-deps.jar run.jar
           java -Xms${{ env.RAM }} -Xmx${{ env.RAM }} -jar run.jar --area="${{ env.AREA }}" "${{ env.BOUNDS_ARG }}" --mbtiles=data/out.mbtiles 2>&1 | tee log
           ls -alh run.jar | tee -a log

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -72,14 +72,14 @@ jobs:
 
       - name: 'Run branch'
         run: |
-          rm -f data/out.mbtiles
+          rm -f data/out.mbtiles data/tmp
           cp branch/planetiler-dist/target/*with-deps.jar run.jar
           java -Xms${{ env.RAM }} -Xmx${{ env.RAM }} -jar run.jar --area="${{ env.AREA }}" "${{ env.BOUNDS_ARG }}" --mbtiles=data/out.mbtiles 2>&1 | tee log
           ls -alh run.jar | tee -a log
           cat log | strip-ansi > build-info/branchlogs.txt
       - name: 'Run base'
         run: |
-          rm -f data/out.mbtiles
+          rm -f data/out.mbtiles data/tmp
           cp base/planetiler-dist/target/*with-deps.jar run.jar
           java -Xms${{ env.RAM }} -Xmx${{ env.RAM }} -jar run.jar --area="${{ env.AREA }}" "${{ env.BOUNDS_ARG }}" --mbtiles=data/out.mbtiles 2>&1 | tee log
           ls -alh run.jar | tee -a log

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/collection/ExternalMergeSort.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/collection/ExternalMergeSort.java
@@ -410,6 +410,8 @@ class ExternalMergeSort implements FeatureSort {
     abstract SortableFeature readNextFeature();
   }
 
+  /** Writer that a single thread can use to write features independent of writers used in other threads. */
+  @NotThreadSafe
   private class ThreadLocalWriter implements CloseableConusmer<SortableFeature> {
     private Chunk currentChunk;
 

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/collection/FeatureGroup.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/collection/FeatureGroup.java
@@ -9,6 +9,7 @@ import com.onthegomap.planetiler.geo.GeometryType;
 import com.onthegomap.planetiler.geo.TileCoord;
 import com.onthegomap.planetiler.render.RenderedFeature;
 import com.onthegomap.planetiler.stats.Stats;
+import com.onthegomap.planetiler.util.CloseableConusmer;
 import com.onthegomap.planetiler.util.CommonStringEncoder;
 import com.onthegomap.planetiler.util.DiskBacked;
 import com.onthegomap.planetiler.util.LayerStats;
@@ -44,8 +45,7 @@ import org.slf4j.LoggerFactory;
  * supported (see {@link CommonStringEncoder})
  */
 @NotThreadSafe
-public final class FeatureGroup implements Consumer<SortableFeature>, Iterable<FeatureGroup.TileFeatures>,
-  DiskBacked {
+public final class FeatureGroup implements Iterable<FeatureGroup.TileFeatures>, DiskBacked {
 
   public static final int SORT_KEY_BITS = 23;
   public static final int SORT_KEY_MAX = (1 << (SORT_KEY_BITS - 1)) - 1;
@@ -246,10 +246,9 @@ public final class FeatureGroup implements Consumer<SortableFeature>, Iterable<F
     return (byte) ((geometry.geomType().asByte() & 0xff) | (geometry.scale() << 3));
   }
 
-  /** Writes a serialized binary feature to intermediate storage. */
-  @Override
-  public void accept(SortableFeature entry) {
-    sorter.add(entry);
+  /** Returns a new feature writer that can be used for a single thread. */
+  public CloseableConusmer<SortableFeature> writerForThread() {
+    return sorter.writerForThread();
   }
 
   private volatile boolean prepared = false;

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/collection/FeatureSort.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/collection/FeatureSort.java
@@ -76,6 +76,9 @@ interface FeatureSort extends Iterable<SortableFeature>, DiskBacked, MemoryEstim
     return list;
   }
 
-  /** Returns a new writer that can be used for a single thread. */
+  /**
+   * Returns a new writer that can be used to write features from a single thread independent of writers used from other
+   * threads.
+   */
   CloseableConusmer<SortableFeature> writerForThread();
 }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/collection/FeatureSort.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/collection/FeatureSort.java
@@ -1,8 +1,10 @@
 package com.onthegomap.planetiler.collection;
 
+import com.onthegomap.planetiler.util.CloseableConusmer;
 import com.onthegomap.planetiler.util.DiskBacked;
 import com.onthegomap.planetiler.util.MemoryEstimator;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
@@ -26,7 +28,7 @@ interface FeatureSort extends Iterable<SortableFeature>, DiskBacked, MemoryEstim
 
   /** Returns a feature sorter that sorts all features in memory. Suitable for toy examples (unit tests). */
   static FeatureSort newInMemory() {
-    List<SortableFeature> list = new ArrayList<>();
+    List<SortableFeature> list = Collections.synchronizedList(new ArrayList<>());
     return new FeatureSort() {
       @Override
       public void sort() {
@@ -39,8 +41,8 @@ interface FeatureSort extends Iterable<SortableFeature>, DiskBacked, MemoryEstim
       }
 
       @Override
-      public void add(SortableFeature newEntry) {
-        list.add(newEntry);
+      public CloseableConusmer<SortableFeature> writerForThread() {
+        return list::add;
       }
 
       @Override
@@ -74,6 +76,6 @@ interface FeatureSort extends Iterable<SortableFeature>, DiskBacked, MemoryEstim
     return list;
   }
 
-  void add(SortableFeature newEntry);
-
+  /** Returns a new writer that can be used for a single thread. */
+  CloseableConusmer<SortableFeature> writerForThread();
 }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/SimpleReader.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/SimpleReader.java
@@ -49,7 +49,7 @@ public abstract class SimpleReader implements Closeable {
   public final void process(FeatureGroup writer, PlanetilerConfig config) {
     var timer = stats.startStage(sourceName);
     long featureCount = getCount();
-    int writers = config.featureWriteThreads();
+    int writeThreads = config.featureWriteThreads();
     int processThreads = config.featureProcessThreads();
     Envelope latLonBounds = config.bounds().latLon();
     AtomicLong featuresRead = new AtomicLong(0);
@@ -80,7 +80,7 @@ public abstract class SimpleReader implements Closeable {
       // output large batches since each input may map to many tiny output features (i.e. slicing ocean tiles)
       // which turns enqueueing into the bottleneck
       .addBuffer("write_queue", 50_000, 1_000)
-      .sinkTo("write", writers, prev -> {
+      .sinkTo("write", writeThreads, prev -> {
         try (var threadLocalWriter = writer.writerForThread()) {
           for (var item : prev) {
             featuresWritten.incrementAndGet();

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/util/BinPack.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/util/BinPack.java
@@ -1,0 +1,45 @@
+package com.onthegomap.planetiler.util;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.ToLongFunction;
+
+/**
+ * {@link #pack(Collection, long, ToLongFunction)} implements a best-effort 1-D bin packing using the "best-fit
+ * decreasing" algorithm.
+ */
+public class BinPack {
+  private BinPack() {}
+
+  /**
+   * Returns {@code items} grouped into an approximately minimum number of bins under {@code maxBinSize} according to
+   * {@code getSize} function.
+   */
+  public static <T> List<List<T>> pack(Collection<T> items, long maxBinSize, ToLongFunction<T> getSize) {
+    class Bin {
+      long size = 0;
+      final List<T> items = new ArrayList<>();
+    }
+    var descendingItems = items.stream().sorted(Comparator.comparingLong(getSize).reversed()).toList();
+    List<Bin> bins = new ArrayList<>();
+    for (var item : descendingItems) {
+      long size = getSize.applyAsLong(item);
+      var bestBin = bins.stream()
+        .filter(b -> maxBinSize - b.size >= size)
+        // Instead of using the first bin that this element fits in, use the "fullest" bin.
+        // This makes the algorithm "best-fit decreasing" instead of "first-fit decreasing"
+        .max(Comparator.comparingLong(bin -> bin.size));
+      Bin bin;
+      if (bestBin.isPresent()) {
+        bin = bestBin.get();
+      } else {
+        bins.add(bin = new Bin());
+      }
+      bin.items.add(item);
+      bin.size += size;
+    }
+    return bins.stream().map(bin -> bin.items).toList();
+  }
+}

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/util/BinPack.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/util/BinPack.java
@@ -7,8 +7,9 @@ import java.util.List;
 import java.util.function.ToLongFunction;
 
 /**
- * {@link #pack(Collection, long, ToLongFunction)} implements a best-effort 1-D bin packing using the "best-fit
- * decreasing" algorithm.
+ * Implements a best-effort 1-D bin packing using the
+ * <a href="https://en.wikipedia.org/wiki/First-fit-decreasing_bin_packing#Other_variants">best-fit decreasing</a>
+ * algorithm.
  */
 public class BinPack {
   private BinPack() {}

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/util/CloseableConusmer.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/util/CloseableConusmer.java
@@ -1,0 +1,12 @@
+package com.onthegomap.planetiler.util;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.function.Consumer;
+
+@FunctionalInterface
+public interface CloseableConusmer<T> extends Consumer<T>, Closeable {
+
+  @Override
+  default void close() throws IOException {}
+}

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/worker/WorkQueue.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/worker/WorkQueue.java
@@ -56,7 +56,7 @@ public class WorkQueue<T> implements AutoCloseable, IterableOnce<T>, Consumer<T>
    * @param stats    stats to monitor this with
    */
   public WorkQueue(String name, int capacity, int maxBatch, Stats stats) {
-    this.pendingBatchesCapacity = capacity / maxBatch;
+    this.pendingBatchesCapacity = Math.max(1, capacity / maxBatch);
     this.batchSize = maxBatch;
     itemQueue = new ArrayBlockingQueue<>(pendingBatchesCapacity);
 

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
@@ -1579,7 +1579,11 @@ class PlanetilerTests {
     Files.copy(originalOsm, tempOsm);
     Planetiler.create(Arguments.fromArgs(
       "--tmpdir", tempDir.toString(),
-      "--free-osm-after-read"
+      "--free-osm-after-read",
+      // ensure we exercise the multi-threaded code
+      "--write-threads=2",
+      "--process-threads=2",
+      "--threads=4"
     ))
       .setProfile(new Profile.NullProfile() {
         @Override

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/collection/FeatureGroupTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/collection/FeatureGroupTest.java
@@ -13,6 +13,7 @@ import com.onthegomap.planetiler.geo.GeometryType;
 import com.onthegomap.planetiler.geo.TileCoord;
 import com.onthegomap.planetiler.render.RenderedFeature;
 import com.onthegomap.planetiler.stats.Stats;
+import com.onthegomap.planetiler.util.CloseableConusmer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -30,6 +31,7 @@ class FeatureGroupTest {
 
   private final FeatureSort sorter = FeatureSort.newInMemory();
   private FeatureGroup features = new FeatureGroup(sorter, new Profile.NullProfile(), Stats.inMemory());
+  private CloseableConusmer<SortableFeature> featureWriter = features.writerForThread();
 
   @Test
   void testEmpty() {
@@ -65,7 +67,7 @@ class FeatureGroupTest {
       sortKey,
       hasGroup ? Optional.of(new RenderedFeature.Group(group, limit)) : Optional.empty()
     );
-    features.accept(features.newRenderedFeatureEncoder().apply(feature));
+    featureWriter.accept(features.newRenderedFeatureEncoder().apply(feature));
   }
 
   private Map<Integer, Map<String, List<Feature>>> getFeatures() {
@@ -212,6 +214,7 @@ class FeatureGroupTest {
         return items;
       }
     }, Stats.inMemory());
+    featureWriter = features.writerForThread();
     putWithGroup(
       1, "layer", Map.of("id", 3), newPoint(5, 6), 2, 1, 2
     );

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/util/BinBackTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/util/BinBackTest.java
@@ -1,0 +1,56 @@
+package com.onthegomap.planetiler.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class BinBackTest {
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "3;[];[]",
+    "2;[1];[[1]]",
+    "2;[2];[[2]]",
+    "2;[3];[[3]]",
+    "3;[1,2,3];[[3], [2, 1]]",
+    "5;[1,2,3];[[3,2],[1]]",
+    "6;[1,2,3];[[3,2,1]]",
+    "2;[1,2,3];[[3],[2],[1]]",
+    "1;[1,2,3];[[3],[2],[1]]",
+  }, delimiter = ';')
+  void test(int limit, String inputString, String expectedString) {
+    List<Long> input = parseList(inputString);
+    List<List<Long>> expected = parseListList(expectedString);
+    // make sure we parsed correctly
+    assertEqualsIgnoringWhitespace(inputString, input, "failed to parse input");
+    assertEqualsIgnoringWhitespace(expectedString, expected, "failed to parse expected");
+
+    assertEquals(expected, BinPack.pack(input, limit, i -> i));
+  }
+
+  private static List<Long> parseList(String string) {
+    return Stream.of(string.replaceAll("[\\[\\]]", "").split(","))
+      .map(String::strip)
+      .filter(s -> !s.isBlank())
+      .map(Long::parseLong)
+      .toList();
+  }
+
+  private static List<List<Long>> parseListList(String string) {
+    return Stream.of(string.replaceAll("((^\\[)|(]$))", "").split("]\\s*,\\s*\\["))
+      .map(BinBackTest::parseList)
+      .filter(l -> !l.isEmpty())
+      .toList();
+  }
+
+  private static void assertEqualsIgnoringWhitespace(Object expected, Object actual, String message) {
+    assertEquals(
+      expected.toString().replaceAll("\\s", ""),
+      actual.toString().replaceAll("\\s", ""),
+      message
+    );
+  }
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,4 @@
-sonar.issue.ignore.multicriteria=js1659,js3358,js1172,js106,js125,js2699,js3776,js1121,js107
+sonar.issue.ignore.multicriteria=js1659,js3358,js1172,js106,js125,js2699,js3776,js1121,js107,js1192
 # subjective
 sonar.issue.ignore.multicriteria.js1659.ruleKey=java:S1659
 sonar.issue.ignore.multicriteria.js1659.resourceKey=**/*.java
@@ -14,6 +14,8 @@ sonar.issue.ignore.multicriteria.js1121.ruleKey=java:S1121
 sonar.issue.ignore.multicriteria.js1121.resourceKey=**/*.java
 sonar.issue.ignore.multicriteria.js107.ruleKey=java:S107
 sonar.issue.ignore.multicriteria.js107.resourceKey=**/*.java
+sonar.issue.ignore.multicriteria.js1192.ruleKey=java:S1192
+sonar.issue.ignore.multicriteria.js1192.resourceKey=**/*.java
 
 # layer constructors need same signatures
 sonar.issue.ignore.multicriteria.js1172.ruleKey=java:S1172


### PR DESCRIPTION
Fixes #118 by adding a `--write-threads` argument that can control the number of threads writing temporary features in parallel. It defaults to 1 thread for <48 cpus, then an additional writer thread per 32 cpus after that.

Since this could result in smaller unfinished chunks, also pack small chunks into fewer larger chunks that can be sorted in-memory together during the `sort` step.