### PR TITLE
add compact DB mode (--compact-db) to de-duplicate mbtiles output

### DIFF
--- a/planetiler-basemap/src/test/java/com/onthegomap/planetiler/basemap/util/VerifyMonacoTest.java
+++ b/planetiler-basemap/src/test/java/com/onthegomap/planetiler/basemap/util/VerifyMonacoTest.java
@@ -11,6 +11,7 @@ import com.onthegomap.planetiler.mbtiles.TileEncodingResult;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalInt;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -52,7 +53,7 @@ class VerifyMonacoTest {
         VectorTile.encodeGeometry(point(0, 0)),
         Map.of()
       )));
-      writer.write(new TileEncodingResult(TileCoord.ofXYZ(0, 0, 0), gzip(tile.encode()), false, null));
+      writer.write(new TileEncodingResult(TileCoord.ofXYZ(0, 0, 0), gzip(tile.encode()), OptionalInt.empty()));
     }
     assertInvalid(mbtiles);
   }

--- a/planetiler-basemap/src/test/java/com/onthegomap/planetiler/basemap/util/VerifyMonacoTest.java
+++ b/planetiler-basemap/src/test/java/com/onthegomap/planetiler/basemap/util/VerifyMonacoTest.java
@@ -51,7 +51,7 @@ class VerifyMonacoTest {
         VectorTile.encodeGeometry(point(0, 0)),
         Map.of()
       )));
-      writer.write(TileCoord.ofXYZ(0, 0, 0), gzip(tile.encode()));
+      writer.write(TileCoord.ofXYZ(0, 0, 0), gzip(tile.encode()), 1);
     }
     assertInvalid(mbtiles);
   }

--- a/planetiler-basemap/src/test/java/com/onthegomap/planetiler/basemap/util/VerifyMonacoTest.java
+++ b/planetiler-basemap/src/test/java/com/onthegomap/planetiler/basemap/util/VerifyMonacoTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.onthegomap.planetiler.VectorTile;
 import com.onthegomap.planetiler.geo.TileCoord;
 import com.onthegomap.planetiler.mbtiles.Mbtiles;
+import com.onthegomap.planetiler.mbtiles.TileEncodingResult;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -51,7 +52,7 @@ class VerifyMonacoTest {
         VectorTile.encodeGeometry(point(0, 0)),
         Map.of()
       )));
-      writer.write(TileCoord.ofXYZ(0, 0, 0), gzip(tile.encode()), 1);
+      writer.write(new TileEncodingResult(TileCoord.ofXYZ(0, 0, 0), gzip(tile.encode()), false, null));
     }
     assertInvalid(mbtiles);
   }

