### PR TITLE
use current repo for update-pr/dawidd6/action-download-artifact

### DIFF
--- a/.github/workflows/update-pr.yml
+++ b/.github/workflows/update-pr.yml
@@ -28,7 +28,6 @@ jobs:
           run_id: ${{ github.event.workflow_run.id }}
           name: build-info
           path: build-info
-          repo: onthegomap/planetiler
       - name: 'Get build info'
         id: build_info
         run: echo "::set-output name=pr_number::$(cat build-info/pull_request_number)"


### PR DESCRIPTION
I'd like to run some actions also in a fork but for now hard-coded `onthegomap/planetiler` causes `update-pr` action to fail in fork:

```
Run dawidd6/action-download-artifact@v2
==> Repository: onthegomap/planetiler
==> Artifact name: build-info
==> Local path: build-info
==> Workflow name: 39841294
==> Workflow conclusion: success
Error: Not Found
```
Removing explicit `repo` should cause the action to use "current" repo, i.e. in case of upstream still `onthegomap/planetiler` and in case of a fork the fork repo.

All that to allow me to try things out before submitting upstream.