### PR TITLE
Cli add version argument

### DIFF
--- a/planetiler-core/pom.xml
+++ b/planetiler-core/pom.xml
@@ -138,15 +138,15 @@
       <artifactId>guava</artifactId>
       <version>31.1-jre</version>
     </dependency>
-    <dependency>
-      <groupId>de.westemeyer</groupId>
-      <artifactId>artifact-version-service</artifactId>
-      <version>1.1.0</version>
-      <scope>compile</scope>
-    </dependency>
   </dependencies>
 
   <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
     <testResources>
       <testResource>
         <directory>src/test/resources</directory>

--- a/planetiler-core/pom.xml
+++ b/planetiler-core/pom.xml
@@ -138,6 +138,12 @@
       <artifactId>guava</artifactId>
       <version>31.1-jre</version>
     </dependency>
+    <dependency>
+      <groupId>de.westemeyer</groupId>
+      <artifactId>artifact-version-service</artifactId>
+      <version>1.1.0</version>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
@@ -563,14 +563,18 @@ public class Planetiler {
           URL url = urlsOfManifests.nextElement();
           InputStream inputStream = url.openStream();
           if (inputStream != null) {
-            LOGGER.debug("Reading manifest from url: {}", url);
-            Manifest manifest = new Manifest(inputStream);
-            Attributes mainAttributes = manifest.getMainAttributes();
-            LOGGER.info("Implementation-Version: {}", mainAttributes.getValue("Implementation-Version"));
-            LOGGER.info("Implementation-Build: {}", mainAttributes.getValue("Implementation-Build"));
-            LOGGER.info("Implementation-Vendor: {}", mainAttributes.getValue("Implementation-Vendor"));
-            LOGGER.info("Implementation-Timestamp: {}", mainAttributes.getValue("Implementation-Timestamp"));
-            LOGGER.info("Implementation-Title: {}", mainAttributes.getValue("Implementation-Title"));
+            try {
+              LOGGER.debug("Reading manifest from url: {}", url);
+              Manifest manifest = new Manifest(inputStream);
+              Attributes mainAttributes = manifest.getMainAttributes();
+              LOGGER.info("Implementation-Version: {}", mainAttributes.getValue("Implementation-Version"));
+              LOGGER.info("Implementation-Build: {}", mainAttributes.getValue("Implementation-Build"));
+              LOGGER.info("Implementation-Vendor: {}", mainAttributes.getValue("Implementation-Vendor"));
+              LOGGER.info("Implementation-Timestamp: {}", mainAttributes.getValue("Implementation-Timestamp"));
+              LOGGER.info("Implementation-Title: {}", mainAttributes.getValue("Implementation-Title"));
+            } finally {
+              inputStream.close();
+            }
           }
         } catch (Exception e) {
           // Silently ignore wrong manifests on classpath?

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
@@ -557,9 +557,9 @@ public class Planetiler {
       parsed.load(properties);
       LOGGER.info("Planetiler build git hash: {}", parsed.getProperty("githash"));
       LOGGER.info("Planetiler build version: {}", parsed.getProperty("version"));
-      var version = parsed.getProperty("timestamp");
-      if (version != null && !version.isBlank() && version.matches("^\\d+$")) {
-        var time = Instant.ofEpochMilli(Long.parseLong(version));
+      var epochMs = parsed.getProperty("timestamp");
+      if (epochMs != null && !epochMs.isBlank() && epochMs.matches("^\\d+$")) {
+        var time = Instant.ofEpochMilli(Long.parseLong(epochMs));
         LOGGER.info("Planetiler build timestamp: {}", time);
       }
     } catch (IOException e) {

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
@@ -441,10 +441,10 @@ public class Planetiler {
    * @throws Exception                if an error occurs while processing
    */
   public void run() throws Exception {
+    for (Artifact artifact : ArtifactVersionCollector.findArtifactsByGroupId("com.onthegomap.planetiler", true)) {
+      LOGGER.info("module: {} - version: {}", artifact.getArtifactId(), artifact.getVersion());
+    }
     if (arguments.getBoolean("version", "show version then exit", false)) {
-      for (Artifact artifact : ArtifactVersionCollector.findArtifactsByGroupId("com.onthegomap.planetiler", true)) {
-        LOGGER.info(String.format("module: %s - version: %s", artifact.getArtifactId(), artifact.getVersion()));
-      }
       System.exit(0);
     }
 

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
@@ -25,6 +25,8 @@ import com.onthegomap.planetiler.util.ResourceUsage;
 import com.onthegomap.planetiler.util.Translations;
 import com.onthegomap.planetiler.util.Wikidata;
 import com.onthegomap.planetiler.worker.RunnableThatThrows;
+import de.westemeyer.version.model.Artifact;
+import de.westemeyer.version.service.ArtifactVersionCollector;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -439,6 +441,13 @@ public class Planetiler {
    * @throws Exception                if an error occurs while processing
    */
   public void run() throws Exception {
+    if (arguments.getBoolean("version", "show version then exit", false)) {
+      for (Artifact artifact : ArtifactVersionCollector.findArtifactsByGroupId("com.onthegomap.planetiler", true)) {
+        LOGGER.info(String.format("module: %s - version: %s", artifact.getArtifactId(), artifact.getVersion()));
+      }
+      System.exit(0);
+    }
+
     if (profile() == null) {
       throw new IllegalArgumentException("No profile specified");
     }

--- a/planetiler-core/src/main/resources/buildinfo.properties
+++ b/planetiler-core/src/main/resources/buildinfo.properties
@@ -1,0 +1,3 @@
+githash=${buildNumber}
+timestamp=${timestamp}
+version=${revision}

--- a/pom.xml
+++ b/pom.xml
@@ -161,16 +161,32 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>de.westemeyer</groupId>
-        <artifactId>artifact-version-maven-plugin</artifactId>
-        <version>1.1.0</version>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>buildnumber-maven-plugin</artifactId>
+        <version>3.0.0</version>
         <executions>
           <execution>
+            <phase>validate</phase>
             <goals>
-              <goal>generate-service</goal>
+              <goal>create</goal>
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+            </manifest>
+            <manifestEntries>
+              <Implementation-Build>${buildNumber}</Implementation-Build>
+              <Implementation-Timestamp>${maven.build.timestamp}</Implementation-Timestamp>
+            </manifestEntries>
+          </archive>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>com.diffplug.spotless</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,18 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>de.westemeyer</groupId>
+        <artifactId>artifact-version-maven-plugin</artifactId>
+        <version>1.1.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate-service</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>com.diffplug.spotless</groupId>
         <artifactId>spotless-maven-plugin</artifactId>
         <version>2.27.2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
     <sonar.moduleKey>${project.artifactId}</sonar.moduleKey>
     <sonar.exclusions>planetiler-benchmarks/**/*, planetiler-openmaptiles/**/*</sonar.exclusions>
     <revision>0.6-SNAPSHOT</revision>
+    <timestamp>${maven.build.timestamp}</timestamp>
   </properties>
 
   <scm>
@@ -172,21 +173,6 @@
             </goals>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifest>
-              <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-            </manifest>
-            <manifestEntries>
-              <Implementation-Build>${buildNumber}</Implementation-Build>
-              <Implementation-Timestamp>${maven.build.timestamp}</Implementation-Timestamp>
-            </manifestEntries>
-          </archive>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>com.diffplug.spotless</groupId>


### PR DESCRIPTION
I saw https://github.com/onthegomap/planetiler/issues/326 and even though I have no experience with Java I thought it would be easy enough to add.

Let me know if this approach is ok or not.

Running `$ java -jar planetiler-dist/target/planetiler-dist-*-with-deps.jar --version` results in logger printing arguments and versions of modules at the end:
```
(...)
0:00:00 DEB - argument: version=true (show version then exit)
0:00:00 INF - module: planetiler-benchmarks - version: 0.6-SNAPSHOT
0:00:00 INF - module: planetiler-core - version: 0.6-SNAPSHOT
0:00:00 INF - module: planetiler-custommap - version: 0.6-SNAPSHOT
0:00:00 INF - module: planetiler-dist - version: 0.6-SNAPSHOT
0:00:00 INF - module: planetiler-examples - version: 0.6-SNAPSHOT
```