### PR TITLE
Unsynchronize ICU4j transliterate

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/util/DuplicateClassLoader.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/util/DuplicateClassLoader.java
@@ -1,0 +1,51 @@
+package com.onthegomap.planetiler.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+/**
+ * A class loader that loads certain classes even if they are already loaded by a parent classloader.
+ *
+ * This makes it possible to get multiple copies of the same class, so for example you could invoke a method
+ * synchronized on a static variable from different classes without contention.
+ */
+public class DuplicateClassLoader extends ClassLoader {
+
+  private final Predicate<String> shouldDuplicate;
+
+  private DuplicateClassLoader(Predicate<String> shouldDuplicate) {
+    this.shouldDuplicate = shouldDuplicate;
+  }
+
+  /**
+   * Returns a {@link ClassLoader} that loads every class with a name starting with {@code prefix} even if the parent
+   * has already loaded it.
+   */
+  public static DuplicateClassLoader duplicateClassesWithPrefix(String prefix) {
+    return new DuplicateClassLoader(name -> name.startsWith(prefix));
+  }
+
+  @Override
+  public Class<?> loadClass(String name) throws ClassNotFoundException {
+    if (shouldDuplicate.test(name)) {
+      Class<?> c = findLoadedClass(name);
+      if (c == null) {
+        byte[] b = loadClassFromFile(name);
+        return defineClass(name, b, 0, b.length);
+      }
+    }
+    return super.loadClass(name);
+  }
+
+  private byte[] loadClassFromFile(String fileName) {
+    String classFileName = fileName.replace('.', File.separatorChar) + ".class";
+    try (var inputStream = getClass().getClassLoader().getResourceAsStream(classFileName)) {
+      return Objects.requireNonNull(inputStream).readAllBytes();
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+}

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/util/ThreadLocalTransliterator.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/util/ThreadLocalTransliterator.java
@@ -1,0 +1,60 @@
+package com.onthegomap.planetiler.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Objects;
+import java.util.function.UnaryOperator;
+
+public class ThreadLocalTransliterator {
+  private final UnaryOperator<String> transliterator;
+
+  public String transliterate(String input) {
+    return transliterator.apply(input);
+  }
+
+  public ThreadLocalTransliterator() {
+    var c = new Cloader();
+    try {
+      Class<?> cls = c.loadClass("com.ibm.icu.text.Transliterator");
+      Method getInstance = cls.getMethod("getInstance", String.class);
+      Object t = getInstance.invoke(null, "Any-Latin");
+      Method transform = cls.getMethod("transform", String.class);
+      transliterator = str -> {
+        try {
+          return (String) transform.invoke(t, str);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+          throw new IllegalStateException(e);
+        }
+      };
+    } catch (ClassNotFoundException | InvocationTargetException | NoSuchMethodException | IllegalAccessException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private static class Cloader extends ClassLoader {
+    @Override
+    protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+      if (!resolve && name.startsWith("com.ibm.icu")) {
+        Class<?> c = findLoadedClass(name);
+        if (c == null) {
+          byte[] b = loadClassFromFile(name);
+          return defineClass(name, b, 0, b.length);
+        }
+      }
+      return super.loadClass(name, resolve);
+    }
+
+    private byte[] loadClassFromFile(String fileName) {
+      try {
+        return Objects.requireNonNull(
+          getClass().getClassLoader().getResourceAsStream(fileName.replace('.', File.separatorChar) + ".class"))
+          .readAllBytes();
+      } catch (IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    }
+  }
+}

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/util/ThreadLocalTransliterator.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/util/ThreadLocalTransliterator.java
@@ -36,15 +36,15 @@ public class ThreadLocalTransliterator {
 
   private static class Cloader extends ClassLoader {
     @Override
-    protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
-      if (!resolve && name.startsWith("com.ibm.icu")) {
+    public Class<?> loadClass(String name) throws ClassNotFoundException {
+      if (!name.startsWith("com.ibm.icu")) {
         Class<?> c = findLoadedClass(name);
         if (c == null) {
           byte[] b = loadClassFromFile(name);
           return defineClass(name, b, 0, b.length);
         }
       }
-      return super.loadClass(name, resolve);
+      return super.loadClass(name);
     }
 
     private byte[] loadClassFromFile(String fileName) {

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/util/Translations.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/util/Translations.java
@@ -15,8 +15,8 @@ import java.util.Set;
  * wikidata} tag on a source feature points to.
  */
 public class Translations {
-  private static final ThreadLocal<ThreadLocalTransliterator> TRANSLITERATOR =
-    ThreadLocal.withInitial(ThreadLocalTransliterator::new);
+  private static final ThreadLocal<ThreadLocalTransliterator.TransliteratorInstance> TRANSLITERATOR =
+    ThreadLocal.withInitial(() -> new ThreadLocalTransliterator().getInstance("Any-Latin"));
 
   private boolean shouldTransliterate = true;
   private final Set<String> languageSet;
@@ -126,8 +126,7 @@ public class Translations {
    * Attempts to translate non-latin characters to latin characters that preserve the <em>sound</em> of the word (as
    * opposed to translation which attempts to preserve meaning) using ICU4j.
    * <p>
-   * NOTE: This can be expensive and transliteration is synchronized deep down in ICU4j internals which limits benefit
-   * of running in multiple threads, so exhaust all other options first.
+   * NOTE: This can be expensive and the quality is hit or miss, so exhaust all other options first.
    */
   public static String transliterate(String input) {
     return input == null ? null : TRANSLITERATOR.get().transliterate(input);

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/util/DuplicateClassLoaderTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/util/DuplicateClassLoaderTest.java
@@ -1,0 +1,22 @@
+package com.onthegomap.planetiler.util;
+
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.Test;
+
+class DuplicateClassLoaderTest {
+
+  @Test
+  void testDuplicateClassLoader() throws Exception {
+    var cl1 = DuplicateClassLoader.duplicateClassesWithPrefix("com.onthegomap.planetiler.util");
+    var cl2 = DuplicateClassLoader.duplicateClassesWithPrefix("com.onthegomap.planetiler.util");
+    var tc1 = cl1.loadClass("com.onthegomap.planetiler.util.TestClass");
+    var tc2 = cl2.loadClass("com.onthegomap.planetiler.util.TestClass");
+    assertSame(tc1, cl1.loadClass("com.onthegomap.planetiler.util.TestClass"));
+    assertNotSame(tc1, tc2);
+    tc1.getConstructor().newInstance();
+    tc2.getConstructor().newInstance();
+  }
+}
+

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/util/TestClass.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/util/TestClass.java
@@ -1,0 +1,3 @@
+package com.onthegomap.planetiler.util;
+
+public class TestClass {}

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/util/ThreadLocalTransliteratorTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/util/ThreadLocalTransliteratorTest.java
@@ -1,0 +1,15 @@
+package com.onthegomap.planetiler.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class ThreadLocalTransliteratorTest {
+  @Test
+  void test() {
+    var t1 = new ThreadLocalTransliterator();
+    var t2 = new ThreadLocalTransliterator();
+    assertEquals("rì běn", t1.transliterate("日本"));
+    assertEquals("rì běn", t2.transliterate("日本"));
+  }
+}

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/util/ThreadLocalTransliteratorTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/util/ThreadLocalTransliteratorTest.java
@@ -7,8 +7,8 @@ import org.junit.jupiter.api.Test;
 class ThreadLocalTransliteratorTest {
   @Test
   void test() {
-    var t1 = new ThreadLocalTransliterator();
-    var t2 = new ThreadLocalTransliterator();
+    var t1 = new ThreadLocalTransliterator().getInstance("Any-Latin");
+    var t2 = new ThreadLocalTransliterator().getInstance("Any-Latin");
     assertEquals("rì běn", t1.transliterate("日本"));
     assertEquals("rì běn", t2.transliterate("日本"));
   }


### PR DESCRIPTION
Fix #242 by making a custom classloader that loads a copy of the ICU4j tranlisteration class per thread so that when they synchronize on static data it doesn't cause contention between threads.