### PR TITLE
Bump version to 0.6-SNAPSHOT

### DIFF
--- a/planetiler-benchmarks/pom.xml
+++ b/planetiler-benchmarks/pom.xml
@@ -9,19 +9,19 @@
   <parent>
     <groupId>com.onthegomap.planetiler</groupId>
     <artifactId>planetiler-parent</artifactId>
-    <version>0.5-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <dependencies>
     <dependency>
       <groupId>com.onthegomap.planetiler</groupId>
       <artifactId>planetiler-core</artifactId>
-      <version>${project.parent.version}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.openmaptiles</groupId>
       <artifactId>planetiler-openmaptiles</artifactId>
-      <version>${project.parent.version}</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/planetiler-core/pom.xml
+++ b/planetiler-core/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>com.onthegomap.planetiler</groupId>
     <artifactId>planetiler-parent</artifactId>
-    <version>0.5-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <properties>

--- a/planetiler-custommap/pom.xml
+++ b/planetiler-custommap/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>com.onthegomap.planetiler</groupId>
     <artifactId>planetiler-parent</artifactId>
-    <version>0.5-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <dependencies>

--- a/planetiler-dist/pom.xml
+++ b/planetiler-dist/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>com.onthegomap.planetiler</groupId>
     <artifactId>planetiler-parent</artifactId>
-    <version>0.5-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <properties>

--- a/planetiler-examples/pom.xml
+++ b/planetiler-examples/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>com.onthegomap.planetiler</groupId>
     <artifactId>planetiler-parent</artifactId>
-    <version>0.5-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <dependencies>

--- a/planetiler-examples/standalone.pom.xml
+++ b/planetiler-examples/standalone.pom.xml
@@ -11,7 +11,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>16</maven.compiler.source>
     <maven.compiler.target>16</maven.compiler.target>
-    <planetiler.version>0.5-SNAPSHOT</planetiler.version>
+    <planetiler.version>0.6-SNAPSHOT</planetiler.version>
     <junit.version>5.9.0</junit.version>
     <!-- Replace this with the main class for the profile you add -->
     <mainClass>com.onthegomap.planetiler.examples.BikeRouteOverlay</mainClass>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.onthegomap.planetiler</groupId>
   <artifactId>planetiler-parent</artifactId>
-  <version>0.5-SNAPSHOT</version>
+  <version>${revision}</version>
   <packaging>pom</packaging>
 
   <name>Planetiler Parent</name>
@@ -27,6 +27,7 @@
     <sonar.projectKey>onthegomap_planetiler</sonar.projectKey>
     <sonar.moduleKey>${project.artifactId}</sonar.moduleKey>
     <sonar.exclusions>planetiler-benchmarks/**/*, planetiler-openmaptiles/**/*</sonar.exclusions>
+    <revision>0.6-SNAPSHOT</revision>
   </properties>
 
   <scm>

--- a/scripts/set-versions.sh
+++ b/scripts/set-versions.sh
@@ -9,5 +9,5 @@ fi
 
 version="$1"
 
-./mvnw -B -ntp versions:set-property versions:commit -Dproperty="revision" -DnewVersion="${version}" -f planetiler-examples/standalone.pom.xml
+./mvnw -B -ntp versions:set-property versions:commit -Dproperty="revision" -DnewVersion="${version}"
 ./mvnw -B -ntp versions:set-property versions:commit -Dproperty="planetiler.version" -DnewVersion="${version}" -f planetiler-examples/standalone.pom.xml

--- a/scripts/set-versions.sh
+++ b/scripts/set-versions.sh
@@ -9,5 +9,5 @@ fi
 
 version="$1"
 
-./mvnw -B -ntp versions:set versions:commit -DnewVersion="${version}"
+./mvnw -B -ntp versions:set-property versions:commit -Dproperty="revision" -DnewVersion="${version}" -f planetiler-examples/standalone.pom.xml
 ./mvnw -B -ntp versions:set-property versions:commit -Dproperty="planetiler.version" -DnewVersion="${version}" -f planetiler-examples/standalone.pom.xml


### PR DESCRIPTION
Also change to a revision variable in pom.xml so we don't need to update planetiler-openmaptiles to bump the version (recommended from https://maven.apache.org/maven-ci-friendly.html)