### PR TITLE
Enable `--mmap-temp` by default

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/config/PlanetilerConfig.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/config/PlanetilerConfig.java
@@ -103,7 +103,7 @@ public record PlanetilerConfig(
       arguments.getBoolean("emit_tiles_in_order", "emit tiles in index order", true),
       arguments.getBoolean("force", "overwriting output file and ignore disk/RAM warnings", false),
       arguments.getBoolean("gzip_temp", "gzip temporary feature storage (uses more CPU, but less disk space)", false),
-      arguments.getBoolean("mmap_temp", "use memory-mapped IO for temp feature files", false),
+      arguments.getBoolean("mmap_temp", "use memory-mapped IO for temp feature files", true),
       arguments.getInteger("sort_max_readers", "maximum number of concurrent read threads to use when sorting chunks",
         6),
       arguments.getInteger("sort_max_writers", "maximum number of concurrent write threads to use when sorting chunks",


### PR DESCRIPTION
I've been running with this for a bit without noticing any issues so it's probably time to enable by default.