### PR TITLE
TileCoord supports up to zoom 15 using alternate ordering

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,8 +25,10 @@ To set up your local development environment:
   - to run just one test e.g. `GeoUtilsTest`: `./mvnw -pl planetiler-core -Dtest=GeoUtilsTest test`
   - to run benchmarks e.g. `BenchmarkTileCoord`:
 
-    ./scripts/build.sh
-    java -cp planetiler-dist/target/planetiler-dist-0.5-SNAPSHOT-with-deps.jar com.onthegomap.planetiler.benchmarks.BenchmarkTileCoord
+```sh
+./scripts/build.sh
+java -cp planetiler-dist/target/planetiler-dist-*-with-deps.jar com.onthegomap.planetiler.benchmarks.BenchmarkTileCoord
+```
 
 GitHub Workflows will run regression tests on any pull request.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,10 @@ To set up your local development environment:
   - on windows: `mvnw.cmd clean test`
   - or if you already have maven installed globally on your machine: `mvn clean test`
   - to run just one test e.g. `GeoUtilsTest`: `./mvnw -pl planetiler-core -Dtest=GeoUtilsTest test`
+  - to run benchmarks e.g. `BenchmarkTileCoord`:
+
+    ./scripts/build.sh
+    java -cp planetiler-dist/target/planetiler-dist-0.5-SNAPSHOT-with-deps.jar com.onthegomap.planetiler.benchmarks.BenchmarkTileCoord
 
 GitHub Workflows will run regression tests on any pull request.
 

--- a/planetiler-benchmarks/src/main/java/com/onthegomap/planetiler/benchmarks/BenchmarkTileCoord.java
+++ b/planetiler-benchmarks/src/main/java/com/onthegomap/planetiler/benchmarks/BenchmarkTileCoord.java
@@ -1,0 +1,38 @@
+package com.onthegomap.planetiler.benchmarks;
+
+import static io.prometheus.client.Collector.NANOSECONDS_PER_SECOND;
+
+import com.onthegomap.planetiler.geo.TileCoord;
+import com.onthegomap.planetiler.stats.Timer;
+import com.onthegomap.planetiler.util.Format;
+
+public class BenchmarkTileCoord {
+
+  public static void main(String[] args) {
+    for (int i = 0; i < 3; i++) {
+      var timer = Timer.start();
+      int num = 0;
+      for (int z = 0; z <= 14; z++) {
+        int max = 1 << z;
+        for (int x = 0; x < max; x++) {
+          for (int y = 0; y < max; y++) {
+            int encoded = TileCoord.encode(x, y, z);
+            int decoded = TileCoord.decode(encoded).encoded();
+            // make sure we use the result so it doesn't get jit'ed-out
+            if (encoded != decoded) {
+              System.err.println("Error on " + z + "/" + x + "/" + y);
+            }
+            num++;
+          }
+        }
+      }
+      System.err.println(
+        "z0-z14 took " +
+          Format.defaultInstance().duration(timer.stop().elapsed().wall()) + " (" +
+          Format.defaultInstance()
+            .numeric(num * 1d / (timer.stop().elapsed().wall().toNanos() / NANOSECONDS_PER_SECOND)) +
+          "/s)"
+      );
+    }
+  }
+}

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/TileCoord.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/TileCoord.java
@@ -91,8 +91,8 @@ public record TileCoord(int encoded, int x, int y, int z) implements Comparable<
     return ((long) resultX << 32) | resultY;
   }
 
