### PR TITLE
fix: merge line if it needs to be simplified

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureMerge.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureMerge.java
@@ -91,7 +91,8 @@ public class FeatureMerge {
       // - only 1 element in the group
       // - it doesn't need to be clipped
       // - and it can't possibly be filtered out for being too short
-      if (groupedFeatures.size() == 1 && buffer == 0d && lengthLimit == 0) {
+      // - and it does not need to be simplified
+      if (groupedFeatures.size() == 1 && buffer == 0d && lengthLimit == 0 && tolerance == 0) {
         result.add(feature1);
       } else {
         LineMerger merger = new LineMerger();

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureMerge.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureMerge.java
@@ -63,24 +63,43 @@ public class FeatureMerge {
    * <p>
    * Orders grouped output multilinestring by the index of the first element in that group from the input list.
    *
-   * @param features  all features in a layer
-   * @param minLength minimum tile pixel length of features to emit, or 0 to emit all merged linestrings
-   * @param tolerance after merging, simplify linestrings using this pixel tolerance, or -1 to skip simplification step
-   * @param buffer    number of pixels outside the visible tile area to include detail for, or -1 to skip clipping step
+   * @param features   all features in a layer
+   * @param minLength  minimum tile pixel length of features to emit, or 0 to emit all merged linestrings
+   * @param tolerance  after merging, simplify linestrings using this pixel tolerance, or -1 to skip simplification step
+   * @param buffer     number of pixels outside the visible tile area to include detail for, or -1 to skip clipping step
+   * @param resimplify True if linestrings should be simplified even if they don't get merged with another
    * @return a new list containing all unaltered features in their original order, then each of the merged groups
    *         ordered by the index of the first element in that group from the input list.
    */
   public static List<VectorTile.Feature> mergeLineStrings(List<VectorTile.Feature> features,
-    double minLength, double tolerance, double buffer) {
-    return mergeLineStrings(features, attrs -> minLength, tolerance, buffer);
+    double minLength, double tolerance, double buffer, boolean resimplify) {
+    return mergeLineStrings(features, attrs -> minLength, tolerance, buffer, resimplify);
   }
 
   /**
-   * Merges linestrings with the same attributes as {@link #mergeLineStrings(List, double, double, double)} except with
-   * a dynamic length limit computed by {@code lengthLimitCalculator} for the attributes of each group.
+   * Merges linestrings with the same attributes as {@link #mergeLineStrings(List, double, double, double, boolean)}
+   * except sets {@code resimplify=false} by default.
+   */
+  public static List<VectorTile.Feature> mergeLineStrings(List<VectorTile.Feature> features,
+    double minLength, double tolerance, double buffer) {
+    return mergeLineStrings(features, minLength, tolerance, buffer, false);
+  }
+
+  /**
+   * Merges linestrings with the same attributes as {@link #mergeLineStrings(List, Function, double, double, boolean)}
+   * except sets {@code resimplify=false} by default.
    */
   public static List<VectorTile.Feature> mergeLineStrings(List<VectorTile.Feature> features,
     Function<Map<String, Object>, Double> lengthLimitCalculator, double tolerance, double buffer) {
+    return mergeLineStrings(features, lengthLimitCalculator, tolerance, buffer, false);
+  }
+
+  /**
+   * Merges linestrings with the same attributes as {@link #mergeLineStrings(List, double, double, double, boolean)}
+   * except with a dynamic length limit computed by {@code lengthLimitCalculator} for the attributes of each group.
+   */
+  public static List<VectorTile.Feature> mergeLineStrings(List<VectorTile.Feature> features,
+    Function<Map<String, Object>, Double> lengthLimitCalculator, double tolerance, double buffer, boolean resimplify) {
     List<VectorTile.Feature> result = new ArrayList<>(features.size());
     var groupedByAttrs = groupByAttrs(features, result, GeometryType.LINE);
     for (List<VectorTile.Feature> groupedFeatures : groupedByAttrs) {
@@ -92,7 +111,7 @@ public class FeatureMerge {
       // - it doesn't need to be clipped
       // - and it can't possibly be filtered out for being too short
       // - and it does not need to be simplified
-      if (groupedFeatures.size() == 1 && buffer == 0d && lengthLimit == 0 && tolerance == 0) {
+      if (groupedFeatures.size() == 1 && buffer == 0d && lengthLimit == 0 && (!resimplify || tolerance == 0)) {
         result.add(feature1);
       } else {
         LineMerger merger = new LineMerger();

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/FeatureMergeTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/FeatureMergeTest.java
@@ -123,6 +123,21 @@ class FeatureMergeTest {
 
   @Test
   void simplifyLineStringIfToleranceIsSet() {
+    // does not resimplify by default
+    assertEquals(
+      List.of(
+        feature(1, newLineString(10, 10, 20, 20, 30, 30), Map.of("a", 1))
+      ),
+      FeatureMerge.mergeLineStrings(
+        List.of(
+          feature(1, newLineString(10, 10, 20, 20, 30, 30), Map.of("a", 1))
+        ),
+        0,
+        1,
+        0
+      )
+    );
+    // but does resimplify when resimplify=true
     assertEquals(
       List.of(
         feature(1, newLineString(10, 10, 30, 30), Map.of("a", 1))
@@ -133,7 +148,8 @@ class FeatureMergeTest {
         ),
         0,
         1,
-        0
+        0,
+        true
       )
     );
   }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/FeatureMergeTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/FeatureMergeTest.java
@@ -122,6 +122,23 @@ class FeatureMergeTest {
   }
 
   @Test
+  void simplifyLineStringIfToleranceIsSet() {
+    assertEquals(
+      List.of(
+        feature(1, newLineString(10, 10, 30, 30), Map.of("a", 1))
+      ),
+      FeatureMerge.mergeLineStrings(
+        List.of(
+          feature(1, newLineString(10, 10, 20, 20, 30, 30), Map.of("a", 1))
+        ),
+        0,
+        1,
+        0
+      )
+    );
+  }
+
+  @Test
   void mergeMultiLineString() {
     assertEquals(
       List.of(


### PR DESCRIPTION
This ensure we still simplify passed line to `mergeLineStrings` even if there is only one