### PR TITLE
Fall back to parsing bounds from all nodes

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/config/Bounds.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/config/Bounds.java
@@ -10,7 +10,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Holds the bounds of the map to generate.
  * <p>
- * Call {@link #setFallbackProvider(Provider)} when input data source (i.e. {@link OsmInputFile}) is available to infer
+ * Call {@link #addFallbackProvider(Provider)} when input data source (i.e. {@link OsmInputFile}) is available to infer
  * bounds automatically. If no bounds are set, defaults to the entire planet.
  */
 public class Bounds {
@@ -41,11 +41,13 @@ public class Bounds {
   }
 
   /** If no bounds were set initially, then infer bounds now from {@code latLonProvider}. */
-  public Bounds setFallbackProvider(Provider latLonProvider) {
+  public Bounds addFallbackProvider(Provider latLonProvider) {
     if (latLon == null) {
       Envelope bounds = latLonProvider.getLatLonBounds();
-      LOGGER.info("Setting map bounds from input: " + bounds);
-      set(bounds);
+      if (bounds != null && !bounds.isNull() && bounds.getArea() > 0) {
+        LOGGER.info("Setting map bounds from input: {}", bounds);
+        set(bounds);
+      }
     }
     return this;
   }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/osm/OsmInputFile.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/osm/OsmInputFile.java
@@ -233,4 +233,8 @@ public class OsmInputFile implements Bounds.Provider, Supplier<OsmBlockSource>, 
       }
     }
   }
+
+  public Path getPath() {
+    return path;
+  }
 }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/osm/OsmNodeBoundsProvider.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/osm/OsmNodeBoundsProvider.java
@@ -1,0 +1,83 @@
+package com.onthegomap.planetiler.reader.osm;
+
+import com.onthegomap.planetiler.config.Bounds;
+import com.onthegomap.planetiler.config.PlanetilerConfig;
+import com.onthegomap.planetiler.stats.ProgressLoggers;
+import com.onthegomap.planetiler.stats.Stats;
+import com.onthegomap.planetiler.worker.WorkerPipeline;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.locationtech.jts.geom.Envelope;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A utility for extracting the lat/lon bounds of all the points in a {@code .osm.pbf} file.
+ */
+public class OsmNodeBoundsProvider implements Bounds.Provider {
+  private static final Logger LOGGER = LoggerFactory.getLogger(OsmNodeBoundsProvider.class);
+
+  private final OsmInputFile file;
+  private final Stats stats;
+  private final PlanetilerConfig config;
+
+  public OsmNodeBoundsProvider(OsmInputFile file, PlanetilerConfig config, Stats stats) {
+    this.file = file;
+    this.config = config;
+    this.stats = stats;
+  }
+
+  @Override
+  public Envelope getLatLonBounds() {
+    LOGGER.warn("Bounds not found in header for {} and --bounds not provided, parsing bounds from nodes",
+      file.getPath().getFileName());
+
+    var timer = stats.startStage("osm_bounds");
+
+    // If the node location writer supports parallel writes, then parse, process, and write node locations from worker threads
+    int parseThreads = Math.max(1, config.threads() - 1);
+    var phaser = new OsmPhaser(parseThreads);
+    List<Envelope> envelopes = new CopyOnWriteArrayList<>();
+
+    var pipeline = WorkerPipeline.start("osm_bounds", stats)
+      .fromGenerator("read", file.get()::forEachBlock)
+      .addBuffer("pbf_blocks", parseThreads * 2)
+      .sinkTo("process", parseThreads, blocks -> {
+        var envelope = new Envelope();
+        envelopes.add(envelope);
+        try (var worker = phaser.forWorker()) {
+          for (var block : blocks) {
+            for (var element : block) {
+              if (element instanceof OsmElement.Node node) {
+                worker.arrive(OsmPhaser.Phase.NODES);
+                envelope.expandToInclude(node.lon(), node.lat());
+              } else if (element instanceof OsmElement.Way) {
+                worker.arrive(OsmPhaser.Phase.WAYS);
+              } else if (element instanceof OsmElement.Relation) {
+                worker.arrive(OsmPhaser.Phase.RELATIONS);
+              }
+            }
+          }
+        }
+      });
+
+    var loggers = ProgressLoggers.create()
+      .addRateCounter("nodes", phaser::nodes, true)
+      .addRateCounter("ways", phaser::ways, true)
+      .addRateCounter("rels", phaser::relations, true)
+      .newLine()
+      .addProcessStats()
+      .newLine()
+      .addPipelineStats(pipeline);
+
+    pipeline.awaitAndLog(loggers, config.logInterval());
+    phaser.printSummary();
+    timer.stop();
+
+    Envelope allBounds = new Envelope();
+    for (var env : envelopes) {
+      allBounds.expandToInclude(env);
+    }
+    return allBounds;
+  }
+}

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
@@ -1581,6 +1581,7 @@ class PlanetilerTests {
     "--write-threads=2 --process-threads=2 --feature-read-threads=2 --threads=4",
     "--emit-tiles-in-order=false",
     "--free-osm-after-read",
+    "--osm-parse-node-bounds",
   })
   void testPlanetilerRunner(String args) throws Exception {
     Path originalOsm = TestUtils.pathToResource("monaco-latest.osm.pbf");

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/config/ArgumentsTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/config/ArgumentsTest.java
@@ -136,7 +136,7 @@ class ArgumentsTest {
       new Bounds(Arguments.of("bounds", "world").bounds("bounds", "bounds")).latLon());
     assertEquals(new Envelope(7.409205, 7.448637, 43.72335, 43.75169),
       new Bounds(Arguments.of().bounds("bounds", "bounds"))
-        .setFallbackProvider(new OsmInputFile(TestUtils.pathToResource("monaco-latest.osm.pbf")))
+        .addFallbackProvider(new OsmInputFile(TestUtils.pathToResource("monaco-latest.osm.pbf")))
         .latLon());
   }
 

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/reader/osm/OsmNodeBoundsProviderTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/reader/osm/OsmNodeBoundsProviderTest.java
@@ -1,0 +1,20 @@
+package com.onthegomap.planetiler.reader.osm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.onthegomap.planetiler.TestUtils;
+import com.onthegomap.planetiler.config.PlanetilerConfig;
+import com.onthegomap.planetiler.stats.Stats;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Envelope;
+
+class OsmNodeBoundsProviderTest {
+  @Test
+  void test() {
+    var config = PlanetilerConfig.defaults();
+    var stats = Stats.inMemory();
+    var inputFile = new OsmInputFile(TestUtils.pathToResource("monaco-latest.osm.pbf"));
+    var provider = new OsmNodeBoundsProvider(inputFile, config, stats);
+    assertEquals(new Envelope(7.4016897, 7.5002447, 43.5165358, 43.7543341), provider.getLatLonBounds());
+  }
+}


### PR DESCRIPTION
Fixes #240 by falling back to a slower approach to determine an osm.pbf file bounds if not specified in the header. The slower approach parses all nodes and finds the minimum bounding box that contains them.