### PR TITLE
Run nested tests

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/collection/ArrayLongLongMapMmap.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/collection/ArrayLongLongMapMmap.java
@@ -58,7 +58,7 @@ class ArrayLongLongMapMmap implements LongLongMap.ParallelWrites {
   private final ConcurrentHashMap<Integer, Segment> writeBuffers = new ConcurrentHashMap<>();
   private final Semaphore activeSegments;
   private final BitSet usedSegments = new BitSet();
-  FileChannel writeChannel;
+  private FileChannel writeChannel;
   private MappedByteBuffer[] segmentsArray;
   private FileChannel readChannel = null;
   private volatile int tail = 0;
@@ -166,11 +166,15 @@ class ArrayLongLongMapMmap implements LongLongMap.ParallelWrites {
       ByteBufferUtil.free(segmentsArray);
       segmentsArray = null;
     }
+    if (writeChannel != null) {
+      writeChannel.close();
+      writeChannel = null;
+    }
     if (readChannel != null) {
       readChannel.close();
       readChannel = null;
-      FileUtils.delete(path);
     }
+    FileUtils.delete(path);
   }
 
   /**

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/collection/ArrayLongLongMapMmap.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/collection/ArrayLongLongMapMmap.java
@@ -1,5 +1,6 @@
 package com.onthegomap.planetiler.collection;
 
+import static com.onthegomap.planetiler.util.Exceptions.throwFatalException;
 import static java.nio.file.StandardOpenOption.CREATE;
 import static java.nio.file.StandardOpenOption.READ;
 import static java.nio.file.StandardOpenOption.WRITE;
@@ -227,9 +228,9 @@ class ArrayLongLongMapMmap implements LongLongMap.ParallelWrites {
         return result.get();
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
-        throw new RuntimeException(e);
+        return throwFatalException(e);
       } catch (ExecutionException e) {
-        throw new RuntimeException(e);
+        return throwFatalException(e);
       }
     }
 
@@ -239,7 +240,7 @@ class ArrayLongLongMapMmap implements LongLongMap.ParallelWrites {
         activeSegments.acquire();
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
-        throw new RuntimeException(e);
+        throwFatalException(e);
       }
       synchronized (usedSegments) {
         usedSegments.set(id);
@@ -255,11 +256,11 @@ class ArrayLongLongMapMmap implements LongLongMap.ParallelWrites {
         activeSegments.release();
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
-        throw new RuntimeException(e);
+        throwFatalException(e);
       } catch (IOException e) {
         throw new UncheckedIOException(e);
       } catch (ExecutionException e) {
-        throw new RuntimeException(e);
+        throwFatalException(e);
       }
     }
   }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/collection/ArrayLongLongMapMmap.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/collection/ArrayLongLongMapMmap.java
@@ -161,6 +161,7 @@ class ArrayLongLongMapMmap implements LongLongMap.ParallelWrites {
 
   @Override
   public void close() throws IOException {
+    ByteBufferUtil.free(segmentsArray);
     if (readChannel != null) {
       readChannel.close();
       readChannel = null;

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/collection/ArrayLongLongMapMmap.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/collection/ArrayLongLongMapMmap.java
@@ -162,7 +162,10 @@ class ArrayLongLongMapMmap implements LongLongMap.ParallelWrites {
 
   @Override
   public void close() throws IOException {
-    ByteBufferUtil.free(segmentsArray);
+    if (segmentsArray != null) {
+      ByteBufferUtil.free(segmentsArray);
+      segmentsArray = null;
+    }
     if (readChannel != null) {
       readChannel.close();
       readChannel = null;

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/collection/LongLongMapTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/collection/LongLongMapTest.java
@@ -7,7 +7,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.onthegomap.planetiler.reader.osm.OsmReader;
 import com.onthegomap.planetiler.util.Format;
 import com.onthegomap.planetiler.util.ResourceUsage;
+import java.io.IOException;
 import java.nio.file.Path;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -21,6 +23,11 @@ public abstract class LongLongMapTest {
   @BeforeEach
   public void setupSequentialWriter(@TempDir Path path) {
     this.sequential = createSequentialWriter(path);
+  }
+
+  @AfterEach
+  public void closeSequentialWriter() throws IOException {
+    this.sequential.close();
   }
 
   @Test

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/collection/ParallelLongLongMapTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/collection/ParallelLongLongMapTest.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -105,6 +106,11 @@ public abstract class ParallelLongLongMapTest extends LongLongMapTest {
   @BeforeEach
   public void setupParallelWriter(@TempDir Path path) {
     this.parallel = create(path);
+  }
+
+  @AfterEach
+  public void closeParallelWriter() throws IOException {
+    this.parallel.close();
   }
 
   @Override

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/collection/ParallelLongLongMapTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/collection/ParallelLongLongMapTest.java
@@ -19,7 +19,7 @@ public abstract class ParallelLongLongMapTest extends LongLongMapTest {
 
   @Test
   @Timeout(10)
-  void testWaitForBothWritersToClose() throws InterruptedException {
+  void testWaitForBothWritersToClose() {
     var writer1 = parallel.newWriter();
     var writer2 = parallel.newWriter();
     writer1.put(0, 1);

--- a/pom.xml
+++ b/pom.xml
@@ -201,6 +201,12 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.0.0-M6</version>
+        <!-- by default surefire excludes tests on nested classes https://github.com/junit-team/junit5/issues/1377 -->
+        <configuration>
+          <excludes>
+            <exclude/>
+          </excludes>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Maven surefire test runner does not run static nested test classes by default, which we use a few places in planetiler.  Change surefire to run these tests, and also fix a bug that was not caught by CI because these tests we silently being skipped.