### PR TITLE
Rename README subtitle from custom map to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Some common arguments:
 
 See [PLANET.md](PLANET.md).
 
-## Creating a Custom Map
+## Examples
 
 See the [planetiler-examples](planetiler-examples) project.
 


### PR DESCRIPTION
Custom map is now its own project so we should use a different subtitle in the README.