-  // Ignore warnings about nested scopes.
-  @SuppressWarnings("java:S1199")
+  // Ignore warnings about nested scopes amd code duplication.
+  @SuppressWarnings({"java:S1199", "common-java:DuplicatedBlocks"})
   private static int hilbertXYToIndex(int n, int tx, int ty) {
     tx = tx << (16 - n);
     ty = ty << (16 - n);

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/TileCoord.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/TileCoord.java
@@ -1,6 +1,5 @@
 package com.onthegomap.planetiler.geo;
 
-import com.onthegomap.planetiler.mbtiles.Mbtiles;
 import com.onthegomap.planetiler.util.Format;
 import javax.annotation.concurrent.Immutable;
 import org.locationtech.jts.geom.Coordinate;
@@ -9,29 +8,24 @@ import org.locationtech.jts.geom.CoordinateXY;
 /**
  * The coordinate of a <a href="https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames">slippy map tile</a>.
  * <p>
- * In order to encode into a 32-bit integer, only zoom levels {@code <= 14} are supported since we need 4 bits for the
- * zoom-level, and 14 bits each for the x/y coordinates.
+ * In order to encode into a 32-bit integer, we define a sequence of Hilbert curves for each zoom level, starting at the
+ * top-left.
  * <p>
- * Tiles are ordered by z ascending, x ascending, y descending to match index ordering of {@link Mbtiles} sqlite
- * database.
  *
  * @param encoded the tile ID encoded as a 32-bit integer
  * @param x       x coordinate of the tile where 0 is the western-most tile just to the east the international date line
  *                and 2^z-1 is the eastern-most tile
  * @param y       y coordinate of the tile where 0 is the northern-most tile and 2^z-1 is the southern-most tile
- * @param z       zoom level ({@code <= 14})
+ * @param z       zoom level ({@code <= 15})
  */
 @Immutable
 public record TileCoord(int encoded, int x, int y, int z) implements Comparable<TileCoord> {
-  // TODO: support higher than z14
-  // z15 could theoretically fit into a 32-bit integer but needs a different packing strategy
   // z16+ would need more space
-  // also need to remove hardcoded z14 limits
 
   private static final int XY_MASK = (1 << 14) - 1;
 
   public TileCoord {
-    assert z <= 14;
+    assert z <= 15;
   }
 
   public static TileCoord ofXYZ(int x, int y, int z) {
@@ -39,10 +33,44 @@ public record TileCoord(int encoded, int x, int y, int z) implements Comparable<
   }
 
   public static TileCoord decode(int encoded) {
-    int z = (encoded >> 28) + 8;
-    int x = (encoded >> 14) & XY_MASK;
-    int y = ((1 << z) - 1) - ((encoded) & XY_MASK);
-    return new TileCoord(encoded, x, y, z);
+    int acc = 0;
+    int tmp_z = 0;
+    while (true) {
+      int num_tiles = (1 << tmp_z) * (1 << tmp_z);
+      if (acc + num_tiles > encoded) {
+        int position = encoded - acc;
+        return decodeOnLevel(tmp_z, position, encoded);
+      }
+      acc += num_tiles;
+      tmp_z++;
+    }
+  }
+
+  private static void rotate(int n, int[] xy, int rx, int ry) {
+    if (ry == 0) {
+      if (rx == 1) {
+        xy[0] = n - 1 - xy[0];
+        xy[1] = n - 1 - xy[1];
+      }
+      int t = xy[0];
+      xy[0] = xy[1];
+      xy[1] = t;
+    }
+  }
+
+  private static TileCoord decodeOnLevel(int z, int position, int encoded) {
+    int n = 1 << z;
+    int rx, ry, t = position;
+    int[] xy = {0, 0};
+    for (int s = 1; s < n; s *= 2) {
+      rx = 1 & Integer.divideUnsigned(t, 2);
+      ry = 1 & (t ^ rx);
+      rotate(s, xy, rx, ry);
+      xy[0] += s * rx;
+      xy[1] += s * ry;
+      t = Integer.divideUnsigned(t, 4);
+    }
+    return new TileCoord(encoded, xy[0], xy[1], z);
   }
 
   /** Returns the tile containing a latitude/longitude coordinate at a given zoom level. */
@@ -54,30 +82,20 @@ public record TileCoord(int encoded, int x, int y, int z) implements Comparable<
   }
 
   private static int encode(int x, int y, int z) {
-    int max = 1 << z;
-    if (x >= max) {
-      x %= max;
+    int acc = 0;
+    for (int tmp_z = 0; tmp_z < z; tmp_z++) {
+      acc += (1 << tmp_z) * (1 << tmp_z);
     }
-    if (x < 0) {
-      x += max;
+    int n = 1 << z;
+    int rx, ry, d = 0;
+    int[] xy = {x, y};
+    for (int s = Integer.divideUnsigned(n, 2); s > 0; s = Integer.divideUnsigned(s, 2)) {
+      rx = (xy[0] & s) > 0 ? 1 : 0;
+      ry = (xy[1] & s) > 0 ? 1 : 0;
+      d += s * s * ((3 * rx) ^ ry);
+      rotate(s, xy, rx, ry);
     }
-    if (y < 0) {
-      y = 0;
-    }
-    if (y >= max) {
-      y = max - 1;
-    }
-    // since most significant bit is treated as the sign bit, make:
-    // z0-7 get encoded from 8 (0b1000) to 15 (0b1111)
-    // z8-14 get encoded from 0 (0b0000) to 6 (0b0110)
-    // so that encoded tile coordinates are ordered by zoom level
-    if (z < 8) {
-      z += 8;
-    } else {
-      z -= 8;
-    }
-    y = max - 1 - y;
-    return (z << 28) | (x << 14) | y;
+    return acc + d;
   }
 
   @Override

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/TileCoord.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/TileCoord.java
@@ -81,7 +81,7 @@ public record TileCoord(int encoded, int x, int y, int z) implements Comparable<
     return TileCoord.ofXYZ((int) Math.floor(x), (int) Math.floor(y), zoom);
   }
 
-  private static int encode(int x, int y, int z) {
+  public static int encode(int x, int y, int z) {
     int acc = 0;
     for (int tmp_z = 0; tmp_z < z; tmp_z++) {
       acc += (1 << tmp_z) * (1 << tmp_z);

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/TileCoord.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/TileCoord.java
@@ -22,8 +22,6 @@ import org.locationtech.jts.geom.CoordinateXY;
 public record TileCoord(int encoded, int x, int y, int z) implements Comparable<TileCoord> {
   // z16+ would need more space
 
-  private static final int XY_MASK = (1 << 14) - 1;
-
   public TileCoord {
     assert z <= 15;
   }
@@ -34,43 +32,129 @@ public record TileCoord(int encoded, int x, int y, int z) implements Comparable<
 
   public static TileCoord decode(int encoded) {
     int acc = 0;
-    int tmp_z = 0;
+    int tmpZ = 0;
     while (true) {
-      int num_tiles = (1 << tmp_z) * (1 << tmp_z);
-      if (acc + num_tiles > encoded) {
+      int numTiles = (1 << tmpZ) * (1 << tmpZ);
+      if (acc + numTiles > encoded) {
         int position = encoded - acc;
-        return decodeOnLevel(tmp_z, position, encoded);
+        long xy = hilbertIndexToXY(tmpZ, position);
+        return new TileCoord(encoded, (int) (xy >>> 32 & 0xFFFFFFFFL), (int) (xy & 0xFFFFFFFFL), tmpZ);
       }
-      acc += num_tiles;
-      tmp_z++;
+      acc += numTiles;
+      tmpZ++;
     }
   }
 
-  private static void rotate(int n, int[] xy, int rx, int ry) {
-    if (ry == 0) {
-      if (rx == 1) {
-        xy[0] = n - 1 - xy[0];
-        xy[1] = n - 1 - xy[1];
-      }
-      int t = xy[0];
-      xy[0] = xy[1];
-      xy[1] = t;
-    }
+  // Fast Hilbert curve algorithm by http://threadlocalmutex.com/
+  // Ported from C++ https://github.com/rawrunprotected/hilbert_curves (public domain)
+  private static int deinterleave(int tx) {
+    tx = tx & 0x55555555;
+    tx = (tx | (tx >>> 1)) & 0x33333333;
+    tx = (tx | (tx >>> 2)) & 0x0F0F0F0F;
+    tx = (tx | (tx >>> 4)) & 0x00FF00FF;
+    tx = (tx | (tx >>> 8)) & 0x0000FFFF;
+    return tx;
   }
 
-  private static TileCoord decodeOnLevel(int z, int position, int encoded) {
-    int n = 1 << z;
-    int rx, ry, t = position;
-    int[] xy = {0, 0};
-    for (int s = 1; s < n; s *= 2) {
-      rx = 1 & Integer.divideUnsigned(t, 2);
-      ry = 1 & (t ^ rx);
-      rotate(s, xy, rx, ry);
-      xy[0] += s * rx;
-      xy[1] += s * ry;
-      t = Integer.divideUnsigned(t, 4);
+  private static int interleave(int tx) {
+    tx = (tx | (tx << 8)) & 0x00FF00FF;
+    tx = (tx | (tx << 4)) & 0x0F0F0F0F;
+    tx = (tx | (tx << 2)) & 0x33333333;
+    tx = (tx | (tx << 1)) & 0x55555555;
+    return tx;
+  }
+
+  private static int prefixScan(int tx) {
+    tx = (tx >>> 8) ^ tx;
+    tx = (tx >>> 4) ^ tx;
+    tx = (tx >>> 2) ^ tx;
+    tx = (tx >>> 1) ^ tx;
+    return tx;
+  }
+
+  private static long hilbertIndexToXY(int n, int i) {
+    i = i << (32 - 2 * n);
+
+    int i0 = deinterleave(i);
+    int i1 = deinterleave(i >>> 1);
+
+    int t0 = (i0 | i1) ^ 0xFFFF;
+    int t1 = i0 & i1;
+
+    int prefixT0 = prefixScan(t0);
+    int prefixT1 = prefixScan(t1);
+
+    int a = (((i0 ^ 0xFFFF) & prefixT1) | (i0 & prefixT0));
+
+    int resultX = (a ^ i1) >>> (16 - n);
+    int resultY = (a ^ i0 ^ i1) >>> (16 - n);
+    return ((long) resultX << 32) | resultY;
+  }
+
+  // Ignore warnings about nested scopes.
+  @SuppressWarnings("java:S1199")
+  private static int hilbertXYToIndex(int n, int tx, int ty) {
+    tx = tx << (16 - n);
+    ty = ty << (16 - n);
+
+    int hA, hB, hC, hD;
+
+    {
+      int a = tx ^ ty;
+      int b = 0xFFFF ^ a;
+      int c = 0xFFFF ^ (tx | ty);
+      int d = tx & (ty ^ 0xFFFF);
+
+      hA = a | (b >>> 1);
+      hB = (a >>> 1) ^ a;
+
+      hC = ((c >>> 1) ^ (b & (d >>> 1))) ^ c;
+      hD = ((a & (c >>> 1)) ^ (d >>> 1)) ^ d;
     }
-    return new TileCoord(encoded, xy[0], xy[1], z);
+
+    {
+      int a = hA;
+      int b = hB;
+      int c = hC;
+      int d = hD;
+
+      hA = ((a & (a >>> 2)) ^ (b & (b >>> 2)));
+      hB = ((a & (b >>> 2)) ^ (b & ((a ^ b) >>> 2)));
+
+      hC ^= ((a & (c >>> 2)) ^ (b & (d >>> 2)));
+      hD ^= ((b & (c >>> 2)) ^ ((a ^ b) & (d >>> 2)));
+    }
+
+    {
+      int a = hA;
+      int b = hB;
+      int c = hC;
+      int d = hD;
+
+      hA = ((a & (a >>> 4)) ^ (b & (b >>> 4)));
+      hB = ((a & (b >>> 4)) ^ (b & ((a ^ b) >>> 4)));
+
+      hC ^= ((a & (c >>> 4)) ^ (b & (d >>> 4)));
+      hD ^= ((b & (c >>> 4)) ^ ((a ^ b) & (d >>> 4)));
+    }
+
+    {
+      int a = hA;
+      int b = hB;
+      int c = hC;
+      int d = hD;
+
+      hC ^= ((a & (c >>> 8)) ^ (b & (d >>> 8)));
+      hD ^= ((b & (c >>> 8)) ^ ((a ^ b) & (d >>> 8)));
+    }
+
+    int a = hC ^ (hC >>> 1);
+    int b = hD ^ (hD >>> 1);
+
+    int i0 = tx ^ ty;
+    int i1 = b | (0xFFFF ^ (i0 | a));
+
+    return ((interleave(i1) << 1) | interleave(i0)) >>> (32 - 2 * n);
   }
 
   /** Returns the tile containing a latitude/longitude coordinate at a given zoom level. */
@@ -83,19 +167,10 @@ public record TileCoord(int encoded, int x, int y, int z) implements Comparable<
 
   public static int encode(int x, int y, int z) {
     int acc = 0;
-    for (int tmp_z = 0; tmp_z < z; tmp_z++) {
-      acc += (1 << tmp_z) * (1 << tmp_z);
+    for (int tmpZ = 0; tmpZ < z; tmpZ++) {
+      acc += (1 << tmpZ) * (1 << tmpZ);
     }
-    int n = 1 << z;
-    int rx, ry, d = 0;
-    int[] xy = {x, y};
-    for (int s = Integer.divideUnsigned(n, 2); s > 0; s = Integer.divideUnsigned(s, 2)) {
-      rx = (xy[0] & s) > 0 ? 1 : 0;
-      ry = (xy[1] & s) > 0 ? 1 : 0;
-      d += s * s * ((3 * rx) ^ ry);
-      rotate(s, xy, rx, ry);
-    }
-    return acc + d;
+    return acc + hilbertXYToIndex(z, x, y);
   }
 
   @Override

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/TileCoord.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/TileCoord.java
@@ -9,9 +9,8 @@ import org.locationtech.jts.geom.CoordinateXY;
  * The coordinate of a <a href="https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames">slippy map tile</a>.
  * <p>
  * Tile coords are sorted by consecutive Z levels in ascending order: 0 coords for z=0, 4 coords for z=1, etc. TMS
- * order: tiles in a level are sorted by x ascending, y descending to match the ordering of {@link mbtiles.Mbtiles}
- * sqlite index. Hilbert order: tiles in a level are ordered on the Hilbert curve with the first coordinate at the tip
- * left.
+ * order: tiles in a level are sorted by x ascending, y descending to match the ordering of the MBTiles sqlite index.
+ * Hilbert order: tiles in a level are ordered on the Hilbert curve with the first coordinate at the tip left.
  * <p>
  *
  * @param encoded the tile ID encoded as a 32-bit integer

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/TileCoord.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/TileCoord.java
@@ -91,62 +91,52 @@ public record TileCoord(int encoded, int x, int y, int z) implements Comparable<
     return ((long) resultX << 32) | resultY;
   }
 
-  // Ignore warnings about nested scopes amd code duplication.
-  @SuppressWarnings({"java:S1199", "common-java:DuplicatedBlocks"})
   private static int hilbertXYToIndex(int n, int tx, int ty) {
     tx = tx << (16 - n);
     ty = ty << (16 - n);
 
     int hA, hB, hC, hD;
 
-    {
-      int a = tx ^ ty;
-      int b = 0xFFFF ^ a;
-      int c = 0xFFFF ^ (tx | ty);
-      int d = tx & (ty ^ 0xFFFF);
+    int a1 = tx ^ ty;
+    int b1 = 0xFFFF ^ a1;
+    int c1 = 0xFFFF ^ (tx | ty);
+    int d1 = tx & (ty ^ 0xFFFF);
 
-      hA = a | (b >>> 1);
-      hB = (a >>> 1) ^ a;
+    hA = a1 | (b1 >>> 1);
+    hB = (a1 >>> 1) ^ a1;
 
-      hC = ((c >>> 1) ^ (b & (d >>> 1))) ^ c;
-      hD = ((a & (c >>> 1)) ^ (d >>> 1)) ^ d;
-    }
+    hC = ((c1 >>> 1) ^ (b1 & (d1 >>> 1))) ^ c1;
+    hD = ((a1 & (c1 >>> 1)) ^ (d1 >>> 1)) ^ d1;
 
-    {
-      int a = hA;
-      int b = hB;
-      int c = hC;
-      int d = hD;
+    int a2 = hA;
+    int b2 = hB;
+    int c2 = hC;
+    int d2 = hD;
 
-      hA = ((a & (a >>> 2)) ^ (b & (b >>> 2)));
-      hB = ((a & (b >>> 2)) ^ (b & ((a ^ b) >>> 2)));
+    hA = ((a2 & (a2 >>> 2)) ^ (b2 & (b2 >>> 2)));
+    hB = ((a2 & (b2 >>> 2)) ^ (b2 & ((a2 ^ b2) >>> 2)));
 
-      hC ^= ((a & (c >>> 2)) ^ (b & (d >>> 2)));
-      hD ^= ((b & (c >>> 2)) ^ ((a ^ b) & (d >>> 2)));
-    }
+    hC ^= ((a2 & (c2 >>> 2)) ^ (b2 & (d2 >>> 2)));
+    hD ^= ((b2 & (c2 >>> 2)) ^ ((a2 ^ b2) & (d2 >>> 2)));
 
-    {
-      int a = hA;
-      int b = hB;
-      int c = hC;
-      int d = hD;
+    int a3 = hA;
+    int b3 = hB;
+    int c3 = hC;
+    int d3 = hD;
 
-      hA = ((a & (a >>> 4)) ^ (b & (b >>> 4)));
-      hB = ((a & (b >>> 4)) ^ (b & ((a ^ b) >>> 4)));
+    hA = ((a3 & (a3 >>> 4)) ^ (b3 & (b3 >>> 4)));
+    hB = ((a3 & (b3 >>> 4)) ^ (b3 & ((a3 ^ b3) >>> 4)));
 
-      hC ^= ((a & (c >>> 4)) ^ (b & (d >>> 4)));
-      hD ^= ((b & (c >>> 4)) ^ ((a ^ b) & (d >>> 4)));
-    }
+    hC ^= ((a3 & (c3 >>> 4)) ^ (b3 & (d3 >>> 4)));
+    hD ^= ((b3 & (c3 >>> 4)) ^ ((a3 ^ b3) & (d3 >>> 4)));
 
-    {
-      int a = hA;
-      int b = hB;
-      int c = hC;
-      int d = hD;
+    int a4 = hA;
+    int b4 = hB;
+    int c4 = hC;
+    int d4 = hD;
 
-      hC ^= ((a & (c >>> 8)) ^ (b & (d >>> 8)));
-      hD ^= ((b & (c >>> 8)) ^ ((a ^ b) & (d >>> 8)));
-    }
+    hC ^= ((a4 & (c4 >>> 8)) ^ (b4 & (d4 >>> 8)));
+    hD ^= ((b4 & (c4 >>> 8)) ^ ((a4 ^ b4) & (d4 >>> 8)));
 
     int a = hC ^ (hC >>> 1);
     int b = hD ^ (hD >>> 1);
@@ -195,6 +185,19 @@ public record TileCoord(int encoded, int x, int y, int z) implements Comparable<
   @Override
   public String toString() {
     return "{x=" + x + " y=" + y + " z=" + z + '}';
+  }
+
+  public double progressOnLevel() {
+    int acc = 0;
+    int tmpZ = 0;
+    while (true) {
+      int numTiles = (1 << tmpZ) * (1 << tmpZ);
+      if (acc + numTiles > encoded) {
+        return (encoded - acc) / (double) numTiles;
+      }
+      acc += numTiles;
+      tmpZ++;
+    }
   }
 
   @Override

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/TileCoord.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/TileCoord.java
@@ -9,8 +9,9 @@ import org.locationtech.jts.geom.CoordinateXY;
  * The coordinate of a <a href="https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames">slippy map tile</a>.
  * <p>
  * Tile coords are sorted by consecutive Z levels in ascending order: 0 coords for z=0, 4 coords for z=1, etc. TMS
- * order: tiles in a level are sorted by x ascending, y descending to match the ordering of {@link Mbtiles} sqlite
- * index. Hilbert order: tiles in a level are ordered on the Hilbert curve with the first coordinate at the tip left.
+ * order: tiles in a level are sorted by x ascending, y descending to match the ordering of {@link mbtiles.Mbtiles}
+ * sqlite index. Hilbert order: tiles in a level are ordered on the Hilbert curve with the first coordinate at the tip
+ * left.
  * <p>
  *
  * @param encoded the tile ID encoded as a 32-bit integer

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/mbtiles/MbtilesWriter.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/mbtiles/MbtilesWriter.java
@@ -203,12 +203,9 @@ public class MbtilesWriter {
     if (lastTile == null) {
       blurb = "n/a";
     } else {
-      var extentForZoom = config.bounds().tileExtents().getForZoom(lastTile.z());
-      int zMinX = extentForZoom.minX();
-      int zMaxX = extentForZoom.maxX();
       blurb = "%d/%d/%d (z%d %s%%) %s".formatted(
         lastTile.z(), lastTile.x(), lastTile.y(),
-        lastTile.z(), (100 * (lastTile.x() + 1 - zMinX)) / (zMaxX - zMinX),
+        lastTile.z(), 100 * lastTile.progressOnLevel(),
         lastTile.getDebugUrl()
       );
     }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/TileCoordTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/TileCoordTest.java
@@ -41,9 +41,17 @@ class TileCoordTest {
     "1,1,1,3",
     "1,0,1,4",
     "0,0,2,5",
+    "0,0,15,357913941",
+    "0,32767,15,715827882",
+    "32767,0,15,1431655764",
+    "32767,32767,15,1073741823"
   })
   void testTileOrderHilbert(int x, int y, int z, int i) {
     int encoded = TileCoord.ofXYZ(x, y, z).encoded();
     assertEquals(i, encoded);
+    TileCoord decoded = TileCoord.decode(i);
+    assertEquals(decoded.x(), x, "x");
+    assertEquals(decoded.y(), y, "y");
+    assertEquals(decoded.z(), z, "z");
   }
 }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/TileCoordTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/TileCoordTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
+
 class TileCoordTest {
 
   @ParameterizedTest

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/TileCoordTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/TileCoordTest.java
@@ -1,10 +1,7 @@
 package com.onthegomap.planetiler.geo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -17,6 +14,14 @@ class TileCoordTest {
     "0,1,1",
     "1,1,1",
     "100,100,14",
+    "0,0,14",
+    "16383,0,14",
+    "0,16383,14",
+    "16363,16363,14",
+    "0,0,15",
+    "32767,0,15",
+    "0,32767,15",
+    "32767,32767,15"
   })
   void testTileCoord(int x, int y, int z) {
     TileCoord coord1 = TileCoord.ofXYZ(x, y, z);
@@ -27,31 +32,17 @@ class TileCoordTest {
     assertEquals(coord1, coord2);
   }
 
-  @Test
-  void testTileSortOrderRespectZ() {
-    int last = Integer.MIN_VALUE;
-    for (int z = 0; z <= 14; z++) {
-      int encoded = TileCoord.ofXYZ(0, 0, z).encoded();
-      if (encoded < last) {
-        fail("encoded value for z" + (z - 1) + " (" + last + ") is not less than z" + z + " (" + encoded + ")");
-      }
-      last = encoded;
-    }
-  }
-
-  @Test
-  void testTileSortOrderFlipY() {
-    for (int z = 1; z <= 14; z++) {
-      int encoded1 = TileCoord.ofXYZ(0, 1, z).encoded();
-      int encoded2 = TileCoord.ofXYZ(0, 0, z).encoded();
-      if (encoded2 < encoded1) {
-        fail("encoded value for y=1 is not less than y=0 at z=" + z);
-      }
-    }
-  }
-
-  @Test
-  void testThrowsPastZ14() {
-    assertThrows(AssertionError.class, () -> TileCoord.ofXYZ(0, 0, 15));
+  @ParameterizedTest
+  @CsvSource({
+    "0,0,0,0",
+    "0,0,1,1",
+    "0,1,1,2",
+    "1,1,1,3",
+    "1,0,1,4",
+    "0,0,2,5",
+  })
+  void testTileOrderHilbert(int x, int y, int z, int i) {
+    int encoded = TileCoord.ofXYZ(x, y, z).encoded();
+    assertEquals(i, encoded);
   }
 }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/TileCoordTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/TileCoordTest.java
@@ -54,4 +54,18 @@ class TileCoordTest {
     assertEquals(decoded.y(), y, "y");
     assertEquals(decoded.z(), z, "z");
   }
+
+  @ParameterizedTest
+  @CsvSource({
+    "0,0,0,0",
+    "0,0,1,0",
+    "0,1,1,0.25",
+    "1,1,1,0.5",
+    "1,0,1,0.75",
+    "0,0,2,0"
+  })
+  void testTileProgressOnLevel(int x, int y, int z, double p) {
+    double progress = TileCoord.ofXYZ(x, y, z).progressOnLevel();
+    assertEquals(p, progress);
+  }
 }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/TileCoordTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/TileCoordTest.java
@@ -10,43 +10,33 @@ class TileCoordTest {
 
   @ParameterizedTest
   @CsvSource({
-    "0,0,0",
-    "0,0,1",
-    "0,1,1",
-    "1,1,1",
-    "100,100,14",
-    "0,0,14",
-    "16383,0,14",
-    "0,16383,14",
-    "16363,16363,14",
-    "0,0,15",
-    "32767,0,15",
-    "0,32767,15",
-    "32767,32767,15"
-  })
-  void testTileCoord(int x, int y, int z) {
-    TileCoord coord1 = TileCoord.ofXYZ(x, y, z);
-    TileCoord coord2 = TileCoord.decode(coord1.encoded());
-    assertEquals(coord1.x(), coord2.x(), "x");
-    assertEquals(coord1.y(), coord2.y(), "y");
-    assertEquals(coord1.z(), coord2.z(), "z");
-    assertEquals(coord1, coord2);
-  }
-
-  @ParameterizedTest
-  @CsvSource({
     "0,0,0,0",
-    "0,0,1,1",
-    "0,1,1,2",
+    "0,1,1,1",
+    "0,0,1,2",
     "1,1,1,3",
     "1,0,1,4",
-    "0,0,2,5",
-    "0,0,15,357913941",
-    "0,32767,15,715827882",
+    "0,3,2,5",
+    "0,2,2,6",
+    "0,1,2,7",
+    "0,0,2,8",
+    "1,3,2,9",
+    "1,2,2,10",
+    "1,1,2,11",
+    "1,0,2,12",
+    "2,3,2,13",
+    "2,2,2,14",
+    "2,1,2,15",
+    "2,0,2,16",
+    "3,3,2,17",
+    "3,2,2,18",
+    "3,1,2,19",
+    "3,0,2,20",
+    "0,0,15,357946708",
+    "0,32767,15,357913941",
     "32767,0,15,1431655764",
-    "32767,32767,15,1073741823"
+    "32767,32767,15,1431622997"
   })
-  void testTileOrderHilbert(int x, int y, int z, int i) {
+  void testTileOrder(int x, int y, int z, int i) {
     int encoded = TileCoord.ofXYZ(x, y, z).encoded();
     assertEquals(i, encoded);
     TileCoord decoded = TileCoord.decode(i);
@@ -58,11 +48,11 @@ class TileCoordTest {
   @ParameterizedTest
   @CsvSource({
     "0,0,0,0",
-    "0,0,1,0",
-    "0,1,1,0.25",
+    "0,1,1,0",
+    "0,0,1,0.25",
     "1,1,1,0.5",
     "1,0,1,0.75",
-    "0,0,2,0"
+    "0,3,2,0"
   })
   void testTileProgressOnLevel(int x, int y, int z, double p) {
     double progress = TileCoord.ofXYZ(x, y, z).progressOnLevel();


### PR DESCRIPTION
This is a rough idea right now (don't merge yet) to explore alternate TileCoord encodings. it deserves some better tests for edge cases as right now it's blindly ported from C++ to java

The current TileCoord uses a fixed 14 bits for X and Y and the remaining bits for Z. This instead defines a mapping from a 32-bit unsigned encoded integer to X,Y,Z like this:

Tile 0 is `(0,0)` on z0
Tile 1-4 are positions on the z1 Hilbert curve; each side of the curve is length 2, so tile 1 is `(0,0)`, tile 2 is `(0,1)`, tile 3 is `(1,1)` and tile 4 is `(1,0)`
Tile 5-20 are positions on the z2 Hilbert curve
etc...

Drawbacks:
* decoding/encoding might more expensive
* does not correspond to index insertion order in MBTiles, but there may be other ways to mitigate this

Potential benefits of doing it this way:
* support z15 without widening the TileCoord encoding to 64 bits
* If features are ordered this way and memory-mapped on disk, reads should have better locality for 2D queries vs. striped Z/X/Y ordering
* for some other tools I'm developing this would aid interoperability, such as a bitmap format for sparse ocean representation or a future ordering requirement for PMTiles 