### PR TITLE
Change terminology around "rendering" to be consistent with MapLibre vision

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -5,7 +5,7 @@
 Planetiler builds a map in 3 phases:
 
 1. [Process Input Files](#1-process-input-files) according to
-   the [Profile](planetiler-core/src/main/java/com/onthegomap/planetiler/Profile.java) and write rendered tile features
+   the [Profile](planetiler-core/src/main/java/com/onthegomap/planetiler/Profile.java) and write vector tile features
    to intermediate files on disk
 2. [Sort Features](#2-sort-features) by tile ID
 3. [Emit Vector Tiles](#3-emit-vector-tiles) by iterating through sorted features to group by tile ID, encoding, and
@@ -46,7 +46,7 @@ from each input source:
       then emit a polygon source feature with the reconstructed geometry if successful
 
 Then, for each [SourceFeature](planetiler-core/src/main/java/com/onthegomap/planetiler/reader/SourceFeature.java),
-render vector tile features according to
+generate vector tile features according to
 the [Profile](planetiler-core/src/main/java/com/onthegomap/planetiler/Profile.java) in a worker thread (default 1 per
 core):
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ tools like [TileServer GL](https://github.com/maptiler/tileserver-gl) or even
 See [awesome-vector-tiles](https://github.com/mapbox/awesome-vector-tiles) for more projects that work with data in this
 format.
 
-Planetiler works by mapping input elements to rendered tile features, flattening them into a big list, then sorting by
+Planetiler works by mapping input elements to vector tile features, flattening them into a big list, then sorting by
 tile ID to group into tiles. See [ARCHITECTURE.md](ARCHITECTURE.md) for more details or
 this [blog post](https://medium.com/@onthegomap/dc419f3af75d?source=friends_link&sk=fb71eaa0e2b26775a9d98c81750ec10b)
 for more of the backstory.
@@ -143,7 +143,7 @@ Some other tools that generate vector tiles from OpenStreetMap data:
   on. It uses an intermediate postgres database and operates in two modes:
   1. Import data into database (~1 day) then serve vector tiles directly from the database. Tile serving is slower and
      requires bigger machines, but lets you easily incorporate realtime updates
-  2. Import data into database (~1 day) then prerender every tile for the planet into an mbtiles file which
+  2. Import data into database (~1 day) then pregenerate every tile for the planet into an mbtiles file which
      takes [over 100 days](https://github.com/openmaptiles/openmaptiles/issues/654#issuecomment-724606293)
      or a cluster of machines, but then tiles can be served faster on smaller machines
 - [Tilemaker](https://github.com/systemed/tilemaker) uses a similar approach to Planetiler (no intermediate database),


### PR DESCRIPTION
In maplibre/maplibre#27, there was a discussion regarding the term "rendering" with regard to the scope of the mapLibre project, and what was considered "rendering" versus not in an mvt technology stack.  There seemed to be a consensus, at least from @wipfli and @nyurik that "rendering" was really describing a technology that produced graphical pixels rather than data.  In order to align with mapLibre, we should change the terminology used in planetiler to align with those definitions.  This PR updates the project's documentation to rephrase usages of the term "render" to be consistent with that definition.

If we agree on drawing a bright line in terminology between rendering and vector tile generation, it would be appropriate also to rename usages of "render" in the code itself in order to avoid developer confusion down the line.  However, this PR does not include any code renames.