--- a/planetiler-benchmarks/src/main/java/com/onthegomap/planetiler/benchmarks/BenchmarkMbtilesRead.java
+++ b/planetiler-benchmarks/src/main/java/com/onthegomap/planetiler/benchmarks/BenchmarkMbtilesRead.java
@@ -7,20 +7,18 @@ import com.onthegomap.planetiler.mbtiles.Mbtiles;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.LongSummaryStatistics;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class BenchmarkMbtilesRead {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(BenchmarkMbtilesWriter.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(BenchmarkMbtilesRead.class);
 
   private static final String SELECT_RANDOM_COORDS =
     "select tile_column, tile_row, zoom_level from tiles order by random() limit ?";
@@ -28,8 +26,8 @@ public class BenchmarkMbtilesRead {
   public static void main(String[] args) throws Exception {
 
     Arguments arguments = Arguments.fromArgs(args);
-    int repetitions = arguments.getInteger("bench_repetitions", "number of repetitions", 100);
-    int nrTileReads = arguments.getInteger("bench_nr_tile_reads", "number of tiles to read", 10000);
+    int repetitions = arguments.getInteger("bench_repetitions", "number of repetitions", 10);
+    int nrTileReads = arguments.getInteger("bench_nr_tile_reads", "number of tiles to read", 500_000);
 
 
     List<String> mbtilesPaths = new ArrayList<>();
@@ -66,7 +64,7 @@ public class BenchmarkMbtilesRead {
       }
     }
 
-    Map<String, Double> avgIndividualReadPerDb = new HashMap<>();
+    Map<String, Double> avgReadOperationsPerSecondPerDb = new HashMap<>();
     for (String dbPathStr : mbtilesPaths) {
       Path dbPath = Path.of(dbPathStr);
       List<ReadResult> results = new LinkedList<>();
@@ -76,20 +74,14 @@ public class BenchmarkMbtilesRead {
       for (int rep = 0; rep < repetitions; rep++) {
         results.add(readEachTile(randomCoordsToFetchPerRepetition, dbPath));
       }
-      var totalStats = results.stream().mapToLong(ReadResult::totalDuration).summaryStatistics();
-      LOGGER.info("totalReadStats: {}", totalStats);
+      var readOperationsPerSecondStats =
+        results.stream().mapToDouble(ReadResult::readOperationsPerSecond).summaryStatistics();
+      LOGGER.info("readOperationsPerSecondStats: {}", readOperationsPerSecondStats);
 
-      LongSummaryStatistics individualStats = results.stream().map(ReadResult::individualReadStats)
-        .collect(Collector.of(LongSummaryStatistics::new, LongSummaryStatistics::combine, (left, right) -> {
-          left.combine(right);
-          return left;
-        }));
-      LOGGER.info("individualReadStats:  {}", individualStats);
-
-      avgIndividualReadPerDb.put(dbPathStr, individualStats.getAverage());
+      avgReadOperationsPerSecondPerDb.put(dbPathStr, readOperationsPerSecondStats.getAverage());
     }
 
-    List<String> keysSorted = avgIndividualReadPerDb.entrySet().stream()
+    List<String> keysSorted = avgReadOperationsPerSecondPerDb.entrySet().stream()
       .sorted((o1, o2) -> o1.getValue().compareTo(o2.getValue()))
       .map(Map.Entry::getKey)
       .toList();
@@ -98,36 +90,35 @@ public class BenchmarkMbtilesRead {
     for (int i = 0; i < keysSorted.size() - 1; i++) {
       for (int j = i + 1; j < keysSorted.size(); j++) {
         String db0 = keysSorted.get(i);
-        double avg0 = avgIndividualReadPerDb.get(db0);
+        double avg0 = avgReadOperationsPerSecondPerDb.get(db0);
         String db1 = keysSorted.get(j);
-        double avg1 = avgIndividualReadPerDb.get(db1);
+        double avg1 = avgReadOperationsPerSecondPerDb.get(db1);
 
         double diff = avg1 * 100 / avg0 - 100;
 
-        LOGGER.info("\"{}\" vs \"{}\": avgs reads up by {}%", db0, db1, diff);
+        LOGGER.info("\"{}\" vs \"{}\": avg read operations per second improved by {}%", db0, db1, diff);
       }
     }
   }
 
   private static ReadResult readEachTile(List<TileCoord> coordsToFetch, Path dbPath) throws IOException {
-    LongSummaryStatistics individualFetchDurations = new LongSummaryStatistics();
     try (var db = Mbtiles.newReadOnlyDatabase(dbPath)) {
       db.getTile(0, 0, 0); // trigger prepared statement creation
       var totalSw = Stopwatch.createStarted();
       for (var coordToFetch : coordsToFetch) {
-        var sw = Stopwatch.createStarted();
         if (db.getTile(coordToFetch) == null) {
           throw new IllegalStateException("%s should exist in %s".formatted(coordToFetch, dbPath));
         }
-        sw.stop();
-        individualFetchDurations.accept(sw.elapsed(TimeUnit.NANOSECONDS));
       }
       totalSw.stop();
-      return new ReadResult(totalSw.elapsed(TimeUnit.NANOSECONDS), individualFetchDurations);
+      return new ReadResult(totalSw.elapsed(), coordsToFetch.size());
     }
   }
 
-  private record ReadResult(long totalDuration, LongSummaryStatistics individualReadStats) {}
-
-
+  private record ReadResult(Duration duration, int coordsFetchedCount) {
+    double readOperationsPerSecond() {
+      double secondsFractional = duration.toNanos() / 1E9;
+      return coordsFetchedCount / secondsFractional;
+    }
+  }
 }

--- a/planetiler-benchmarks/src/main/java/com/onthegomap/planetiler/benchmarks/BenchmarkMbtilesRead.java
+++ b/planetiler-benchmarks/src/main/java/com/onthegomap/planetiler/benchmarks/BenchmarkMbtilesRead.java
@@ -28,6 +28,7 @@ public class BenchmarkMbtilesRead {
     Arguments arguments = Arguments.fromArgs(args);
     int repetitions = arguments.getInteger("bench_repetitions", "number of repetitions", 10);
     int nrTileReads = arguments.getInteger("bench_nr_tile_reads", "number of tiles to read", 500_000);
+    int preWarms = arguments.getInteger("bench_pre_warms", "number of pre warm runs", 3);
 
 
     List<String> mbtilesPaths = new ArrayList<>();
@@ -70,6 +71,10 @@ public class BenchmarkMbtilesRead {
       List<ReadResult> results = new LinkedList<>();
 
       LOGGER.info("working on {}", dbPath);
+
+      for (int preWarm = 0; preWarm < preWarms; preWarm++) {
+        readEachTile(randomCoordsToFetchPerRepetition, dbPath);
+      }
 
       for (int rep = 0; rep < repetitions; rep++) {
         results.add(readEachTile(randomCoordsToFetchPerRepetition, dbPath));

--- a/planetiler-benchmarks/src/main/java/com/onthegomap/planetiler/benchmarks/BenchmarkMbtilesRead.java
+++ b/planetiler-benchmarks/src/main/java/com/onthegomap/planetiler/benchmarks/BenchmarkMbtilesRead.java
@@ -1,0 +1,133 @@
+package com.onthegomap.planetiler.benchmarks;
+
+import com.google.common.base.Stopwatch;
+import com.onthegomap.planetiler.config.Arguments;
+import com.onthegomap.planetiler.geo.TileCoord;
+import com.onthegomap.planetiler.mbtiles.Mbtiles;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.LongSummaryStatistics;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BenchmarkMbtilesRead {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(BenchmarkMbtilesWriter.class);
+
+  private static final String SELECT_RANDOM_COORDS =
+    "select tile_column, tile_row, zoom_level from tiles order by random() limit ?";
+
+  public static void main(String[] args) throws Exception {
+
+    Arguments arguments = Arguments.fromArgs(args);
+    int repetitions = arguments.getInteger("bench_repetitions", "number of repetitions", 100);
+    int nrTileReads = arguments.getInteger("bench_nr_tile_reads", "number of tiles to read", 10000);
+
+
+    List<String> mbtilesPaths = new ArrayList<>();
+    for (int i = 0;; i++) {
+      String mbtilesPathStr = arguments.getString("bench_mbtiles" + i, "the mbtiles file to read from", null);
+      if (mbtilesPathStr == null) {
+        break;
+      }
+      mbtilesPaths.add(mbtilesPathStr);
+    }
+
+    if (mbtilesPaths.isEmpty()) {
+      throw new IllegalArgumentException("pass one or many paths to the same mbtiles file");
+    }
+
+    mbtilesPaths.stream().map(File::new).forEach(f -> {
+      if (!f.exists() || !f.isFile()) {
+        throw new IllegalArgumentException("%s does not exists".formatted(f));
+      }
+    });
+
+    List<TileCoord> randomCoordsToFetchPerRepetition = new LinkedList<>();
+
+    try (var db = Mbtiles.newReadOnlyDatabase(Path.of(mbtilesPaths.get(0)))) {
+      try (var statement = db.connection().prepareStatement(SELECT_RANDOM_COORDS)) {
+        statement.setInt(1, nrTileReads);
+        var rs = statement.executeQuery();
+        while (rs.next()) {
+          int x = rs.getInt("tile_column");
+          int y = rs.getInt("tile_row");
+          int z = rs.getInt("zoom_level");
+          randomCoordsToFetchPerRepetition.add(TileCoord.ofXYZ(x, (1 << z) - 1 - y, z));
+        }
+      }
+    }
+
+    Map<String, Double> avgIndividualReadPerDb = new HashMap<>();
+    for (String dbPathStr : mbtilesPaths) {
+      Path dbPath = Path.of(dbPathStr);
+      List<ReadResult> results = new LinkedList<>();
+
+      LOGGER.info("working on {}", dbPath);
+
+      for (int rep = 0; rep < repetitions; rep++) {
+        results.add(readEachTile(randomCoordsToFetchPerRepetition, dbPath));
+      }
+      var totalStats = results.stream().mapToLong(ReadResult::totalDuration).summaryStatistics();
+      LOGGER.info("totalReadStats: {}", totalStats);
+
+      LongSummaryStatistics individualStats = results.stream().map(ReadResult::individualReadStats)
+        .collect(Collector.of(LongSummaryStatistics::new, LongSummaryStatistics::combine, (left, right) -> {
+          left.combine(right);
+          return left;
+        }));
+      LOGGER.info("individualReadStats:  {}", individualStats);
+
+      avgIndividualReadPerDb.put(dbPathStr, individualStats.getAverage());
+    }
+
+    List<String> keysSorted = avgIndividualReadPerDb.entrySet().stream()
+      .sorted((o1, o2) -> o1.getValue().compareTo(o2.getValue()))
+      .map(Map.Entry::getKey)
+      .toList();
+
+    LOGGER.info("diffs");
+    for (int i = 0; i < keysSorted.size() - 1; i++) {
+      for (int j = i + 1; j < keysSorted.size(); j++) {
+        String db0 = keysSorted.get(i);
+        double avg0 = avgIndividualReadPerDb.get(db0);
+        String db1 = keysSorted.get(j);
+        double avg1 = avgIndividualReadPerDb.get(db1);
+
+        double diff = avg1 * 100 / avg0 - 100;
+
+        LOGGER.info("\"{}\" vs \"{}\": avgs reads up by {}%", db0, db1, diff);
+      }
+    }
+  }
+
+  private static ReadResult readEachTile(List<TileCoord> coordsToFetch, Path dbPath) throws IOException {
+    LongSummaryStatistics individualFetchDurations = new LongSummaryStatistics();
+    try (var db = Mbtiles.newReadOnlyDatabase(dbPath)) {
+      db.getTile(0, 0, 0); // trigger prepared statement creation
+      var totalSw = Stopwatch.createStarted();
+      for (var coordToFetch : coordsToFetch) {
+        var sw = Stopwatch.createStarted();
+        if (db.getTile(coordToFetch) == null) {
+          throw new IllegalStateException("%s should exist in %s".formatted(coordToFetch, dbPath));
+        }
+        sw.stop();
+        individualFetchDurations.accept(sw.elapsed(TimeUnit.NANOSECONDS));
+      }
+      totalSw.stop();
+      return new ReadResult(totalSw.elapsed(TimeUnit.NANOSECONDS), individualFetchDurations);
+    }
+  }
+
+  private record ReadResult(long totalDuration, LongSummaryStatistics individualReadStats) {}
+
+
+}

--- a/planetiler-benchmarks/src/main/java/com/onthegomap/planetiler/benchmarks/BenchmarkMbtilesWriter.java
+++ b/planetiler-benchmarks/src/main/java/com/onthegomap/planetiler/benchmarks/BenchmarkMbtilesWriter.java
@@ -1,31 +1,19 @@
 package com.onthegomap.planetiler.benchmarks;
 
-import com.onthegomap.planetiler.Profile;
-import com.onthegomap.planetiler.VectorTile;
-import com.onthegomap.planetiler.collection.FeatureGroup;
+import com.google.common.base.Stopwatch;
 import com.onthegomap.planetiler.config.Arguments;
-import com.onthegomap.planetiler.config.MbtilesMetadata;
 import com.onthegomap.planetiler.config.PlanetilerConfig;
-import com.onthegomap.planetiler.geo.GeometryType;
 import com.onthegomap.planetiler.geo.TileCoord;
-import com.onthegomap.planetiler.mbtiles.MbtilesWriter;
-import com.onthegomap.planetiler.render.RenderedFeature;
-import com.onthegomap.planetiler.stats.Counter;
-import com.onthegomap.planetiler.stats.Stats;
-import com.onthegomap.planetiler.stats.Timers;
-import com.onthegomap.planetiler.util.MemoryEstimator.HasEstimate;
+import com.onthegomap.planetiler.mbtiles.Mbtiles;
+import com.onthegomap.planetiler.mbtiles.Mbtiles.BatchedTileWriter;
+import com.onthegomap.planetiler.mbtiles.TileEncodingResult;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.Duration;
-import java.time.Instant;
-import java.util.LongSummaryStatistics;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.LongSupplier;
-import java.util.function.Supplier;
+import java.util.Arrays;
+import java.util.DoubleSummaryStatistics;
+import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,79 +21,105 @@ public class BenchmarkMbtilesWriter {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(BenchmarkMbtilesWriter.class);
 
-
   public static void main(String[] args) throws IOException {
 
     Arguments arguments = Arguments.fromArgs(args);
 
     int tilesToWrite = arguments.getInteger("bench_tiles_to_write", "number of tiles to write", 1_000_000);
     int repetitions = arguments.getInteger("bench_repetitions", "number of repetitions", 10);
-    // to put some context here: Australia has 8% distinct tiles
-    int distinctTilesInPercent = arguments.getInteger("bench_distinct_tiles", "distinct tiles in percent", 10);
+    /*
+     * select count(distinct(tile_data_id)) * 100.0 / count(*) from tiles_shallow
+     * => ~8% (Australia)
+     */
+    int noDupeTilesInPercent = arguments.getInteger("bench_no_dupe_tiles", "distinct tiles in percent", 10);
+    /*
+     * select avg(length(tile_data)) 
+     * from (select tile_data_id from tiles_shallow group by tile_data_id having count(*) = 1) as x 
+     * join tiles_data using(tile_data_id)
+     * => ~785 (Australia)
+     */
+    int distinctTileDataSize =
+      arguments.getInteger("bench_distinct_tile_data_size", "distinct tile data size in bytes", 800);
+    /*
+     * select avg(length(tile_data)) 
+     * from (select tile_data_id from tiles_shallow group by tile_data_id having count(*) > 1) as x 
+     * join tiles_shallow using(tile_data_id) 
+     * join tiles_data using(tile_data_id)
+     * => ~93 (Australia)
+     */
+    int dupeTileDataSize = arguments.getInteger("bench_dupe_tile_data_size", "dupe tile data size in bytes", 100);
+    /*
+     * select count(*) * 100.0 / sum(usage_count) 
+     * from (select tile_data_id, count(*) as usage_count from tiles_shallow group by tile_data_id having count(*) > 1)
+     * => ~0.17% (Australia)
+     */
+    int dupeSpreadInPercent = arguments.getInteger("bench_dupe_spread", "dupe spread in percent", 10);
 
+    byte[] distinctTileData = createFilledByteArray(distinctTileDataSize);
+    byte[] dupeTileData = createFilledByteArray(dupeTileDataSize);
 
-    MbtilesMetadata mbtilesMetadata = new MbtilesMetadata(new Profile.NullProfile());
     PlanetilerConfig config = PlanetilerConfig.from(arguments);
 
-    FeatureGroup featureGroup = FeatureGroup.newInMemoryFeatureGroup(new Profile.NullProfile(), Stats.inMemory());
-    renderTiles(featureGroup, tilesToWrite, distinctTilesInPercent, config.minzoom(), config.maxzoom());
+    DoubleSummaryStatistics tileWritesPerSecondsStats = new DoubleSummaryStatistics();
 
-    RepeatedMbtilesWriteStats repeatedMbtilesStats = new RepeatedMbtilesWriteStats();
     for (int repetition = 0; repetition < repetitions; repetition++) {
-      MyStats myStats = new MyStats();
+
       Path outputPath = getTempOutputPath();
-      MbtilesWriter.writeOutput(featureGroup, outputPath, mbtilesMetadata, config, myStats);
-      repeatedMbtilesStats.updateWithStats(myStats, outputPath);
-      outputPath.toFile().delete();
+      try (var mbtiles = Mbtiles.newWriteToFileDatabase(outputPath, config.compactDb())) {
+
+        mbtiles.createTables();
+        if (!config.deferIndexCreation()) {
+          mbtiles.addTileIndex();
+        }
+
+        try (var writer = mbtiles.newBatchedTileWriter()) {
+          Stopwatch sw = Stopwatch.createStarted();
+          writeTiles(writer, tilesToWrite, noDupeTilesInPercent, distinctTileData, dupeTileData, dupeSpreadInPercent);
+          sw.stop();
+          double secondsFractional = sw.elapsed(TimeUnit.NANOSECONDS) / 1E9;
+          double tileWritesPerSecond = tilesToWrite / secondsFractional;
+          tileWritesPerSecondsStats.accept(tileWritesPerSecond);
+        }
+
+      } finally {
+        Files.delete(outputPath);
+      }
     }
 
-    LOGGER.info("{}", repeatedMbtilesStats);
+    LOGGER.info("tileWritesPerSecondsStats: {}", tileWritesPerSecondsStats);
   }
 
 
-  private static void renderTiles(FeatureGroup featureGroup, int tilesToWrite, int distinctTilesInPercent, int minzoom,
-    int maxzoom) throws IOException {
+  private static void writeTiles(BatchedTileWriter writer, int tilesToWrite, int noDupeTilesInPercent,
+    byte[] distinctTileData, byte[] dupeTileData, int dupeSpreadInPercent) {
 
-    String lastDistinctAttributeValue = "0";
-    String prevLastDistinctAttributeValue = "0";
+    int dupesToWrite = (int) Math.round(tilesToWrite * (100 - noDupeTilesInPercent) / 100.0);
+    int dupeHashMod = (int) Math.round(dupesToWrite * dupeSpreadInPercent / 100.0);
+    int tilesWritten = 0;
+    int dupeCounter = 0;
+    for (int z = 0; z <= 14; z++) {
+      int maxCoord = 1 << z;
+      for (int x = 0; x < maxCoord; x++) {
+        for (int y = 0; y < maxCoord; y++) {
 
-    try (
-      var renderer = featureGroup.newRenderedFeatureEncoder();
-      var writer = featureGroup.writerForThread();
-    ) {
-      int tilesWritten = 0;
-      for (int z = minzoom; z <= maxzoom; z++) {
-        int maxCoord = 1 << z;
-        for (int x = 0; x < maxCoord; x++) {
-          for (int y = 0; y < maxCoord; y++) {
+          TileCoord coord = TileCoord.ofXYZ(x, y, z);
+          TileEncodingResult toWrite;
+          if (tilesWritten % 100 < noDupeTilesInPercent) {
+            toWrite = new TileEncodingResult(coord, distinctTileData, false, null);
+          } else {
+            ++dupeCounter;
+            int hash = dupeHashMod == 0 ? 0 : dupeCounter % dupeHashMod;
+            toWrite = new TileEncodingResult(coord, dupeTileData, true, hash);
+          }
 
-            String attributeValue;
-            if (tilesWritten % 100 < distinctTilesInPercent) {
-              attributeValue = Integer.toString(tilesWritten);
-              prevLastDistinctAttributeValue = lastDistinctAttributeValue;
-              lastDistinctAttributeValue = attributeValue;
-            } else if (tilesWritten % 2 == 0) { // make sure the existing de-duping mechanism won't work
-              attributeValue = prevLastDistinctAttributeValue;
-            } else {
-              attributeValue = lastDistinctAttributeValue;
-            }
+          writer.write(toWrite);
 
-            var renderedFeatures = createRenderedFeature(x, y, z, attributeValue);
-            var sortableFeature = renderer.apply(renderedFeatures);
-            writer.accept(sortableFeature);
-            if (++tilesWritten >= tilesToWrite) {
-              return;
-            }
+          if (++tilesWritten >= tilesToWrite) {
+            return;
           }
         }
       }
     }
-  }
-
-  private static RenderedFeature createRenderedFeature(int x, int y, int z, String attributeValue) {
-    var geometry = new VectorTile.VectorGeometry(new int[0], GeometryType.POINT, 14);
-    var vectorTileFeature = new VectorTile.Feature("layer", 0, geometry, Map.of("k", attributeValue));
-    return new RenderedFeature(TileCoord.ofXYZ(x, y, z), vectorTileFeature, 0, Optional.empty());
   }
 
   private static Path getTempOutputPath() {
@@ -119,136 +133,9 @@ public class BenchmarkMbtilesWriter {
     return f.toPath();
   }
 
-  private record RepeatedMbtilesWriteStats(
-    LongSummaryStatistics total,
-    LongSummaryStatistics read,
-    LongSummaryStatistics encode,
-    LongSummaryStatistics write,
-    LongSummaryStatistics memoizedTiles,
-    LongSummaryStatistics file
-  ) {
-    RepeatedMbtilesWriteStats() {
-      this(
-        new LongSummaryStatistics(),
-        new LongSummaryStatistics(),
-        new LongSummaryStatistics(),
-        new LongSummaryStatistics(),
-        new LongSummaryStatistics(),
-        new LongSummaryStatistics()
-      );
-    }
-
-    void updateWithStats(MyStats myStats, Path mbtilesPath) {
-      total.accept(myStats.getStageDuration("mbtiles").toMillis());
-      memoizedTiles.accept(myStats.getLongCounter("mbtiles_memoized_tiles"));
-      MyTimers myTimers = myStats.timers();
-      read.accept(myTimers.getWorkerDuration("mbtiles_read").toMillis());
-      encode.accept(myTimers.getWorkerDuration("mbtiles_encode").toMillis());
-      write.accept(myTimers.getWorkerDuration("mbtiles_write").toMillis());
-      try {
-        file.accept(Files.size(mbtilesPath));
-      } catch (IOException e) {
-        throw new RuntimeException(e);
-      }
-    }
+  private static byte[] createFilledByteArray(int len) {
+    byte[] data = new byte[len];
+    Arrays.fill(data, (byte) 1);
+    return data;
   }
-
-  private static class MyTimers extends Timers {
-    private final Map<String, Duration> workerDurations = new ConcurrentHashMap<>();
-
-    @Override
-    public void finishedWorker(String prefix, Duration elapsed) {
-      workerDurations.put(prefix, elapsed);
-      super.finishedWorker(prefix, elapsed);
-    }
-
-    Duration getWorkerDuration(String prefix) {
-      return workerDurations.get(prefix);
-    }
-  }
-  /*
-   * custom stats in order to have custom times in order to get worker durations
-   * and while at it, make stage durations available as well
-   * note: the actual problem here is that Timer.Stage/ThreadInfo are not public
-   */
-  private static class MyStats implements Stats {
-
-    private final Map<String, Duration> stageDurations = new ConcurrentHashMap<>();
-    private final Map<String, Counter.MultiThreadCounter> longCounters = new ConcurrentHashMap<>();
-
-    private final MyTimers timers = new MyTimers();
-
-    Duration getStageDuration(String name) {
-      return stageDurations.get(name);
-    }
-
-    long getLongCounter(String name) {
-      var counter = longCounters.get(name);
-      if (counter == null) {
-        return -1;
-      }
-      return counter.get();
-    }
-
-    @Override
-    public Timers.Finishable startStage(String name) {
-      Instant start = Instant.now();
-      Timers.Finishable wrapped = Stats.super.startStage(name);
-      return () -> {
-        stageDurations.put(name, Duration.between(start, Instant.now()));
-        wrapped.stop();
-      };
-    }
-
-    @Override
-    public void close() throws Exception {}
-
-    @Override
-    public void emittedFeatures(int z, String layer, int numFeatures) {}
-
-    @Override
-    public void processedElement(String elemType, String layer) {}
-
-    @Override
-    public void wroteTile(int zoom, int bytes) {}
-
-    @Override
-    public MyTimers timers() {
-      return timers;
-    }
-
-    @Override
-    public Map<String, Path> monitoredFiles() {
-      return Map.of();
-    }
-
-    @Override
-    public void monitorInMemoryObject(String name, HasEstimate object) {}
-
-    @Override
-    public void gauge(String name, Supplier<Number> value) {}
-
-    @Override
-    public void counter(String name, Supplier<Number> supplier) {}
-
-    @Override
-    public void counter(String name, String label, Supplier<Map<String, LongSupplier>> values) {}
-
-    @Override
-    public void dataError(String errorCode) {}
-
-    @Override
-    public Counter.MultiThreadCounter longCounter(String name) {
-      var counter = Counter.newMultiThreadCounter();
-      longCounters.put(name, counter);
-      return counter;
-    }
-
-    @Override
-    public Counter.MultiThreadCounter nanoCounter(String name) {
-      return Counter.newMultiThreadCounter();
-    }
-
-  }
-
 }

--- a/planetiler-benchmarks/src/main/java/com/onthegomap/planetiler/benchmarks/BenchmarkMbtilesWriter.java
+++ b/planetiler-benchmarks/src/main/java/com/onthegomap/planetiler/benchmarks/BenchmarkMbtilesWriter.java
@@ -1,0 +1,254 @@
+package com.onthegomap.planetiler.benchmarks;
+
+import com.onthegomap.planetiler.Profile;
+import com.onthegomap.planetiler.VectorTile;
+import com.onthegomap.planetiler.collection.FeatureGroup;
+import com.onthegomap.planetiler.config.Arguments;
+import com.onthegomap.planetiler.config.MbtilesMetadata;
+import com.onthegomap.planetiler.config.PlanetilerConfig;
+import com.onthegomap.planetiler.geo.GeometryType;
+import com.onthegomap.planetiler.geo.TileCoord;
+import com.onthegomap.planetiler.mbtiles.MbtilesWriter;
+import com.onthegomap.planetiler.render.RenderedFeature;
+import com.onthegomap.planetiler.stats.Counter;
+import com.onthegomap.planetiler.stats.Stats;
+import com.onthegomap.planetiler.stats.Timers;
+import com.onthegomap.planetiler.util.MemoryEstimator.HasEstimate;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.LongSummaryStatistics;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BenchmarkMbtilesWriter {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(BenchmarkMbtilesWriter.class);
+
+
+  public static void main(String[] args) throws IOException {
+
+    Arguments arguments = Arguments.fromArgs(args);
+
+    int tilesToWrite = arguments.getInteger("bench_tiles_to_write", "number of tiles to write", 1_000_000);
+    int repetitions = arguments.getInteger("bench_repetitions", "number of repetitions", 10);
+    // to put some context here: Australia has 8% distinct tiles
+    int distinctTilesInPercent = arguments.getInteger("bench_distinct_tiles", "distinct tiles in percent", 10);
+
+
+    MbtilesMetadata mbtilesMetadata = new MbtilesMetadata(new Profile.NullProfile());
+    PlanetilerConfig config = PlanetilerConfig.from(arguments);
+
+    FeatureGroup featureGroup = FeatureGroup.newInMemoryFeatureGroup(new Profile.NullProfile(), Stats.inMemory());
+    renderTiles(featureGroup, tilesToWrite, distinctTilesInPercent, config.minzoom(), config.maxzoom());
+
+    RepeatedMbtilesWriteStats repeatedMbtilesStats = new RepeatedMbtilesWriteStats();
+    for (int repetition = 0; repetition < repetitions; repetition++) {
+      MyStats myStats = new MyStats();
+      Path outputPath = getTempOutputPath();
+      MbtilesWriter.writeOutput(featureGroup, outputPath, mbtilesMetadata, config, myStats);
+      repeatedMbtilesStats.updateWithStats(myStats, outputPath);
+      outputPath.toFile().delete();
+    }
+
+    LOGGER.info("{}", repeatedMbtilesStats);
+  }
+
+
+  private static void renderTiles(FeatureGroup featureGroup, int tilesToWrite, int distinctTilesInPercent, int minzoom,
+    int maxzoom) throws IOException {
+
+    String lastDistinctAttributeValue = "0";
+    String prevLastDistinctAttributeValue = "0";
+
+    try (
+      var renderer = featureGroup.newRenderedFeatureEncoder();
+      var writer = featureGroup.writerForThread();
+    ) {
+      int tilesWritten = 0;
+      for (int z = minzoom; z <= maxzoom; z++) {
+        int maxCoord = 1 << z;
+        for (int x = 0; x < maxCoord; x++) {
+          for (int y = 0; y < maxCoord; y++) {
+
+            String attributeValue;
+            if (tilesWritten % 100 < distinctTilesInPercent) {
+              attributeValue = Integer.toString(tilesWritten);
+              prevLastDistinctAttributeValue = lastDistinctAttributeValue;
+              lastDistinctAttributeValue = attributeValue;
+            } else if (tilesWritten % 2 == 0) { // make sure the existing de-duping mechanism won't work
+              attributeValue = prevLastDistinctAttributeValue;
+            } else {
+              attributeValue = lastDistinctAttributeValue;
+            }
+
+            var renderedFeatures = createRenderedFeature(x, y, z, attributeValue);
+            var sortableFeature = renderer.apply(renderedFeatures);
+            writer.accept(sortableFeature);
+            if (++tilesWritten >= tilesToWrite) {
+              return;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private static RenderedFeature createRenderedFeature(int x, int y, int z, String attributeValue) {
+    var geometry = new VectorTile.VectorGeometry(new int[0], GeometryType.POINT, 14);
+    var vectorTileFeature = new VectorTile.Feature("layer", 0, geometry, Map.of("k", attributeValue));
+    return new RenderedFeature(TileCoord.ofXYZ(x, y, z), vectorTileFeature, 0, Optional.empty());
+  }
+
+  private static Path getTempOutputPath() {
+    File f;
+    try {
+      f = File.createTempFile("planetiler", ".mbtiles");
+    } catch (IOException e) {
+      throw new IllegalStateException(e);
+    }
+    f.deleteOnExit();
+    return f.toPath();
+  }
+
+  private record RepeatedMbtilesWriteStats(
+    LongSummaryStatistics total,
+    LongSummaryStatistics read,
+    LongSummaryStatistics encode,
+    LongSummaryStatistics write,
+    LongSummaryStatistics memoizedTiles,
+    LongSummaryStatistics file
+  ) {
+    RepeatedMbtilesWriteStats() {
+      this(
+        new LongSummaryStatistics(),
+        new LongSummaryStatistics(),
+        new LongSummaryStatistics(),
+        new LongSummaryStatistics(),
+        new LongSummaryStatistics(),
+        new LongSummaryStatistics()
+      );
+    }
+
+    void updateWithStats(MyStats myStats, Path mbtilesPath) {
+      total.accept(myStats.getStageDuration("mbtiles").toMillis());
+      memoizedTiles.accept(myStats.getLongCounter("mbtiles_memoized_tiles"));
+      MyTimers myTimers = myStats.timers();
+      read.accept(myTimers.getWorkerDuration("mbtiles_read").toMillis());
+      encode.accept(myTimers.getWorkerDuration("mbtiles_encode").toMillis());
+      write.accept(myTimers.getWorkerDuration("mbtiles_write").toMillis());
+      try {
+        file.accept(Files.size(mbtilesPath));
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  private static class MyTimers extends Timers {
+    private final Map<String, Duration> workerDurations = new ConcurrentHashMap<>();
+
+    @Override
+    public void finishedWorker(String prefix, Duration elapsed) {
+      workerDurations.put(prefix, elapsed);
+      super.finishedWorker(prefix, elapsed);
+    }
+
+    Duration getWorkerDuration(String prefix) {
+      return workerDurations.get(prefix);
+    }
+  }
+  /*
+   * custom stats in order to have custom times in order to get worker durations
+   * and while at it, make stage durations available as well
+   * note: the actual problem here is that Timer.Stage/ThreadInfo are not public
+   */
+  private static class MyStats implements Stats {
+
+    private final Map<String, Duration> stageDurations = new ConcurrentHashMap<>();
+    private final Map<String, Counter.MultiThreadCounter> longCounters = new ConcurrentHashMap<>();
+
+    private final MyTimers timers = new MyTimers();
+
+    Duration getStageDuration(String name) {
+      return stageDurations.get(name);
+    }
+
+    long getLongCounter(String name) {
+      var counter = longCounters.get(name);
+      if (counter == null) {
+        return -1;
+      }
+      return counter.get();
+    }
+
+    @Override
+    public Timers.Finishable startStage(String name) {
+      Instant start = Instant.now();
+      Timers.Finishable wrapped = Stats.super.startStage(name);
+      return () -> {
+        stageDurations.put(name, Duration.between(start, Instant.now()));
+        wrapped.stop();
+      };
+    }
+
+    @Override
+    public void close() throws Exception {}
+
+    @Override
+    public void emittedFeatures(int z, String layer, int numFeatures) {}
+
+    @Override
+    public void processedElement(String elemType, String layer) {}
+
+    @Override
+    public void wroteTile(int zoom, int bytes) {}
+
+    @Override
+    public MyTimers timers() {
+      return timers;
+    }
+
+    @Override
+    public Map<String, Path> monitoredFiles() {
+      return Map.of();
+    }
+
+    @Override
+    public void monitorInMemoryObject(String name, HasEstimate object) {}
+
+    @Override
+    public void gauge(String name, Supplier<Number> value) {}
+
+    @Override
+    public void counter(String name, Supplier<Number> supplier) {}
+
+    @Override
+    public void counter(String name, String label, Supplier<Map<String, LongSupplier>> values) {}
+
+    @Override
+    public void dataError(String errorCode) {}
+
+    @Override
+    public Counter.MultiThreadCounter longCounter(String name) {
+      var counter = Counter.newMultiThreadCounter();
+      longCounters.put(name, counter);
+      return counter;
+    }
+
+    @Override
+    public Counter.MultiThreadCounter nanoCounter(String name) {
+      return Counter.newMultiThreadCounter();
+    }
+
+  }
+
+}

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/collection/FeatureGroup.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/collection/FeatureGroup.java
@@ -1,7 +1,6 @@
 package com.onthegomap.planetiler.collection;
 
 import com.carrotsearch.hppc.LongLongHashMap;
-import com.google.common.primitives.Longs;
 import com.onthegomap.planetiler.Profile;
 import com.onthegomap.planetiler.VectorTile;
 import com.onthegomap.planetiler.config.PlanetilerConfig;
@@ -352,9 +351,9 @@ public final class FeatureGroup implements Iterable<FeatureGroup.TileFeatures>, 
     public int generateContentHash() {
       int hash = Hashing.FNV1_32_INIT;
       for (var feature : entries) {
-        long layerId = extractLayerIdFromKey(feature.key());
-        hash = Hashing.fnv32(hash, Longs.toByteArray(layerId));
-        hash = Hashing.fnv32(hash, feature.value());
+        byte layerId = extractLayerIdFromKey(feature.key());
+        hash = Hashing.fnv1a32(hash, layerId);
+        hash = Hashing.fnv1a32(hash, feature.value());
       }
       return hash;
     }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/collection/FeatureGroup.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/collection/FeatureGroup.java
@@ -1,8 +1,7 @@
 package com.onthegomap.planetiler.collection;
 
 import com.carrotsearch.hppc.LongLongHashMap;
-import com.google.common.io.ByteArrayDataOutput;
-import com.google.common.io.ByteStreams;
+import com.google.common.primitives.Longs;
 import com.onthegomap.planetiler.Profile;
 import com.onthegomap.planetiler.VectorTile;
 import com.onthegomap.planetiler.config.PlanetilerConfig;
@@ -351,14 +350,13 @@ public final class FeatureGroup implements Iterable<FeatureGroup.TileFeatures>, 
      * Used as an optimization to avoid writing the same (ocean) tiles over and over again.
      */
     public int generateContentHash() {
-      ByteArrayDataOutput out = ByteStreams.newDataOutput();
+      int hash = Hashing.FNV1_32_INIT;
       for (var feature : entries) {
         long layerId = extractLayerIdFromKey(feature.key());
-        out.writeLong(layerId);
-        out.write(feature.value());
-        out.writeBoolean(extractHasGroupFromKey(feature.key()));
+        hash = Hashing.fnv32(hash, Longs.toByteArray(layerId));
+        hash = Hashing.fnv32(hash, feature.value());
       }
-      return Hashing.fnv32(out.toByteArray());
+      return hash;
     }
 
     /**

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/config/PlanetilerConfig.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/config/PlanetilerConfig.java
@@ -39,7 +39,8 @@ public record PlanetilerConfig(
   double minFeatureSizeBelowMaxZoom,
   double simplifyToleranceAtMaxZoom,
   double simplifyToleranceBelowMaxZoom,
-  boolean osmLazyReads
+  boolean osmLazyReads,
+  boolean compactDb
 ) {
 
   public static final int MIN_MINZOOM = 0;
@@ -135,6 +136,9 @@ public record PlanetilerConfig(
         0.1d),
       arguments.getBoolean("osm_lazy_reads",
         "Read OSM blocks from disk in worker threads",
+        false),
+      arguments.getBoolean("compact_db",
+        "Reduce the DB size by separating and deduping the tile data",
         false)
     );
   }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/mbtiles/Compare.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/mbtiles/Compare.java
@@ -78,17 +78,12 @@ public class Compare {
             .map(VectorTileFeatureForCmp::fromActualFeature)
             .collect(Collectors.toSet());
 
-          if (features0.size() != features1.size()) {
-            throw new IllegalArgumentException(
-              "feature size differs on coord=%s db0=%d vs db1=%d".formatted(coord, features0.size(), features1.size())
-            );
-          }
-
           if (!features0.equals(features1)) {
             ++tilesWithDiffs;
+            boolean featureCountMatches = features0.size() == features1.size();
             var msg = """
               <<<
-              feature diff on coord %s
+              feature diff on coord %s - featureCountMatches: %b (%d vs %d)
 
               additional in db0
               ---
@@ -99,7 +94,7 @@ public class Compare {
               %s
               >>>
               """.formatted(
-              coord,
+              coord, featureCountMatches, features0.size(), features1.size(),
               getDiffJoined(features0, features1, "\n"),
               getDiffJoined(features1, features0, "\n"));
 

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/mbtiles/Compare.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/mbtiles/Compare.java
@@ -1,0 +1,165 @@
+package com.onthegomap.planetiler.mbtiles;
+
+import static com.onthegomap.planetiler.VectorTile.decode;
+import static com.onthegomap.planetiler.util.Gzip.gunzip;
+
+import com.google.common.collect.Sets;
+import com.onthegomap.planetiler.VectorTile;
+import com.onthegomap.planetiler.config.Arguments;
+import com.onthegomap.planetiler.geo.GeometryException;
+import com.onthegomap.planetiler.geo.TileCoord;
+import java.nio.file.Path;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.locationtech.jts.geom.Geometry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A utility to compare two mbtiles files.
+ * <p>
+ * See {@link VectorTileFeatureForCmp} for comparison rules. The results planetiler produces are not necessarily stable,
+ * so sometimes a few feature may be different in one tile. Also POI coordinates may sometimes differ slightly.
+ * <p>
+ * => The tool helps to see if two mbtiles files are mostly identical.
+ *
+ */
+public class Compare {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(Compare.class);
+
+  public static void main(String[] args) throws Exception {
+
+
+    Arguments arguments = Arguments.fromArgs(args);
+    String dbPath0 = arguments.getString("bench_mbtiles0", "the first mbtiles file", null);
+    String dbPath1 = arguments.getString("bench_mbtiles1", "the second mbtiles file", null);
+    boolean failOnFeatureDiff = arguments.getBoolean("bench_fail_on_feature_diff", "fail on feature diff", false);
+
+    try (
+      var db0 = Mbtiles.newReadOnlyDatabase(Path.of(dbPath0));
+      var db1 = Mbtiles.newReadOnlyDatabase(Path.of(dbPath1))
+    ) {
+      long tilesCount0 = getTilesCount(db0);
+      long tilesCount1 = getTilesCount(db1);
+      if (tilesCount0 != tilesCount1) {
+        throw new IllegalArgumentException(
+          "expected tiles count to be equal but tilesCount0=%d tilesCount1=%d".formatted(tilesCount0, tilesCount1)
+        );
+      }
+
+      int lastPercentage = -1;
+      long processedTileCounter = 0;
+      long tilesWithDiffs = 0;
+      try (var statement = db0.connection().prepareStatement("select tile_column, tile_row, zoom_level from tiles")) {
+        var rs = statement.executeQuery();
+        while (rs.next()) {
+          processedTileCounter++;
+          int x = rs.getInt("tile_column");
+          int y = rs.getInt("tile_row");
+          int z = rs.getInt("zoom_level");
+          TileCoord coord = TileCoord.ofXYZ(x, (1 << z) - 1 - y, z);
+
+          int currentPercentage = (int) (processedTileCounter * 100 / tilesCount0);
+          if (lastPercentage != currentPercentage) {
+            LOGGER.info("processed {}%", currentPercentage);
+          }
+          lastPercentage = currentPercentage;
+
+          var features0 = decode(gunzip(db0.getTile(coord)))
+            .stream()
+            .map(VectorTileFeatureForCmp::fromActualFeature)
+            .collect(Collectors.toSet());
+          var features1 = decode(gunzip(db1.getTile(coord)))
+            .stream()
+            .map(VectorTileFeatureForCmp::fromActualFeature)
+            .collect(Collectors.toSet());
+
+          if (features0.size() != features1.size()) {
+            throw new IllegalArgumentException(
+              "feature size differs on coord=%s db0=%d vs db1=%d".formatted(coord, features0.size(), features1.size())
+            );
+          }
+
+          if (!features0.equals(features1)) {
+            ++tilesWithDiffs;
+            var msg = """
+              <<<
+              feature diff on coord %s
+
+              additional in db0
+              ---
+              %s
+
+              additional in db1
+              ---
+              %s
+              >>>
+              """.formatted(
+              coord,
+              getDiffJoined(features0, features1, "\n"),
+              getDiffJoined(features1, features0, "\n"));
+
+            if (failOnFeatureDiff) {
+              throw new RuntimeException(msg);
+            } else {
+              LOGGER.warn(msg);
+            }
+          }
+        }
+      }
+
+      LOGGER.info("totalTiles={} tilesWithDiffs={}", processedTileCounter, tilesWithDiffs);
+    }
+  }
+
+  private static long getTilesCount(Mbtiles db) throws SQLException {
+    try (var statement = db.connection().createStatement()) {
+      var rs = statement.executeQuery("select count(*) from tiles_shallow");
+      rs.next();
+      return rs.getLong(1);
+    } catch (Exception e) {
+      try (var statement = db.connection().createStatement()) {
+        var rs = statement.executeQuery("select count(*) from tiles");
+        rs.next();
+        return rs.getLong(1);
+      }
+    }
+  }
+
+  private static <T> String getDiffJoined(Set<T> s0, Set<T> s1, String delimiter) {
+    return Sets.difference(s0, s1).stream().map(Object::toString).collect(Collectors.joining(delimiter));
+  }
+
+  /**
+   * Wrapper around {@link VectorTile.Feature} to compare vector tiles.
+   * <ul>
+   * <li>{@link VectorTile.Feature#id()} won't be compared
+   * <li>{@link VectorTile.Feature#layer()} will be compared
+   * <li>{@link VectorTile.Feature#geometry()} gets normalized for comparing
+   * <li>{@link VectorTile.Feature#attrs()} will be compared except for the rank attribute since the value produced by
+   * planetiler is not stable and differs on every run (at least for parks)
+   * <li>{@link VectorTile.Feature#group()} will be compared
+   * </ul>
+   */
+  private record VectorTileFeatureForCmp(
+    String layer,
+    Geometry normalizedGeometry,
+    Map<String, Object> attrs,
+    long group
+  ) {
+    static VectorTileFeatureForCmp fromActualFeature(VectorTile.Feature f) {
+      try {
+        var attrs = new HashMap<>(f.attrs());
+        attrs.remove("rank");
+        return new VectorTileFeatureForCmp(f.layer(), f.geometry().decode().norm(), attrs, f.group());
+      } catch (GeometryException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+}

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/mbtiles/Mbtiles.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/mbtiles/Mbtiles.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.onthegomap.planetiler.geo.GeoUtils;
 import com.onthegomap.planetiler.geo.TileCoord;
+import com.onthegomap.planetiler.mbtiles.Mbtiles.MetadataJson.VectorLayer;
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -20,15 +21,18 @@ import java.sql.Statement;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 import java.util.stream.DoubleStream;
+import java.util.stream.IntStream;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
 import org.slf4j.Logger;
@@ -57,6 +61,23 @@ public final class Mbtiles implements Closeable {
   );
   private static final String TILES_COL_DATA = "tile_data";
 
+  private static final String TILES_DATA_TABLE = "tiles_data";
+  private static final String TILES_DATA_COL_DATA_ID = "tile_data_id";
+  private static final String TILES_DATA_COL_DATA = "tile_data";
+
+  private static final String TILES_SHALLOW_TABLE = "tiles_shallow";
+  private static final String TILES_SHALLOW_COL_X = TILES_COL_X;
+  private static final String TILES_SHALLOW_COL_Y = TILES_COL_Y;
+  private static final String TILES_SHALLOW_COL_Z = TILES_COL_Z;
+  private static final String TILES_SHALLOW_COL_DATA_ID = TILES_DATA_COL_DATA_ID;
+  private static final String ADD_TILES_SHALLOW_INDEX_SQL =
+    "create unique index tiles_shallow_index on %s (%s, %s, %s)".formatted(
+      TILES_SHALLOW_TABLE,
+      TILES_SHALLOW_COL_Z,
+      TILES_SHALLOW_COL_X,
+      TILES_SHALLOW_COL_Y
+    );
+
   private static final String METADATA_TABLE = "metadata";
   private static final String METADATA_COL_NAME = "name";
   private static final String METADATA_COL_VALUE = "value";
@@ -77,24 +98,31 @@ public final class Mbtiles implements Closeable {
 
   private final Connection connection;
   private PreparedStatement getTileStatement = null;
+  private final boolean compactDb;
 
-  public Mbtiles(Connection connection) {
+  private Mbtiles(Connection connection, boolean compactDb) {
     this.connection = connection;
+    this.compactDb = compactDb;
   }
 
   /** Returns a new mbtiles file that won't get written to disk. Useful for toy use-cases like unit tests. */
-  public static Mbtiles newInMemoryDatabase() {
+  public static Mbtiles newInMemoryDatabase(boolean compactDb) {
     try {
       SQLiteConfig config = new SQLiteConfig();
       config.setApplicationId(MBTILES_APPLICATION_ID);
-      return new Mbtiles(DriverManager.getConnection("jdbc:sqlite::memory:", config.toProperties()));
+      return new Mbtiles(DriverManager.getConnection("jdbc:sqlite::memory:", config.toProperties()), compactDb);
     } catch (SQLException throwables) {
       throw new IllegalStateException("Unable to create in-memory database", throwables);
     }
   }
 
+  /** @see {@link #newInMemoryDatabase(boolean)} */
+  public static Mbtiles newInMemoryDatabase() {
+    return newInMemoryDatabase(false);
+  }
+
   /** Returns a new connection to an mbtiles file optimized for fast bulk writes. */
-  public static Mbtiles newWriteToFileDatabase(Path path) {
+  public static Mbtiles newWriteToFileDatabase(Path path, boolean compactDb) {
     try {
       SQLiteConfig config = new SQLiteConfig();
       config.setJournalMode(SQLiteConfig.JournalMode.OFF);
@@ -103,7 +131,8 @@ public final class Mbtiles implements Closeable {
       config.setLockingMode(SQLiteConfig.LockingMode.EXCLUSIVE);
       config.setTempStore(SQLiteConfig.TempStore.MEMORY);
       config.setApplicationId(MBTILES_APPLICATION_ID);
-      return new Mbtiles(DriverManager.getConnection("jdbc:sqlite:" + path.toAbsolutePath(), config.toProperties()));
+      return new Mbtiles(DriverManager.getConnection("jdbc:sqlite:" + path.toAbsolutePath(), config.toProperties()),
+        compactDb);
     } catch (SQLException throwables) {
       throw new IllegalArgumentException("Unable to open " + path, throwables);
     }
@@ -121,7 +150,7 @@ public final class Mbtiles implements Closeable {
       // config.setOpenMode(SQLiteOpenMode.NOMUTEX);
       Connection connection = DriverManager
         .getConnection("jdbc:sqlite:" + path.toAbsolutePath(), config.toProperties());
-      return new Mbtiles(connection);
+      return new Mbtiles(connection, false /* in read-only mode, it's irrelevant if compact or not */);
     } catch (SQLException throwables) {
       throw new IllegalArgumentException("Unable to open " + path, throwables);
     }
@@ -136,29 +165,81 @@ public final class Mbtiles implements Closeable {
     }
   }
 
-  private Mbtiles execute(String... queries) {
+  private Mbtiles execute(Collection<String> queries) {
     for (String query : queries) {
       try (var statement = connection.createStatement()) {
-        LOGGER.debug("Execute mbtiles: " + query);
+        LOGGER.debug("Execute mbtiles: {}", query);
         statement.execute(query);
       } catch (SQLException throwables) {
-        throw new IllegalStateException("Error executing queries " + Arrays.toString(queries), throwables);
+        throw new IllegalStateException("Error executing queries " + String.join(",", queries), throwables);
       }
     }
     return this;
   }
 
+  private Mbtiles execute(String... queries) {
+    return execute(Arrays.asList(queries));
+  }
+
   public Mbtiles addTileIndex() {
-    return execute(ADD_TILE_INDEX_SQL);
+    if (compactDb) {
+      return execute(ADD_TILES_SHALLOW_INDEX_SQL);
+    } else {
+      return execute(ADD_TILE_INDEX_SQL);
+    }
   }
 
   public Mbtiles createTables() {
-    return execute(
-      "create table " + METADATA_TABLE + " (" + METADATA_COL_NAME + " text, " + METADATA_COL_VALUE + " text);",
-      "create unique index name on " + METADATA_TABLE + " (" + METADATA_COL_NAME + ");",
-      "create table " + TILES_TABLE + " (" + TILES_COL_Z + " integer, " + TILES_COL_X + " integer, " + TILES_COL_Y +
-        ", " + TILES_COL_DATA + " blob);"
-    );
+
+    List<String> ddlStatements = new ArrayList<>();
+
+    ddlStatements
+      .add("create table " + METADATA_TABLE + " (" + METADATA_COL_NAME + " text, " + METADATA_COL_VALUE + " text);");
+    ddlStatements
+      .add("create unique index name on " + METADATA_TABLE + " (" + METADATA_COL_NAME + ");");
+
+    if (compactDb) {
+      ddlStatements
+        .add("""
+          create table %s (
+            %s integer,
+            %s integer,
+            %s integer,
+            %s integer
+          )
+          """.formatted(TILES_SHALLOW_TABLE,
+          TILES_SHALLOW_COL_Z, TILES_SHALLOW_COL_X, TILES_SHALLOW_COL_Y, TILES_SHALLOW_COL_DATA_ID));
+      ddlStatements.add("""
+        create table %s (
+          %s integer primary key,
+          %s blob
+        )
+        """.formatted(TILES_DATA_TABLE, TILES_DATA_COL_DATA_ID, TILES_DATA_COL_DATA));
+      ddlStatements.add("""
+        create view %s AS
+        select
+          %s.%s as %s,
+          %s.%s as %s,
+          %s.%s as %s,
+          %s.%s as %s
+        from %s
+        join %s on %s.%s = %s.%s
+        """.formatted(
+        TILES_TABLE,
+        TILES_SHALLOW_TABLE, TILES_SHALLOW_COL_Z, TILES_COL_Z,
+        TILES_SHALLOW_TABLE, TILES_SHALLOW_COL_X, TILES_COL_X,
+        TILES_SHALLOW_TABLE, TILES_SHALLOW_COL_Y, TILES_COL_Y,
+        TILES_DATA_TABLE, TILES_DATA_COL_DATA, TILES_COL_DATA,
+        TILES_SHALLOW_TABLE,
+        TILES_DATA_TABLE, TILES_SHALLOW_TABLE, TILES_SHALLOW_COL_DATA_ID, TILES_DATA_TABLE, TILES_DATA_COL_DATA_ID
+      ));
+    } else {
+      ddlStatements.add("create table " + TILES_TABLE + " (" + TILES_COL_Z + " integer, " + TILES_COL_X + " integer, " +
+        TILES_COL_Y + ", " + TILES_COL_DATA + " blob);");
+    }
+
+
+    return execute(ddlStatements);
   }
 
   public Mbtiles vacuumAnalyze() {
@@ -168,9 +249,13 @@ public final class Mbtiles implements Closeable {
     );
   }
 
-  /** Returns a writer that queues up inserts into the tile database into large batches before executing them. */
+  /** Returns a writer that queues up inserts into the tile database(s) into large batches before executing them. */
   public BatchedTileWriter newBatchedTileWriter() {
-    return new BatchedTileWriter();
+    if (compactDb) {
+      return new BatchedCompactTileWriter();
+    } else {
+      return new BatchedNonCompactTileWriter();
+    }
   }
 
   /** Returns the contents of the metadata table. */
@@ -183,10 +268,8 @@ public final class Mbtiles implements Closeable {
       try {
         getTileStatement = connection.prepareStatement("""
           SELECT tile_data FROM %s
-          WHERE tile_column=?
-          AND tile_row=?
-          AND zoom_level=?
-          """.formatted(TILES_TABLE));
+          WHERE %s=? AND %s=? AND %s=?
+          """.formatted(TILES_TABLE, TILES_COL_X, TILES_COL_Y, TILES_COL_Z));
       } catch (SQLException throwables) {
         throw new IllegalStateException(throwables);
       }
@@ -205,7 +288,7 @@ public final class Mbtiles implements Closeable {
       stmt.setInt(2, (1 << z) - 1 - y);
       stmt.setInt(3, z);
       try (ResultSet rs = stmt.executeQuery()) {
-        return rs.next() ? rs.getBytes("tile_data") : null;
+        return rs.next() ? rs.getBytes(TILES_COL_DATA) : null;
       }
     } catch (SQLException throwables) {
       throw new IllegalStateException("Could not get tile", throwables);
@@ -215,11 +298,13 @@ public final class Mbtiles implements Closeable {
   public List<TileCoord> getAllTileCoords() {
     List<TileCoord> result = new ArrayList<>();
     try (Statement statement = connection.createStatement()) {
-      ResultSet rs = statement.executeQuery("select zoom_level, tile_column, tile_row, tile_data from tiles");
+      ResultSet rs = statement.executeQuery(
+        "select %s, %s, %s, %s from %s".formatted(TILES_COL_Z, TILES_COL_X, TILES_COL_Y, TILES_COL_DATA, TILES_TABLE)
+      );
       while (rs.next()) {
-        int z = rs.getInt("zoom_level");
-        int rawy = rs.getInt("tile_row");
-        int x = rs.getInt("tile_column");
+        int z = rs.getInt(TILES_COL_Z);
+        int rawy = rs.getInt(TILES_COL_Y);
+        int x = rs.getInt(TILES_COL_X);
         result.add(TileCoord.ofXYZ(x, (1 << z) - 1 - rawy, z));
       }
     } catch (SQLException throwables) {
@@ -312,7 +397,7 @@ public final class Mbtiles implements Closeable {
     }
   }
 
-  /** Contents of a row of the tiles table. */
+  /** Contents of a row of the tiles table, or in case of compact mode in the tiles view. */
   public record TileEntry(TileCoord tile, byte[] bytes) implements Comparable<TileEntry> {
 
     @Override
@@ -353,64 +438,92 @@ public final class Mbtiles implements Closeable {
     }
   }
 
-  /**
-   * A high-throughput writer that accepts new tiles and queues up the writes to execute them in fewer large-batches.
-   */
-  public class BatchedTileWriter implements AutoCloseable {
+  /** Contents of a row of the tiles_shallow table. */
+  private record TileShallowEntry(TileCoord coord, long tileDataId) {}
 
-    // max number of parameters in a prepared statements is 999
-    private static final int BATCH_SIZE = 999 / 4;
-    private final List<TileEntry> batch;
-    private final PreparedStatement batchStatement;
-    private final int batchLimit;
-
-    private BatchedTileWriter() {
-      batchLimit = BATCH_SIZE;
-      batch = new ArrayList<>(batchLimit);
-      batchStatement = createBatchStatement(batchLimit);
+  /** Contents of a row of the tiles_data table. */
+  private record TileDataEntry(long tileDataId, byte[] tileData) {
+    @Override
+    public String toString() {
+      return "TileDataEntry [tileDataId=" + tileDataId + ", tileData=" + Arrays.toString(tileData) + "]";
     }
 
-    @SuppressWarnings("java:S2077")
-    private PreparedStatement createBatchStatement(int size) {
-      List<String> groups = new ArrayList<>();
-      for (int i = 0; i < size; i++) {
-        groups.add("(?,?,?,?)");
+    @Override
+    public int hashCode() {
+      final int prime = 31;
+      int result = 1;
+      result = prime * result + Arrays.hashCode(tileData);
+      result = prime * result + Objects.hash(tileDataId);
+      return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
       }
-      try {
-        return connection.prepareStatement("""
-          INSERT INTO %s (%s, %s, %s, %s) VALUES %s;
-          """.formatted(
-          TILES_TABLE,
-          TILES_COL_Z, TILES_COL_X, TILES_COL_Y,
-          TILES_COL_DATA,
-          String.join(", ", groups)
-        ));
-      } catch (SQLException throwables) {
-        throw new IllegalStateException("Could not create prepared statement", throwables);
+      if (!(obj instanceof TileDataEntry)) {
+        return false;
       }
+      TileDataEntry other = (TileDataEntry) obj;
+      return Arrays.equals(tileData, other.tileData) && tileDataId == other.tileDataId;
+    }
+  }
+
+  private abstract class BatchedTableWriterBase<T> implements AutoCloseable {
+
+    private static final int MAX_PARAMETERS_IN_PREPARED_STATEMENT = 999;
+    private final List<T> batch;
+    private final PreparedStatement batchStatement;
+    private final int batchLimit;
+    private final String insertStmtTableName;
+    private final boolean insertStmtInsertIgnore;
+    private final String insertStmtValuesPlaceHolder;
+    private final String insertStmtColumnsCsv;
+
+
+    protected BatchedTableWriterBase(String tableName, List<String> columns, boolean insertIgnore) {
+      batchLimit = MAX_PARAMETERS_IN_PREPARED_STATEMENT / columns.size();
+      batch = new ArrayList<>(batchLimit);
+      insertStmtTableName = tableName;
+      insertStmtInsertIgnore = insertIgnore;
+      insertStmtValuesPlaceHolder = columns.stream().map(c -> "?").collect(Collectors.joining(",", "(", ")"));
+      insertStmtColumnsCsv = columns.stream().collect(Collectors.joining(","));
+      batchStatement = createBatchInsertPreparedStatement(batchLimit);
     }
 
     /** Queue-up a write or flush to disk if enough are waiting. */
-    public void write(TileCoord tile, byte[] data) {
-      batch.add(new TileEntry(tile, data));
+    void write(T item) {
+      batch.add(item);
       if (batch.size() >= batchLimit) {
         flush(batchStatement);
+      }
+    }
+
+    protected abstract int setParamsInStatementForItem(int positionOffset, PreparedStatement statement, T item)
+      throws SQLException;
+
+    private PreparedStatement createBatchInsertPreparedStatement(int size) {
+
+      final String sql = "INSERT %s INTO %s (%s) VALUES %s;".formatted(
+        insertStmtInsertIgnore ? "OR IGNORE" : "",
+        insertStmtTableName,
+        insertStmtColumnsCsv,
+        IntStream.range(0, size).mapToObj(i -> insertStmtValuesPlaceHolder).collect(Collectors.joining(", "))
+      );
+
+      try {
+        return connection.prepareStatement(sql);
+      } catch (SQLException throwables) {
+        throw new IllegalStateException("Could not create prepared statement", throwables);
       }
     }
 
     private void flush(PreparedStatement statement) {
       try {
         int pos = 1;
-        for (TileEntry tile : batch) {
-          TileCoord coord = tile.tile();
-          int x = coord.x();
-          int y = coord.y();
-          int z = coord.z();
-          statement.setInt(pos++, z);
-          statement.setInt(pos++, x);
-          // flip Y
-          statement.setInt(pos++, (1 << z) - 1 - y);
-          statement.setBytes(pos++, tile.bytes());
+        for (T item : batch) {
+          pos = setParamsInStatementForItem(pos, statement, item);
         }
         statement.execute();
         batch.clear();
@@ -421,16 +534,138 @@ public final class Mbtiles implements Closeable {
 
     @Override
     public void close() {
-      try {
-        if (batch.size() > 0) {
-          try (var lastBatch = createBatchStatement(batch.size())) {
-            flush(lastBatch);
-          }
+      if (!batch.isEmpty()) {
+        try (var lastBatch = createBatchInsertPreparedStatement(batch.size())) {
+          flush(lastBatch);
+        } catch (SQLException throwables) {
+          throw new IllegalStateException("Error flushing batch", throwables);
         }
+      }
+      try {
         batchStatement.close();
       } catch (SQLException throwables) {
         LOGGER.warn("Error closing prepared statement", throwables);
       }
+    }
+
+  }
+
+
+  private class BatchedTileTableWriter extends BatchedTableWriterBase<TileEntry> {
+
+    private static final List<String> COLUMNS = List.of(TILES_COL_Z, TILES_COL_X, TILES_COL_Y, TILES_COL_DATA);
+
+    BatchedTileTableWriter() {
+      super(TILES_TABLE, COLUMNS, false);
+    }
+
+    @Override
+    protected int setParamsInStatementForItem(int positionOffset, PreparedStatement statement, TileEntry tile)
+      throws SQLException {
+
+      TileCoord coord = tile.tile();
+      int x = coord.x();
+      int y = coord.y();
+      int z = coord.z();
+      statement.setInt(positionOffset++, z);
+      statement.setInt(positionOffset++, x);
+      // flip Y
+      statement.setInt(positionOffset++, (1 << z) - 1 - y);
+      statement.setBytes(positionOffset++, tile.bytes());
+      return positionOffset;
+    }
+  }
+
+  private class BatchedTileShallowTableWriter extends BatchedTableWriterBase<TileShallowEntry> {
+
+    private static final List<String> COLUMNS =
+      List.of(TILES_SHALLOW_COL_Z, TILES_SHALLOW_COL_X, TILES_SHALLOW_COL_Y, TILES_SHALLOW_COL_DATA_ID);
+
+    BatchedTileShallowTableWriter() {
+      super(TILES_SHALLOW_TABLE, COLUMNS, false);
+    }
+
+    @Override
+    protected int setParamsInStatementForItem(int positionOffset, PreparedStatement statement, TileShallowEntry item)
+      throws SQLException {
+
+      TileCoord coord = item.coord();
+      int x = coord.x();
+      int y = coord.y();
+      int z = coord.z();
+      statement.setInt(positionOffset++, z);
+      statement.setInt(positionOffset++, x);
+      // flip Y
+      statement.setInt(positionOffset++, (1 << z) - 1 - y);
+      statement.setLong(positionOffset++, item.tileDataId());
+
+      return positionOffset;
+    }
+  }
+
+  private class BatchedTileDataTableWriter extends BatchedTableWriterBase<TileDataEntry> {
+
+    private static final List<String> COLUMNS = List.of(TILES_DATA_COL_DATA_ID, TILES_DATA_COL_DATA);
+
+    BatchedTileDataTableWriter() {
+      super(TILES_DATA_TABLE, COLUMNS, true);
+    }
+
+    @Override
+    protected int setParamsInStatementForItem(int positionOffset, PreparedStatement statement, TileDataEntry item)
+      throws SQLException {
+
+      statement.setLong(positionOffset++, item.tileDataId());
+      statement.setBytes(positionOffset++, item.tileData());
+
+      return positionOffset;
+    }
+  }
+
+
+  /**
+   * A high-throughput writer that accepts new tiles and queues up the writes to execute them in fewer large-batches.
+   */
+  public interface BatchedTileWriter extends AutoCloseable {
+    void write(TileCoord coord, byte[] tileData, long tileDataId);
+
+    @Override
+    void close();
+  }
+
+  private class BatchedNonCompactTileWriter implements BatchedTileWriter {
+
+    private final BatchedTileTableWriter tableWriter = new BatchedTileTableWriter();
+
+    @Override
+    public void write(TileCoord coord, byte[] tileData, long tileDataId) {
+      tableWriter.write(new TileEntry(coord, tileData));
+    }
+
+    @Override
+    public void close() {
+      tableWriter.close();
+    }
+
+  }
+
+  private class BatchedCompactTileWriter implements BatchedTileWriter {
+
+    private final BatchedTileShallowTableWriter batchedTileShallowTableWriter = new BatchedTileShallowTableWriter();
+    private final BatchedTileDataTableWriter batchedTileDataTableWriter = new BatchedTileDataTableWriter();
+
+    @Override
+    public void write(TileCoord coord, byte[] tileData, long tileDataId) {
+      if (tileData != null) {
+        batchedTileDataTableWriter.write(new TileDataEntry(tileDataId, tileData));
+      }
+      batchedTileShallowTableWriter.write(new TileShallowEntry(coord, tileDataId));
+    }
+
+    @Override
+    public void close() {
+      batchedTileShallowTableWriter.close();
+      batchedTileDataTableWriter.close();
     }
   }
 
@@ -450,7 +685,7 @@ public final class Mbtiles implements Closeable {
 
     public Metadata setMetadata(String name, Object value) {
       if (value != null) {
-        LOGGER.debug("Set mbtiles metadata: " + name + "=" + value);
+        LOGGER.debug("Set mbtiles metadata: {}={}", name, value);
         try (
           PreparedStatement statement = connection.prepareStatement(
             "INSERT INTO " + METADATA_TABLE + " (" + METADATA_COL_NAME + "," + METADATA_COL_VALUE + ") VALUES(?, ?);")
@@ -550,7 +785,7 @@ public final class Mbtiles implements Closeable {
           );
         }
       } catch (SQLException throwables) {
-        LOGGER.warn("Error retrieving metadata: " + throwables);
+        LOGGER.warn("Error retrieving metadata: ", throwables);
         LOGGER.trace("Error retrieving metadata details: ", throwables);
       }
       return result;

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/mbtiles/MbtilesWriter.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/mbtiles/MbtilesWriter.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalInt;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -243,13 +244,11 @@ public class MbtilesWriter {
         FeatureGroup.TileFeatures tileFeatures = batch.in.get(i);
         featuresProcessed.incBy(tileFeatures.getNumFeaturesProcessed());
         byte[] bytes, encoded;
-        boolean memoized;
         Integer tileDataHash;
         if (tileFeatures.hasSameContents(last)) {
           bytes = lastBytes;
           encoded = lastEncoded;
           tileDataHash = lastTileDataHash;
-          memoized = true;
           memoizedTiles.inc();
         } else {
           VectorTile en = tileFeatures.getVectorTileEncoder();
@@ -269,14 +268,14 @@ public class MbtilesWriter {
             tileDataHash = null;
           }
           lastTileDataHash = tileDataHash;
-          memoized = false;
         }
         int zoom = tileFeatures.tileCoord().z();
         int encodedLength = encoded == null ? 0 : encoded.length;
         totalTileSizesByZoom[zoom].incBy(encodedLength);
         maxTileSizesByZoom[zoom].accumulate(encodedLength);
         result.add(
-          new TileEncodingResult(tileFeatures.tileCoord(), bytes, memoized, tileDataHash)
+          new TileEncodingResult(tileFeatures.tileCoord(), bytes,
+            tileDataHash == null ? OptionalInt.empty() : OptionalInt.of(tileDataHash))
         );
       }
       // hand result off to writer

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/mbtiles/TileEncodingResult.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/mbtiles/TileEncodingResult.java
@@ -3,14 +3,13 @@ package com.onthegomap.planetiler.mbtiles;
 import com.onthegomap.planetiler.geo.TileCoord;
 import java.util.Arrays;
 import java.util.Objects;
-import javax.annotation.Nullable;
+import java.util.OptionalInt;
 
 public record TileEncodingResult(
   TileCoord coord,
   byte[] tileData,
-  boolean memoized,
-  /** will always be null in non-compact mode and might also be null in compact mode */
-  @Nullable Integer tileDataHash
+  /** will always be empty in non-compact mode and might also be empty in compact mode */
+  OptionalInt tileDataHash
 ) {
 
   @Override
@@ -18,7 +17,7 @@ public record TileEncodingResult(
     final int prime = 31;
     int result = 1;
     result = prime * result + Arrays.hashCode(tileData);
-    result = prime * result + Objects.hash(coord, memoized, tileDataHash);
+    result = prime * result + Objects.hash(coord, tileDataHash);
     return result;
   }
 
@@ -31,14 +30,14 @@ public record TileEncodingResult(
       return false;
     }
     TileEncodingResult other = (TileEncodingResult) obj;
-    return Objects.equals(coord, other.coord) && memoized == other.memoized &&
-      Arrays.equals(tileData, other.tileData) && Objects.equals(tileDataHash, other.tileDataHash);
+    return Objects.equals(coord, other.coord) && Arrays.equals(tileData, other.tileData) &&
+      Objects.equals(tileDataHash, other.tileDataHash);
   }
 
   @Override
   public String toString() {
-    return "TileEncodingResult [coord=" + coord + ", tileData=" + Arrays.toString(tileData) + ", memoized=" + memoized +
-      ", tileDataHash=" + tileDataHash + "]";
+    return "TileEncodingResult [coord=" + coord + ", tileData=" + Arrays.toString(tileData) + ", tileDataHash=" +
+      tileDataHash + "]";
   }
 
 }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/mbtiles/TileEncodingResult.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/mbtiles/TileEncodingResult.java
@@ -1,0 +1,44 @@
+package com.onthegomap.planetiler.mbtiles;
+
+import com.onthegomap.planetiler.geo.TileCoord;
+import java.util.Arrays;
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+public record TileEncodingResult(
+  TileCoord coord,
+  byte[] tileData,
+  boolean memoized,
+  /** will always be null in non-compact mode and might also be null in compact mode */
+  @Nullable Integer tileDataHash
+) {
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + Arrays.hashCode(tileData);
+    result = prime * result + Objects.hash(coord, memoized, tileDataHash);
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof TileEncodingResult)) {
+      return false;
+    }
+    TileEncodingResult other = (TileEncodingResult) obj;
+    return Objects.equals(coord, other.coord) && memoized == other.memoized &&
+      Arrays.equals(tileData, other.tileData) && Objects.equals(tileDataHash, other.tileDataHash);
+  }
+
+  @Override
+  public String toString() {
+    return "TileEncodingResult [coord=" + coord + ", tileData=" + Arrays.toString(tileData) + ", memoized=" + memoized +
+      ", tileDataHash=" + tileDataHash + "]";
+  }
+
+}

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/util/Hashing.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/util/Hashing.java
@@ -1,13 +1,30 @@
 package com.onthegomap.planetiler.util;
 
+/**
+ * Static hash functions and hashing utilities.
+ *
+ */
 public final class Hashing {
 
+  /**
+   * Initial hash for the FNV-1 and FNV-1a 32-bit hash function.
+   */
   public static final int FNV1_32_INIT = 0x811c9dc5;
   private static final int FNV1_PRIME_32 = 16777619;
 
   private Hashing() {}
 
-  public static int fnv32(int initHash, byte... data) {
+  /**
+   * Computes the hash using the FNV-1a 32-bit hash function, starting with the initial hash.
+   * <p>
+   * The hash generation must always start with {@link #FNV1_32_INIT} as initial hash but this version comes in handy
+   * when generating the hash for multiple bytes consecutively in a loop.
+   * 
+   * @param initHash the initial hash
+   * @param data     the data to generate the hash for
+   * @return the generated hash
+   */
+  public static int fnv1a32(int initHash, byte... data) {
     int hash = initHash;
     for (byte datum : data) {
       hash ^= (datum & 0xff);
@@ -16,8 +33,14 @@ public final class Hashing {
     return hash;
   }
 
-  public static int fnv32(byte... data) {
-    return fnv32(FNV1_32_INIT, data);
+  /**
+   * Computes the hash using the FNV-1a 32-bit hash function.
+   * 
+   * @param data the data to generate the hash for
+   * @return the hash
+   */
+  public static int fnv1a32(byte... data) {
+    return fnv1a32(FNV1_32_INIT, data);
   }
 
 }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/util/Hashing.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/util/Hashing.java
@@ -1,0 +1,19 @@
+package com.onthegomap.planetiler.util;
+
+public final class Hashing {
+
+  private static final int FNV1_32_INIT = 0x811c9dc5;
+  private static final int FNV1_PRIME_32 = 16777619;
+
+  private Hashing() {}
+
+  public static int fnv32(byte[] data) {
+    int hash = FNV1_32_INIT;
+    for (byte datum : data) {
+      hash ^= (datum & 0xff);
+      hash *= FNV1_PRIME_32;
+    }
+    return hash;
+  }
+
+}

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/util/Hashing.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/util/Hashing.java
@@ -2,18 +2,22 @@ package com.onthegomap.planetiler.util;
 
 public final class Hashing {
 
-  private static final int FNV1_32_INIT = 0x811c9dc5;
+  public static final int FNV1_32_INIT = 0x811c9dc5;
   private static final int FNV1_PRIME_32 = 16777619;
 
   private Hashing() {}
 
-  public static int fnv32(byte[] data) {
-    int hash = FNV1_32_INIT;
+  public static int fnv32(int initHash, byte... data) {
+    int hash = initHash;
     for (byte datum : data) {
       hash ^= (datum & 0xff);
       hash *= FNV1_PRIME_32;
     }
     return hash;
+  }
+
+  public static int fnv32(byte... data) {
+    return fnv32(FNV1_32_INIT, data);
   }
 
 }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
@@ -71,7 +71,7 @@ class PlanetilerTests {
   private static final double Z13_WIDTH = 1d / Z13_TILES;
   private static final int Z12_TILES = 1 << 12;
   private static final int Z4_TILES = 1 << 4;
-  private static final Polygon worldPolygon = newPolygon(
+  private static final Polygon WORLD_POLYGON = newPolygon(
     worldCoordinateList(
       Z14_WIDTH / 2, Z14_WIDTH / 2,
       1 - Z14_WIDTH / 2, Z14_WIDTH / 2,
@@ -660,7 +660,7 @@ class PlanetilerTests {
     var results = runWithReaderFeatures(
       Map.of("threads", "1"),
       List.of(
-        newReaderFeature(worldPolygon, Map.of())
+        newReaderFeature(WORLD_POLYGON, Map.of())
       ),
       (in, features) -> features.polygon("layer")
         .setZoomRange(0, 6)
@@ -1705,7 +1705,7 @@ class PlanetilerTests {
     return runWithReaderFeatures(
       Map.of("threads", "1", "compact-db", Boolean.toString(compactDbEnabled)),
       List.of(
-        newReaderFeature(worldPolygon, Map.of())
+        newReaderFeature(WORLD_POLYGON, Map.of())
       ),
       (in, features) -> features.polygon("layer")
         .setZoomRange(0, 2)

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
@@ -3,6 +3,7 @@ package com.onthegomap.planetiler;
 import static com.onthegomap.planetiler.TestUtils.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.onthegomap.planetiler.TestUtils.OsmXml;
 import com.onthegomap.planetiler.collection.FeatureGroup;
 import com.onthegomap.planetiler.collection.LongLongMap;
 import com.onthegomap.planetiler.collection.LongLongMultimap;
@@ -47,6 +48,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.MultiPolygon;
+import org.locationtech.jts.geom.Polygon;
 import org.locationtech.jts.io.InputStreamInStream;
 import org.locationtech.jts.io.WKBReader;
 import org.slf4j.Logger;
@@ -69,7 +71,18 @@ class PlanetilerTests {
   private static final double Z13_WIDTH = 1d / Z13_TILES;
   private static final int Z12_TILES = 1 << 12;
   private static final int Z4_TILES = 1 << 4;
+  private static final Polygon worldPolygon = newPolygon(
+    worldCoordinateList(
+      Z14_WIDTH / 2, Z14_WIDTH / 2,
+      1 - Z14_WIDTH / 2, Z14_WIDTH / 2,
+      1 - Z14_WIDTH / 2, 1 - Z14_WIDTH / 2,
+      Z14_WIDTH / 2, 1 - Z14_WIDTH / 2,
+      Z14_WIDTH / 2, Z14_WIDTH / 2
+    ),
+    List.of()
+  );
   private final Stats stats = Stats.inMemory();
+
 
   private static <T extends OsmElement> T with(T elem, Consumer<T> fn) {
     fn.accept(elem);
@@ -121,12 +134,13 @@ class PlanetilerTests {
     FeatureGroup featureGroup = FeatureGroup.newInMemoryFeatureGroup(profile, stats);
     runner.run(featureGroup, profile, config);
     featureGroup.prepare();
-    try (Mbtiles db = Mbtiles.newInMemoryDatabase()) {
+    try (Mbtiles db = Mbtiles.newInMemoryDatabase(config.compactDb())) {
       MbtilesWriter.writeOutput(featureGroup, db, () -> 0L, new MbtilesMetadata(profile, config.arguments()), config,
         stats);
       var tileMap = TestUtils.getTileMap(db);
       tileMap.values().forEach(fs -> fs.forEach(f -> f.geometry().validate()));
-      return new PlanetilerResults(tileMap, db.metadata().getAll());
+      int tileDataCount = config.compactDb() ? TestUtils.getTilesDataCount(db) : 0;
+      return new PlanetilerResults(tileMap, db.metadata().getAll(), tileDataCount);
     }
   }
 
@@ -643,21 +657,10 @@ class PlanetilerTests {
 
   @Test
   void testFullWorldPolygon() throws Exception {
-    List<Coordinate> outerPoints = worldCoordinateList(
-      Z14_WIDTH / 2, Z14_WIDTH / 2,
-      1 - Z14_WIDTH / 2, Z14_WIDTH / 2,
-      1 - Z14_WIDTH / 2, 1 - Z14_WIDTH / 2,
-      Z14_WIDTH / 2, 1 - Z14_WIDTH / 2,
-      Z14_WIDTH / 2, Z14_WIDTH / 2
-    );
-
     var results = runWithReaderFeatures(
       Map.of("threads", "1"),
       List.of(
-        newReaderFeature(newPolygon(
-          outerPoints,
-          List.of()
-        ), Map.of())
+        newReaderFeature(worldPolygon, Map.of())
       ),
       (in, features) -> features.polygon("layer")
         .setZoomRange(0, 6)
@@ -1470,7 +1473,7 @@ class PlanetilerTests {
   }
 
   private record PlanetilerResults(
-    Map<TileCoord, List<TestUtils.ComparableFeature>> tiles, Map<String, String> metadata
+    Map<TileCoord, List<TestUtils.ComparableFeature>> tiles, Map<String, String> metadata, int tileDataCount
   ) {}
 
   private record TestProfile(
@@ -1694,5 +1697,34 @@ class PlanetilerTests {
     );
 
     assertSubmap(Map.of(), results.tiles);
+  }
+
+
+  private PlanetilerResults runForCompactTest(boolean compactDbEnabled) throws Exception {
+
+    return runWithReaderFeatures(
+      Map.of("threads", "1", "compact-db", Boolean.toString(compactDbEnabled)),
+      List.of(
+        newReaderFeature(worldPolygon, Map.of())
+      ),
+      (in, features) -> features.polygon("layer")
+        .setZoomRange(0, 2)
+        .setBufferPixels(0)
+    );
+  }
+
+  @Test
+  void testCompactDb() throws Exception {
+
+    var compactResult = runForCompactTest(true);
+    var nonCompactResult = runForCompactTest(false);
+
+    assertEquals(nonCompactResult.tiles, compactResult.tiles);
+    assertTrue(
+      compactResult.tileDataCount() < compactResult.tiles.size(),
+      "tileDataCount=%s should be less than tileCount=%s".formatted(
+        compactResult.tileDataCount(), compactResult.tiles.size()
+      )
+    );
   }
 }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/TestUtils.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/TestUtils.java
@@ -230,6 +230,23 @@ public class TestUtils {
     return result;
   }
 
+  public static int getTilesDataCount(Mbtiles db) throws SQLException {
+    String tableToCountFrom = isCompactDb(db) ? "tiles_data" : "tiles";
+    try (Statement statement = db.connection().createStatement()) {
+      ResultSet rs = statement.executeQuery("select count(*) from %s".formatted(tableToCountFrom));
+      rs.next();
+      return rs.getInt(1);
+    }
+  }
+
+  public static boolean isCompactDb(Mbtiles db) throws SQLException {
+    try (Statement statement = db.connection().createStatement()) {
+      ResultSet rs = statement.executeQuery("select count(*) from sqlite_master where type='view' and name='tiles'");
+      rs.next();
+      return rs.getInt(1) > 0;
+    }
+  }
+
   public static <K extends Comparable<? super K>> void assertSubmap(Map<K, ?> expectedSubmap, Map<K, ?> actual) {
     assertSubmap(expectedSubmap, actual, "");
   }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/collection/FeatureGroupTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/collection/FeatureGroupTest.java
@@ -15,8 +15,6 @@ import com.onthegomap.planetiler.geo.TileCoord;
 import com.onthegomap.planetiler.render.RenderedFeature;
 import com.onthegomap.planetiler.stats.Stats;
 import com.onthegomap.planetiler.util.CloseableConusmer;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -292,7 +290,7 @@ class FeatureGroupTest {
   }
 
   @Test
-  void testHasSameContentHash() {
+  void testHasSameBytesRelevantForHashing() {
     // should be the "same" even though sort-key is different
     putWithIdGroupAndSortKey(
       1, 1, "layer", Map.of("id", 1), newPoint(1, 2), 1, true, 2, 3
@@ -303,13 +301,13 @@ class FeatureGroupTest {
     sorter.sort();
     var iter = features.iterator();
     assertArrayEquals(
-      iter.next().generateContentHash(getMessageDigest()),
-      iter.next().generateContentHash(getMessageDigest())
+      iter.next().getBytesRelevantForHashing(),
+      iter.next().getBytesRelevantForHashing()
     );
   }
 
   @Test
-  void testDoesNotHaveSameContentHashWhenGeometryChanges() {
+  void testDoesNotHaveSameRelevantBytesForHashingWhenGeometryChanges() {
     putWithIdGroupAndSortKey(
       1, 1, "layer", Map.of("id", 1), newPoint(1, 2), 1, true, 2, 3
     );
@@ -319,13 +317,13 @@ class FeatureGroupTest {
     sorter.sort();
     var iter = features.iterator();
     assertArrayNotEquals(
-      iter.next().generateContentHash(getMessageDigest()),
-      iter.next().generateContentHash(getMessageDigest())
+      iter.next().getBytesRelevantForHashing(),
+      iter.next().getBytesRelevantForHashing()
     );
   }
 
   @Test
-  void testDoesNotHaveSameContentHashWhenAttrsChange() {
+  void testDoesNotHaveSameRelevantBytesForHashingWhenAttrsChange() {
     putWithIdGroupAndSortKey(
       1, 1, "layer", Map.of("id", 1), newPoint(1, 2), 1, true, 2, 3
     );
@@ -335,13 +333,13 @@ class FeatureGroupTest {
     sorter.sort();
     var iter = features.iterator();
     assertArrayNotEquals(
-      iter.next().generateContentHash(getMessageDigest()),
-      iter.next().generateContentHash(getMessageDigest())
+      iter.next().getBytesRelevantForHashing(),
+      iter.next().getBytesRelevantForHashing()
     );
   }
 
   @Test
-  void testDoesNotHaveSameContentHashWhenLayerChanges() {
+  void testDoesNotHaveSameRelevantBytesForHashingWhenLayerChanges() {
     putWithIdGroupAndSortKey(
       1, 1, "layer", Map.of("id", 1), newPoint(1, 2), 1, true, 2, 3
     );
@@ -351,13 +349,13 @@ class FeatureGroupTest {
     sorter.sort();
     var iter = features.iterator();
     assertArrayNotEquals(
-      iter.next().generateContentHash(getMessageDigest()),
-      iter.next().generateContentHash(getMessageDigest())
+      iter.next().getBytesRelevantForHashing(),
+      iter.next().getBytesRelevantForHashing()
     );
   }
 
   @Test
-  void testDoesNotHaveSameContentHashWhenIdChanges() {
+  void testDoesNotHaveSameRelevantBytesForHashingWhenIdChanges() {
     putWithIdGroupAndSortKey(
       1, 1, "layer", Map.of("id", 1), newPoint(1, 2), 1, true, 2, 3
     );
@@ -367,8 +365,8 @@ class FeatureGroupTest {
     sorter.sort();
     var iter = features.iterator();
     assertArrayNotEquals(
-      iter.next().generateContentHash(getMessageDigest()),
-      iter.next().generateContentHash(getMessageDigest())
+      iter.next().getBytesRelevantForHashing(),
+      iter.next().getBytesRelevantForHashing()
     );
   }
 
@@ -384,14 +382,6 @@ class FeatureGroupTest {
     byte encoded = FeatureGroup.encodeGeomTypeAndScale(new VectorTile.VectorGeometry(new int[0], geomType, scale));
     assertEquals(geomType, FeatureGroup.decodeGeomType(encoded));
     assertEquals(scale, FeatureGroup.decodeScale(encoded));
-  }
-
-  private MessageDigest getMessageDigest() {
-    try {
-      return MessageDigest.getInstance("SHA-1");
-    } catch (NoSuchAlgorithmException e) {
-      throw new IllegalStateException("SHA-1 message digest not available", e);
-    }
   }
 
   private static void assertArrayNotEquals(byte[] expected, byte[] actual) {

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/collection/FeatureGroupTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/collection/FeatureGroupTest.java
@@ -2,9 +2,9 @@ package com.onthegomap.planetiler.collection;
 
 import static com.onthegomap.planetiler.TestUtils.decodeSilently;
 import static com.onthegomap.planetiler.TestUtils.newPoint;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.DynamicTest.dynamicTest;
 
@@ -16,16 +16,20 @@ import com.onthegomap.planetiler.render.RenderedFeature;
 import com.onthegomap.planetiler.stats.Stats;
 import com.onthegomap.planetiler.util.CloseableConusmer;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.locationtech.jts.geom.Geometry;
 
@@ -70,6 +74,11 @@ class FeatureGroupTest {
       hasGroup ? Optional.of(new RenderedFeature.Group(group, limit)) : Optional.empty()
     );
     featureWriter.accept(features.newRenderedFeatureEncoder().apply(feature));
+  }
+
+  private void put(PuTileArgs args) {
+    putWithIdGroupAndSortKey(args.id(), args.tile(), args.layer(), args.attrs(), args.geom(), args.sortKey(),
+      args.hasGroup(), args.group(), args.limit());
   }
 
   private Map<Integer, Map<String, List<Feature>>> getFeatures() {
@@ -289,85 +298,32 @@ class FeatureGroupTest {
     );
   }
 
-  @Test
-  void testHasSameBytesRelevantForHashing() {
-    // should be the "same" even though sort-key is different
-    putWithIdGroupAndSortKey(
-      1, 1, "layer", Map.of("id", 1), newPoint(1, 2), 1, true, 2, 3
-    );
-    putWithIdGroupAndSortKey(
-      1, 2, "layer", Map.of("id", 1), newPoint(1, 2), 2, true, 2, 3
-    );
+  @ParameterizedTest(name = "{0}")
+  @ArgumentsSource(SameFeatureGroupTestArgs.class)
+  void testHasSameContents(String testName, boolean expectSame, PuTileArgs args0, PuTileArgs args1) {
+    put(args0);
+    put(args1);
     sorter.sort();
     var iter = features.iterator();
-    assertArrayEquals(
-      iter.next().getBytesRelevantForHashing(),
-      iter.next().getBytesRelevantForHashing()
-    );
+    var tile0 = iter.next();
+    var tile1 = iter.next();
+    assertEquals(expectSame, tile0.hasSameContents(tile1));
   }
 
-  @Test
-  void testDoesNotHaveSameRelevantBytesForHashingWhenGeometryChanges() {
-    putWithIdGroupAndSortKey(
-      1, 1, "layer", Map.of("id", 1), newPoint(1, 2), 1, true, 2, 3
-    );
-    putWithIdGroupAndSortKey(
-      1, 2, "layer", Map.of("id", 1), newPoint(1, 3), 1, true, 2, 3
-    );
+  @ParameterizedTest(name = "{0}")
+  @ArgumentsSource(SameFeatureGroupTestArgs.class)
+  void testGenerateContentHash(String testName, boolean expectSame, PuTileArgs args0, PuTileArgs args1) {
+    put(args0);
+    put(args1);
     sorter.sort();
     var iter = features.iterator();
-    assertArrayNotEquals(
-      iter.next().getBytesRelevantForHashing(),
-      iter.next().getBytesRelevantForHashing()
-    );
-  }
-
-  @Test
-  void testDoesNotHaveSameRelevantBytesForHashingWhenAttrsChange() {
-    putWithIdGroupAndSortKey(
-      1, 1, "layer", Map.of("id", 1), newPoint(1, 2), 1, true, 2, 3
-    );
-    putWithIdGroupAndSortKey(
-      1, 2, "layer", Map.of("id", 2), newPoint(1, 2), 1, true, 2, 3
-    );
-    sorter.sort();
-    var iter = features.iterator();
-    assertArrayNotEquals(
-      iter.next().getBytesRelevantForHashing(),
-      iter.next().getBytesRelevantForHashing()
-    );
-  }
-
-  @Test
-  void testDoesNotHaveSameRelevantBytesForHashingWhenLayerChanges() {
-    putWithIdGroupAndSortKey(
-      1, 1, "layer", Map.of("id", 1), newPoint(1, 2), 1, true, 2, 3
-    );
-    putWithIdGroupAndSortKey(
-      1, 2, "layer2", Map.of("id", 1), newPoint(1, 2), 1, true, 2, 3
-    );
-    sorter.sort();
-    var iter = features.iterator();
-    assertArrayNotEquals(
-      iter.next().getBytesRelevantForHashing(),
-      iter.next().getBytesRelevantForHashing()
-    );
-  }
-
-  @Test
-  void testDoesNotHaveSameRelevantBytesForHashingWhenIdChanges() {
-    putWithIdGroupAndSortKey(
-      1, 1, "layer", Map.of("id", 1), newPoint(1, 2), 1, true, 2, 3
-    );
-    putWithIdGroupAndSortKey(
-      2, 2, "layer", Map.of("id", 1), newPoint(1, 2), 1, true, 2, 3
-    );
-    sorter.sort();
-    var iter = features.iterator();
-    assertArrayNotEquals(
-      iter.next().getBytesRelevantForHashing(),
-      iter.next().getBytesRelevantForHashing()
-    );
+    var tile0 = iter.next();
+    var tile1 = iter.next();
+    if (expectSame) {
+      assertEquals(tile0.generateContentHash(), tile1.generateContentHash());
+    } else {
+      assertNotEquals(tile0.generateContentHash(), tile1.generateContentHash());
+    }
   }
 
   @ParameterizedTest
@@ -384,7 +340,45 @@ class FeatureGroupTest {
     assertEquals(scale, FeatureGroup.decodeScale(encoded));
   }
 
-  private static void assertArrayNotEquals(byte[] expected, byte[] actual) {
-    assertFalse(Arrays.equals(expected, actual));
+  private static class SameFeatureGroupTestArgs implements ArgumentsProvider {
+
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+      return Stream.of(
+        argsOf(
+          "same despite diff sort key", true,
+          new PuTileArgs(1, 1, "layer", Map.of("id", 1), newPoint(1, 2), 1, true, 2, 3),
+          new PuTileArgs(1, 2, "layer", Map.of("id", 1), newPoint(1, 2), 2, true, 2, 3)
+        ),
+        argsOf(
+          "diff when geometry changes", false,
+          new PuTileArgs(1, 1, "layer", Map.of("id", 1), newPoint(1, 2), 1, true, 2, 3),
+          new PuTileArgs(1, 2, "layer", Map.of("id", 1), newPoint(1, 3), 1, true, 2, 3)
+        ),
+        argsOf(
+          "diff when attrs changes", false,
+          new PuTileArgs(1, 1, "layer", Map.of("id", 1), newPoint(1, 2), 1, true, 2, 3),
+          new PuTileArgs(1, 2, "layer", Map.of("id", 2), newPoint(1, 2), 1, true, 2, 3)
+        ),
+        argsOf(
+          "diff when layer changes", false,
+          new PuTileArgs(1, 1, "layer", Map.of("id", 1), newPoint(1, 2), 1, true, 2, 3),
+          new PuTileArgs(1, 2, "layer2", Map.of("id", 1), newPoint(1, 2), 1, true, 2, 3)
+        ),
+        argsOf(
+          "diff when id changes", false,
+          new PuTileArgs(1, 1, "layer", Map.of("id", 1), newPoint(1, 2), 1, true, 2, 3),
+          new PuTileArgs(2, 2, "layer", Map.of("id", 1), newPoint(1, 2), 1, true, 2, 3)
+        )
+      );
+    }
+
+    private static Arguments argsOf(String testName, boolean expectSame, PuTileArgs args0,
+      PuTileArgs args1) {
+      return Arguments.of(testName, expectSame, args0, args1);
+    }
   }
+
+  private static record PuTileArgs(long id, int tile, String layer, Map<String, Object> attrs, Geometry geom,
+    int sortKey, boolean hasGroup, long group, int limit) {}
 }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/mbtiles/MbtilesTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/mbtiles/MbtilesTest.java
@@ -44,15 +44,15 @@ class MbtilesTest {
       Set<Mbtiles.TileEntry> expected = new TreeSet<>();
       try (var writer = db.newBatchedTileWriter()) {
         for (int i = 0; i < howMany; i++) {
-          var dataId = i - (i % 2);
-          var dataBase = howMany + dataId;
+          var dataHash = i - (i % 2);
+          var dataBase = howMany + dataHash;
           var entry = new Mbtiles.TileEntry(TileCoord.ofXYZ(i, i + 1, 14), new byte[]{
             (byte) dataBase,
             (byte) (dataBase >> 8),
             (byte) (dataBase >> 16),
             (byte) (dataBase >> 24)
           });
-          writer.write(entry.tile(), entry.bytes(), dataId);
+          writer.write(new TileEncodingResult(entry.tile(), entry.bytes(), true, dataHash));
           expected.add(entry);
         }
       }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/mbtiles/MbtilesTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/mbtiles/MbtilesTest.java
@@ -14,6 +14,7 @@ import java.math.RoundingMode;
 import java.sql.SQLException;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -52,7 +53,7 @@ class MbtilesTest {
             (byte) (dataBase >> 16),
             (byte) (dataBase >> 24)
           });
-          writer.write(new TileEncodingResult(entry.tile(), entry.bytes(), true, dataHash));
+          writer.write(new TileEncodingResult(entry.tile(), entry.bytes(), OptionalInt.of(dataHash)));
           expected.add(entry);
         }
       }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/mbtiles/MbtilesTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/mbtiles/MbtilesTest.java
@@ -5,10 +5,12 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import com.google.common.math.IntMath;
 import com.onthegomap.planetiler.TestUtils;
 import com.onthegomap.planetiler.geo.GeoUtils;
 import com.onthegomap.planetiler.geo.TileCoord;
 import java.io.IOException;
+import java.math.RoundingMode;
 import java.sql.SQLException;
 import java.util.HashSet;
 import java.util.Map;
@@ -23,11 +25,17 @@ import org.locationtech.jts.geom.Envelope;
 
 class MbtilesTest {
 
-  private static final int BATCH = 999 / 4;
+  private static final int MAX_PARAMETERS_IN_PREPARED_STATEMENT = 999;
+  private static final int TILES_BATCH = MAX_PARAMETERS_IN_PREPARED_STATEMENT / 4;
+  private static final int TILES_SHALLOW_BATCH = MAX_PARAMETERS_IN_PREPARED_STATEMENT / 4;
+  private static final int TILES_DATA_BATCH = MAX_PARAMETERS_IN_PREPARED_STATEMENT / 2;
 
-  void testWriteTiles(int howMany, boolean deferIndexCreation, boolean optimize)
-    throws IOException, SQLException {
-    try (Mbtiles db = Mbtiles.newInMemoryDatabase()) {
+
+  private static final
+
+    void testWriteTiles(int howMany, boolean deferIndexCreation, boolean optimize, boolean compactDb)
+      throws IOException, SQLException {
+    try (Mbtiles db = Mbtiles.newInMemoryDatabase(compactDb)) {
       db.createTables();
       if (!deferIndexCreation) {
         db.addTileIndex();
@@ -36,13 +44,15 @@ class MbtilesTest {
       Set<Mbtiles.TileEntry> expected = new TreeSet<>();
       try (var writer = db.newBatchedTileWriter()) {
         for (int i = 0; i < howMany; i++) {
+          var dataId = i - (i % 2);
+          var dataBase = howMany + dataId;
           var entry = new Mbtiles.TileEntry(TileCoord.ofXYZ(i, i + 1, 14), new byte[]{
-            (byte) howMany,
-            (byte) (howMany >> 8),
-            (byte) (howMany >> 16),
-            (byte) (howMany >> 24)
+            (byte) dataBase,
+            (byte) (dataBase >> 8),
+            (byte) (dataBase >> 16),
+            (byte) (dataBase >> 24)
           });
-          writer.write(entry.tile(), entry.bytes());
+          writer.write(entry.tile(), entry.bytes(), dataId);
           expected.add(entry);
         }
       }
@@ -62,23 +72,34 @@ class MbtilesTest {
         byte[] data = db.getTile(tile.x(), tile.y(), tile.z());
         assertArrayEquals(expectedEntry.bytes(), data);
       }
+      assertEquals(compactDb, TestUtils.isCompactDb(db));
+      if (compactDb) {
+        assertEquals(IntMath.divide(howMany, 2, RoundingMode.CEILING), TestUtils.getTilesDataCount(db));
+      }
     }
   }
 
   @ParameterizedTest
-  @ValueSource(ints = {0, 1, BATCH, BATCH + 1, 2 * BATCH, 2 * BATCH + 1})
-  void testWriteTilesDifferentSize(int howMany) throws IOException, SQLException {
-    testWriteTiles(howMany, false, false);
+  @ValueSource(ints = {0, 1, TILES_BATCH, TILES_BATCH + 1, 2 * TILES_BATCH, 2 * TILES_BATCH + 1})
+  void testWriteTilesDifferentSizeInNonCompactMode(int howMany) throws IOException, SQLException {
+    testWriteTiles(howMany, false, false, false);
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {0, 1, TILES_DATA_BATCH, TILES_DATA_BATCH + 1, 2 * TILES_DATA_BATCH, 2 * TILES_DATA_BATCH + 1,
+    TILES_SHALLOW_BATCH, TILES_SHALLOW_BATCH + 1, 2 * TILES_SHALLOW_BATCH, 2 * TILES_SHALLOW_BATCH + 1})
+  void testWriteTilesDifferentSizeInCompactMode(int howMany) throws IOException, SQLException {
+    testWriteTiles(howMany, false, false, true);
   }
 
   @Test
   void testDeferIndexCreation() throws IOException, SQLException {
-    testWriteTiles(10, true, false);
+    testWriteTiles(10, true, false, false);
   }
 
   @Test
   void testVacuumAnalyze() throws IOException, SQLException {
-    testWriteTiles(10, false, true);
+    testWriteTiles(10, false, true, false);
   }
 
   @Test

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/mbtiles/VerifyTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/mbtiles/VerifyTest.java
@@ -11,6 +11,7 @@ import com.onthegomap.planetiler.geo.TileCoord;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalInt;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -52,7 +53,7 @@ class VerifyTest {
         VectorTile.encodeGeometry(point(0, 0)),
         Map.of()
       )));
-      writer.write(new TileEncodingResult(TileCoord.ofXYZ(0, 0, 0), gzip(tile.encode()), false, null));
+      writer.write(new TileEncodingResult(TileCoord.ofXYZ(0, 0, 0), gzip(tile.encode()), OptionalInt.empty()));
     }
     assertValid(mbtiles);
   }
@@ -76,7 +77,7 @@ class VerifyTest {
         )),
         Map.of()
       )));
-      writer.write(new TileEncodingResult(TileCoord.ofXYZ(0, 0, 0), gzip(tile.encode()), false, null));
+      writer.write(new TileEncodingResult(TileCoord.ofXYZ(0, 0, 0), gzip(tile.encode()), OptionalInt.empty()));
     }
     assertInvalid(mbtiles);
   }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/mbtiles/VerifyTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/mbtiles/VerifyTest.java
@@ -52,7 +52,7 @@ class VerifyTest {
         VectorTile.encodeGeometry(point(0, 0)),
         Map.of()
       )));
-      writer.write(TileCoord.ofXYZ(0, 0, 0), gzip(tile.encode()), 1);
+      writer.write(new TileEncodingResult(TileCoord.ofXYZ(0, 0, 0), gzip(tile.encode()), false, null));
     }
     assertValid(mbtiles);
   }
@@ -76,7 +76,7 @@ class VerifyTest {
         )),
         Map.of()
       )));
-      writer.write(TileCoord.ofXYZ(0, 0, 0), gzip(tile.encode()), 1);
+      writer.write(new TileEncodingResult(TileCoord.ofXYZ(0, 0, 0), gzip(tile.encode()), false, null));
     }
     assertInvalid(mbtiles);
   }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/mbtiles/VerifyTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/mbtiles/VerifyTest.java
@@ -52,7 +52,7 @@ class VerifyTest {
         VectorTile.encodeGeometry(point(0, 0)),
         Map.of()
       )));
-      writer.write(TileCoord.ofXYZ(0, 0, 0), gzip(tile.encode()));
+      writer.write(TileCoord.ofXYZ(0, 0, 0), gzip(tile.encode()), 1);
     }
     assertValid(mbtiles);
   }
@@ -76,7 +76,7 @@ class VerifyTest {
         )),
         Map.of()
       )));
-      writer.write(TileCoord.ofXYZ(0, 0, 0), gzip(tile.encode()));
+      writer.write(TileCoord.ofXYZ(0, 0, 0), gzip(tile.encode()), 1);
     }
     assertInvalid(mbtiles);
   }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/util/HashingTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/util/HashingTest.java
@@ -3,44 +3,20 @@ package com.onthegomap.planetiler.util;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-import java.util.stream.Stream;
-import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.ArgumentsProvider;
-import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.api.Test;
 
 class HashingTest {
 
-  @ParameterizedTest
-  @ArgumentsSource(TestArgs.class)
-  void testFnv32(boolean expectSame, byte[] data0, byte[] data1) {
-    var hash0 = Hashing.fnv32(data0);
-    var hash1 = Hashing.fnv32(data1);
-    if (expectSame) {
-      assertEquals(hash0, hash1);
-    } else {
-      assertNotEquals(hash0, hash1);
-    }
-  }
+  @Test
+  void testFnv32() {
+    assertEquals(Hashing.fnv32(), Hashing.fnv32());
+    assertEquals(Hashing.fnv32((byte) 1), Hashing.fnv32((byte) 1));
+    assertEquals(Hashing.fnv32((byte) 1, (byte) 2), Hashing.fnv32((byte) 1, (byte) 2));
+    assertNotEquals(Hashing.fnv32((byte) 1), Hashing.fnv32((byte) 2));
+    assertNotEquals(Hashing.fnv32((byte) 1), Hashing.fnv32((byte) 1, (byte) 1));
 
-  public static class TestArgs implements ArgumentsProvider {
-
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
-      return Stream.of(
-        argsOf(true, new byte[]{}, new byte[]{}),
-        argsOf(true, new byte[]{1}, new byte[]{1}),
-        argsOf(true, new byte[]{1, 2}, new byte[]{1, 2}),
-        argsOf(false, new byte[]{1}, new byte[]{2}),
-        argsOf(false, new byte[]{1}, new byte[]{1, 1})
-      );
-    }
-
-    private static Arguments argsOf(boolean expectSame, byte[] data0, byte[] data1) {
-      return Arguments.of(expectSame, data0, data1);
-    }
-
+    assertEquals(Hashing.FNV1_32_INIT, Hashing.fnv32());
+    assertEquals(123, Hashing.fnv32(123));
   }
 
 }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/util/HashingTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/util/HashingTest.java
@@ -8,15 +8,15 @@ import org.junit.jupiter.api.Test;
 class HashingTest {
 
   @Test
-  void testFnv32() {
-    assertEquals(Hashing.fnv32(), Hashing.fnv32());
-    assertEquals(Hashing.fnv32((byte) 1), Hashing.fnv32((byte) 1));
-    assertEquals(Hashing.fnv32((byte) 1, (byte) 2), Hashing.fnv32((byte) 1, (byte) 2));
-    assertNotEquals(Hashing.fnv32((byte) 1), Hashing.fnv32((byte) 2));
-    assertNotEquals(Hashing.fnv32((byte) 1), Hashing.fnv32((byte) 1, (byte) 1));
+  void testFnv1a32() {
+    assertEquals(Hashing.fnv1a32(), Hashing.fnv1a32());
+    assertEquals(Hashing.fnv1a32((byte) 1), Hashing.fnv1a32((byte) 1));
+    assertEquals(Hashing.fnv1a32((byte) 1, (byte) 2), Hashing.fnv1a32((byte) 1, (byte) 2));
+    assertNotEquals(Hashing.fnv1a32((byte) 1), Hashing.fnv1a32((byte) 2));
+    assertNotEquals(Hashing.fnv1a32((byte) 1), Hashing.fnv1a32((byte) 1, (byte) 1));
 
-    assertEquals(Hashing.FNV1_32_INIT, Hashing.fnv32());
-    assertEquals(123, Hashing.fnv32(123));
+    assertEquals(Hashing.FNV1_32_INIT, Hashing.fnv1a32());
+    assertEquals(123, Hashing.fnv1a32(123));
   }
 
 }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/util/HashingTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/util/HashingTest.java
@@ -1,0 +1,46 @@
+package com.onthegomap.planetiler.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+class HashingTest {
+
+  @ParameterizedTest
+  @ArgumentsSource(TestArgs.class)
+  void testFnv32(boolean expectSame, byte[] data0, byte[] data1) {
+    var hash0 = Hashing.fnv32(data0);
+    var hash1 = Hashing.fnv32(data1);
+    if (expectSame) {
+      assertEquals(hash0, hash1);
+    } else {
+      assertNotEquals(hash0, hash1);
+    }
+  }
+
+  public static class TestArgs implements ArgumentsProvider {
+
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+      return Stream.of(
+        argsOf(true, new byte[]{}, new byte[]{}),
+        argsOf(true, new byte[]{1}, new byte[]{1}),
+        argsOf(true, new byte[]{1, 2}, new byte[]{1, 2}),
+        argsOf(false, new byte[]{1}, new byte[]{2}),
+        argsOf(false, new byte[]{1}, new byte[]{1, 1})
+      );
+    }
+
+    private static Arguments argsOf(boolean expectSame, byte[] data0, byte[] data1) {
+      return Arguments.of(expectSame, data0, data1);
+    }
+
+  }
+
+}


### PR DESCRIPTION
# Context

this addresses point 2 of https://github.com/onthegomap/planetiler/issues/167#issuecomment-1115483329

# Overview

the compact DB mode splits the tiles table into tiles_shallow and tiles_data
- tiles_shallow contains the coordinates plus a reference on the data ID
- tiles_data contains the data ID plus the actual tile data

this allows to de-duplicate content since multiple tiles can reference the same data

in this mode, tiles is realized as a view that joins the two tables tiles_shallow and tiles_data

# Impact

- it can significantly de-crease the mbtiles file size iff there's many duplicates (ocean tiles) - in case of Australia: 3.1GB -> 1.7GB
- it has little to no impact on writing mbtiles (if no dupes it's slower, and the more dupes the faster but not significantly)
- reading from the mbtiles is 10-15% slower because of the indirection over the view


some more insights can be found here: [PR-impact.txt](https://github.com/onthegomap/planetiler/files/8655715/PR-impact.txt)

# Concept

The main idea to realize this is to create a hash over the tile data, and build a map between that hash and a data ID.

# Failed Approaches

I was a bit surprised that the impact on writing the mbtiles is little to none. The only explanation I have is that we have to do more inserts than before (tiles_shallow, tiles_data). I tried to offload this "dual insert" from code to the DB. So in planetiler I produced just one insert but the insert was into a view - which then either just inserted into tiles_shallow or both tiles_shallow and tiles_data. This, however, increased the overall mbtiles generation time by almost 20%.

# Next

I'd like to address point 1 in https://github.com/onthegomap/planetiler/issues/167#issuecomment-1115483329  either in this or a follow-up PR


