### PR TITLE
Decrease power sample minzoom from 12 to 7

### DIFF
--- a/planetiler-custommap/src/main/resources/samples/power.yml
+++ b/planetiler-custommap/src/main/resources/samples/power.yml
@@ -24,7 +24,7 @@ layers:
   - sources:
     - osm
     geometry: line
-    min_zoom: 12
+    min_zoom: 7
     include_when:
       power:
       - line


### PR DESCRIPTION
With a minzoom of 12, tileserver-gl will show an empty map when opening the power.yml sample. I adjusted the minzoom to 7 because this is what tileserver-gl seems to use as a default zoom when opening the power sample.
