### PR TITLE
Allow more than 256 attribute keys

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/collection/FeatureGroup.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/collection/FeatureGroup.java
@@ -56,12 +56,12 @@ public final class FeatureGroup implements Iterable<FeatureGroup.TileFeatures>, 
   private static final Logger LOGGER = LoggerFactory.getLogger(FeatureGroup.class);
   private final FeatureSort sorter;
   private final Profile profile;
-  private final CommonStringEncoder commonStrings;
+  private final CommonStringEncoder.AsByte commonStrings;
   private final Stats stats;
   private final LayerStats layerStats = new LayerStats();
   private volatile boolean prepared = false;
 
-  FeatureGroup(FeatureSort sorter, Profile profile, CommonStringEncoder commonStrings, Stats stats) {
+  FeatureGroup(FeatureSort sorter, Profile profile, CommonStringEncoder.AsByte commonStrings, Stats stats) {
     this.sorter = sorter;
     this.profile = profile;
     this.commonStrings = commonStrings;
@@ -69,7 +69,7 @@ public final class FeatureGroup implements Iterable<FeatureGroup.TileFeatures>, 
   }
 
   FeatureGroup(FeatureSort sorter, Profile profile, Stats stats) {
-    this(sorter, profile, new CommonStringEncoder(), stats);
+    this(sorter, profile, new CommonStringEncoder.AsByte(), stats);
   }
 
   /** Returns a feature grouper that stores all feature in-memory. Only suitable for toy use-cases like unit tests. */
@@ -190,7 +190,7 @@ public final class FeatureGroup implements Iterable<FeatureGroup.TileFeatures>, 
 
   private long encodeKey(RenderedFeature feature) {
     var vectorTileFeature = feature.vectorTileFeature();
-    byte encodedLayer = commonStrings.encodeByte(vectorTileFeature.layer());
+    byte encodedLayer = commonStrings.encode(vectorTileFeature.layer());
     return encodeKey(
       feature.tile().encoded(),
       encodedLayer,
@@ -214,7 +214,7 @@ public final class FeatureGroup implements Iterable<FeatureGroup.TileFeatures>, 
       packer.packMapHeader((int) attrs.values().stream().filter(Objects::nonNull).count());
       for (Map.Entry<String, Object> entry : attrs.entrySet()) {
         if (entry.getValue() != null) {
-          packer.packInt(commonStrings.encodeInt(entry.getKey()));
+          packer.packInt(commonStrings.encode(entry.getKey()));
           Object value = entry.getValue();
           if (value instanceof String string) {
             packer.packValue(ValueFactory.newString(string));
@@ -427,7 +427,7 @@ public final class FeatureGroup implements Iterable<FeatureGroup.TileFeatures>, 
         int mapSize = unpacker.unpackMapHeader();
         Map<String, Object> attrs = new HashMap<>(mapSize);
         for (int i = 0; i < mapSize; i++) {
-          String key = commonStrings.decodeInt(unpacker.unpackInt());
+          String key = commonStrings.decode(unpacker.unpackByte());
           Value v = unpacker.unpackValue();
           if (v.isStringValue()) {
             attrs.put(key, v.asStringValue().asString());
@@ -444,7 +444,7 @@ public final class FeatureGroup implements Iterable<FeatureGroup.TileFeatures>, 
         for (int i = 0; i < commandSize; i++) {
           commands[i] = unpacker.unpackInt();
         }
-        String layer = commonStrings.decodeByte(extractLayerIdFromKey(entry.key()));
+        String layer = commonStrings.decode(extractLayerIdFromKey(entry.key()));
         return new VectorTile.Feature(
           layer,
           id,

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/collection/FeatureGroup.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/collection/FeatureGroup.java
@@ -190,7 +190,7 @@ public final class FeatureGroup implements Iterable<FeatureGroup.TileFeatures>, 
 
   private long encodeKey(RenderedFeature feature) {
     var vectorTileFeature = feature.vectorTileFeature();
-    byte encodedLayer = commonStrings.encode(vectorTileFeature.layer());
+    byte encodedLayer = commonStrings.encodeByte(vectorTileFeature.layer());
     return encodeKey(
       feature.tile().encoded(),
       encodedLayer,
@@ -214,7 +214,7 @@ public final class FeatureGroup implements Iterable<FeatureGroup.TileFeatures>, 
       packer.packMapHeader((int) attrs.values().stream().filter(Objects::nonNull).count());
       for (Map.Entry<String, Object> entry : attrs.entrySet()) {
         if (entry.getValue() != null) {
-          packer.packByte(commonStrings.encode(entry.getKey()));
+          packer.packInt(commonStrings.encodeInt(entry.getKey()));
           Object value = entry.getValue();
           if (value instanceof String string) {
             packer.packValue(ValueFactory.newString(string));
@@ -427,7 +427,7 @@ public final class FeatureGroup implements Iterable<FeatureGroup.TileFeatures>, 
         int mapSize = unpacker.unpackMapHeader();
         Map<String, Object> attrs = new HashMap<>(mapSize);
         for (int i = 0; i < mapSize; i++) {
-          String key = commonStrings.decode(unpacker.unpackByte());
+          String key = commonStrings.decodeInt(unpacker.unpackInt());
           Value v = unpacker.unpackValue();
           if (v.isStringValue()) {
             attrs.put(key, v.asStringValue().asString());
@@ -444,7 +444,7 @@ public final class FeatureGroup implements Iterable<FeatureGroup.TileFeatures>, 
         for (int i = 0; i < commandSize; i++) {
           commands[i] = unpacker.unpackInt();
         }
-        String layer = commonStrings.decode(extractLayerIdFromKey(entry.key()));
+        String layer = commonStrings.decodeByte(extractLayerIdFromKey(entry.key()));
         return new VectorTile.Feature(
           layer,
           id,

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/util/CommonStringEncoder.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/util/CommonStringEncoder.java
@@ -40,14 +40,18 @@ public class CommonStringEncoder {
   public int encode(String string) {
     // optimization to avoid more expensive computeIfAbsent call for the majority case when concurrent hash map already
     // contains the value.
-    return stringToId.computeIfAbsent(string, s -> {
-      int id = stringId.getAndIncrement();
-      if (id >= MAX_STRINGS) {
-        throw new IllegalArgumentException("Too many strings");
-      }
-      idToString[id] = string;
-      return id;
-    });
+    Integer result = stringToId.get(string);
+    if (result == null) {
+      result = stringToId.computeIfAbsent(string, s -> {
+        int id = stringId.getAndIncrement();
+        if (id >= MAX_STRINGS) {
+          throw new IllegalArgumentException("Too many strings");
+        }
+        idToString[id] = string;
+        return id;
+      });
+    }
+    return result;
   }
 
   /**

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/util/CommonStringEncoder.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/util/CommonStringEncoder.java
@@ -1,27 +1,44 @@
 package com.onthegomap.planetiler.util;
 
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
- * A utility for compressing up to 250 commonly-used strings (i.e. layer name, tag attributes) into a single byte.
+ * A utility for compressing commonly-used strings (i.e. layer name, tag attributes).
  */
 @ThreadSafe
 public class CommonStringEncoder {
 
-  private final ConcurrentMap<String, Byte> stringToId = new ConcurrentHashMap<>(255);
+  private final Map<String, Byte> stringToId = new ConcurrentHashMap<>(255);
   private final String[] idToString = new String[255];
   private final AtomicInteger layerId = new AtomicInteger(0);
+
+  private final Map<String, Integer> stringToIdMap = new ConcurrentHashMap<>(255);
+  private final Map<Integer, String> idToStringMap = new ConcurrentHashMap<>();
+  private final AtomicInteger intStringId = new AtomicInteger(0);
 
   /**
    * Returns the string for {@code id}.
    *
    * @throws IllegalArgumentException if there is no value for {@code id}.
    */
-  public String decode(byte id) {
+  public String decodeByte(byte id) {
     String str = idToString[id & 0xff];
+    if (str == null) {
+      throw new IllegalArgumentException("No string for " + id);
+    }
+    return str;
+  }
+
+  /**
+   * Returns the string for {@code id}.
+   *
+   * @throws IllegalArgumentException if there is no value for {@code id}.
+   */
+  public String decodeInt(int id) {
+    String str = idToStringMap.get(id);
     if (str == null) {
       throw new IllegalArgumentException("No string for " + id);
     }
@@ -32,10 +49,10 @@ public class CommonStringEncoder {
    * Returns a byte value to each unique string passed in.
    *
    * @param string the string to store
-   * @return a byte that can be converted back to a string by {@link #decode(byte)}.
+   * @return a byte that can be converted back to a string by {@link #decodeByte(byte)}.
    * @throws IllegalArgumentException if called for too many values
    */
-  public byte encode(String string) {
+  public byte encodeByte(String string) {
     // optimization to avoid more expensive computeIfAbsent call for the majority case when concurrent hash map already
     // contains the value.
     Byte result = stringToId.get(string);
@@ -50,5 +67,22 @@ public class CommonStringEncoder {
       });
     }
     return result;
+  }
+
+  /**
+   * Returns a int value to each unique string passed in.
+   *
+   * @param string the string to store
+   * @return an int that can be converted back to a string by {@link #decodeInt(int)}.
+   * @throws IllegalArgumentException if called for too many values
+   */
+  public int encodeInt(String string) {
+    // optimization to avoid more expensive computeIfAbsent call for the majority case when concurrent hash map already
+    // contains the value.
+    return stringToIdMap.computeIfAbsent(string, s -> {
+      int id = intStringId.getAndIncrement();
+      idToStringMap.put(id, string);
+      return id;
+    });
   }
 }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/FeatureCollectorTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/FeatureCollectorTest.java
@@ -13,6 +13,7 @@ import com.onthegomap.planetiler.reader.SimpleFeature;
 import com.onthegomap.planetiler.stats.Stats;
 import com.onthegomap.planetiler.util.ZoomFunction;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.StreamSupport;
@@ -582,4 +583,32 @@ class FeatureCollectorTest {
 
     assertFalse(iter.hasNext());
   }
+
+  @Test
+  void testManyAttr() {
+
+    Map<String, Object> tags = new HashMap<>();
+
+    for (int i = 0; i < 500; i++) {
+      tags.put("key" + i, "val" + i);
+    }
+
+    var collector = factory.get(newReaderFeature(newPoint(0, 0), tags));
+    var point = collector.point("layername");
+
+    for (int i = 0; i < 500; i++) {
+      point.setAttr("key" + i, tags.get("key" + i));
+    }
+
+    assertFeatures(13, List.of(
+      Map.of(
+        "key0", "val0",
+        "key10", "val10",
+        "key100", "val100",
+        "key256", "val256",
+        "key499", "val499"
+      )
+    ), collector);
+  }
+
 }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/util/CommonStringEncoderTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/util/CommonStringEncoderTest.java
@@ -11,22 +11,22 @@ class CommonStringEncoderTest {
 
   @Test
   void testRoundTrip() {
-    byte a = commonStringEncoder.encode("a");
-    byte b = commonStringEncoder.encode("b");
-    assertEquals("a", commonStringEncoder.decode(a));
-    assertEquals(a, commonStringEncoder.encode("a"));
-    assertEquals("b", commonStringEncoder.decode(b));
-    assertThrows(IllegalArgumentException.class, () -> commonStringEncoder.decode((byte) (b + 1)));
+    byte a = commonStringEncoder.encodeByte("a");
+    byte b = commonStringEncoder.encodeByte("b");
+    assertEquals("a", commonStringEncoder.decodeByte(a));
+    assertEquals(a, commonStringEncoder.encodeByte("a"));
+    assertEquals("b", commonStringEncoder.decodeByte(b));
+    assertThrows(IllegalArgumentException.class, () -> commonStringEncoder.decodeByte((byte) (b + 1)));
   }
 
   @Test
   void testLimitsTo250() {
     for (int i = 0; i <= 250; i++) {
       String string = Integer.toString(i);
-      byte encoded = commonStringEncoder.encode(Integer.toString(i));
-      String decoded = commonStringEncoder.decode(encoded);
+      byte encoded = commonStringEncoder.encodeByte(Integer.toString(i));
+      String decoded = commonStringEncoder.decodeByte(encoded);
       assertEquals(string, decoded);
     }
-    assertThrows(IllegalArgumentException.class, () -> commonStringEncoder.encode("too many"));
+    assertThrows(IllegalArgumentException.class, () -> commonStringEncoder.encodeByte("too many"));
   }
 }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/util/CommonStringEncoderTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/util/CommonStringEncoderTest.java
@@ -34,10 +34,21 @@ class CommonStringEncoderTest {
   void testByteLimitsToMax() {
     for (int i = 0; i <= 255; i++) {
       String string = Integer.toString(i);
-      byte encoded = commonStringEncoderByte.encode(Integer.toString(i));
+      byte encoded = commonStringEncoderByte.encode(string);
       String decoded = commonStringEncoderByte.decode(encoded);
       assertEquals(string, decoded);
     }
     assertThrows(IllegalArgumentException.class, () -> commonStringEncoderByte.encode("too many"));
+  }
+
+  @Test
+  void testIntDoesNotLimitTo250() {
+    for (int i = 0; i < 100_000; i++) {
+      String string = Integer.toString(i);
+      int encoded = commonStringEncoderInteger.encode(string);
+      String decoded = commonStringEncoderInteger.decode(encoded);
+      assertEquals(string, decoded);
+    }
+    assertThrows(IllegalArgumentException.class, () -> commonStringEncoderInteger.encode("too many"));
   }
 }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/util/CommonStringEncoderTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/util/CommonStringEncoderTest.java
@@ -7,26 +7,37 @@ import org.junit.jupiter.api.Test;
 
 class CommonStringEncoderTest {
 
-  private final CommonStringEncoder commonStringEncoder = new CommonStringEncoder();
+  private final CommonStringEncoder commonStringEncoderInteger = new CommonStringEncoder();
+  private final CommonStringEncoder.AsByte commonStringEncoderByte = new CommonStringEncoder.AsByte();
 
   @Test
-  void testRoundTrip() {
-    byte a = commonStringEncoder.encodeByte("a");
-    byte b = commonStringEncoder.encodeByte("b");
-    assertEquals("a", commonStringEncoder.decodeByte(a));
-    assertEquals(a, commonStringEncoder.encodeByte("a"));
-    assertEquals("b", commonStringEncoder.decodeByte(b));
-    assertThrows(IllegalArgumentException.class, () -> commonStringEncoder.decodeByte((byte) (b + 1)));
+  void testRoundTripByte() {
+    byte a = commonStringEncoderByte.encode("a");
+    byte b = commonStringEncoderByte.encode("b");
+    assertEquals("a", commonStringEncoderByte.decode(a));
+    assertEquals(a, commonStringEncoderByte.encode("a"));
+    assertEquals("b", commonStringEncoderByte.decode(b));
+    assertThrows(IllegalArgumentException.class, () -> commonStringEncoderByte.decode((byte) (b + 1)));
   }
 
   @Test
-  void testLimitsTo250() {
-    for (int i = 0; i <= 250; i++) {
+  void testRoundTripInteger() {
+    int a = commonStringEncoderInteger.encode("a");
+    int b = commonStringEncoderInteger.encode("b");
+    assertEquals("a", commonStringEncoderInteger.decode(a));
+    assertEquals(a, commonStringEncoderInteger.encode("a"));
+    assertEquals("b", commonStringEncoderInteger.decode(b));
+    assertThrows(IllegalArgumentException.class, () -> commonStringEncoderInteger.decode(b + 1));
+  }
+
+  @Test
+  void testByteLimitsTo250() {
+    for (int i = 0; i <= 255; i++) {
       String string = Integer.toString(i);
-      byte encoded = commonStringEncoder.encodeByte(Integer.toString(i));
-      String decoded = commonStringEncoder.decodeByte(encoded);
+      byte encoded = commonStringEncoderByte.encode(Integer.toString(i));
+      String decoded = commonStringEncoderByte.decode(encoded);
       assertEquals(string, decoded);
     }
-    assertThrows(IllegalArgumentException.class, () -> commonStringEncoder.encodeByte("too many"));
+    assertThrows(IllegalArgumentException.class, () -> commonStringEncoderByte.encode("too many"));
   }
 }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/util/CommonStringEncoderTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/util/CommonStringEncoderTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 class CommonStringEncoderTest {
 
-  private final CommonStringEncoder commonStringEncoderInteger = new CommonStringEncoder();
+  private final CommonStringEncoder commonStringEncoderInteger = new CommonStringEncoder(100_000);
   private final CommonStringEncoder.AsByte commonStringEncoderByte = new CommonStringEncoder.AsByte();
 
   @Test
@@ -31,7 +31,7 @@ class CommonStringEncoderTest {
   }
 
   @Test
-  void testByteLimitsTo250() {
+  void testByteLimitsToMax() {
     for (int i = 0; i <= 255; i++) {
       String string = Integer.toString(i);
       byte encoded = commonStringEncoderByte.encode(Integer.toString(i));


### PR DESCRIPTION
Currently, planetiler is limited to 256 total attribute keys due to this being packed in a byte.  This PR changes the attribute key index to an integer, which increases this limit to 2 billion.  Since there's only 83,000 unique keys in the OSM database according to taginfo, this should effectively uncap the attribute limit.

This PR retains the byte limit for layers, because only a madman could possibly want more than 256 layers (famous last words).