### PR TITLE
Move NumberFormat to thread-local variable

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/util/Format.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/util/Format.java
@@ -18,29 +18,39 @@ public class Format {
 
   public static final Locale DEFAULT_LOCALE = Locale.getDefault(Locale.Category.FORMAT);
 
+  private static final ConcurrentMap<Locale, Format> instances = new ConcurrentHashMap<>();
+
   // `NumberFormat` instances are not thread safe, so we need to wrap them inside a `ThreadLocal`.
   //
   // Ignore warnings about not removing thread local values since planetiler uses dedicated worker threads that release
   // values when a task is finished and are not re-used.
   @SuppressWarnings("java:S5164")
-  private static final ThreadLocal<ConcurrentMap<Locale, Format>> instances = ThreadLocal.withInitial(
-    ConcurrentHashMap::new);
-
-  private final NumberFormat pf;
-  private final NumberFormat nf;
-  private final NumberFormat intF;
+  private final ThreadLocal<NumberFormat> pf;
+  @SuppressWarnings("java:S5164")
+  private final ThreadLocal<NumberFormat> nf;
+  @SuppressWarnings("java:S5164")
+  private final ThreadLocal<NumberFormat> intF;
 
   private Format(Locale locale) {
-    pf = NumberFormat.getPercentInstance(locale);
-    pf.setMaximumFractionDigits(0);
-    nf = NumberFormat.getNumberInstance(locale);
-    nf.setMaximumFractionDigits(1);
-    intF = NumberFormat.getNumberInstance(locale);
-    intF.setMaximumFractionDigits(0);
+    pf = ThreadLocal.withInitial(() -> {
+      var f = NumberFormat.getPercentInstance(locale);
+      f.setMaximumFractionDigits(0);
+      return f;
+    });
+    nf = ThreadLocal.withInitial(() -> {
+      var f = NumberFormat.getNumberInstance(locale);
+      f.setMaximumFractionDigits(1);
+      return f;
+    });
+    intF = ThreadLocal.withInitial(() -> {
+      var f = NumberFormat.getNumberInstance(locale);
+      f.setMaximumFractionDigits(0);
+      return f;
+    });
   }
 
   public static Format forLocale(Locale locale) {
-    return instances.get().computeIfAbsent(locale, Format::new);
+    return instances.computeIfAbsent(locale, Format::new);
   }
 
   public static Format defaultInstance() {
@@ -121,17 +131,17 @@ public class Format {
 
   /** Returns 0.0-1.0 as a "0%" - "100%" with no decimal points. */
   public String percent(double value) {
-    return pf.format(value);
+    return pf.get().format(value);
   }
 
   /** Returns a number formatted with 1 decimal point. */
   public String decimal(double value) {
-    return nf.format(value);
+    return nf.get().format(value);
   }
 
   /** Returns a number formatted with 0 decimal points. */
   public String integer(Number value) {
-    return intF.format(value);
+    return intF.get().format(value);
   }
 
   /** Returns a duration formatted as fractional seconds with 1 decimal point. */

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/util/Parse.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/util/Parse.java
@@ -19,7 +19,8 @@ public class Parse {
     Pattern.compile(
       "(?<value>-?[\\d.]+)\\s*((?<mi>mi)|(?<m>m|$)|(?<km>km|kilom)|(?<ft>ft|')|(?<in>in|\")|(?<nmi>nmi|international nautical mile|nautical))",
       Pattern.CASE_INSENSITIVE);
-  private static final NumberFormat PARSER = NumberFormat.getNumberInstance(Locale.ROOT);
+  private static final ThreadLocal<NumberFormat> PARSER =
+    ThreadLocal.withInitial(() -> NumberFormat.getNumberInstance(Locale.ROOT));
 
   private Parse() {}
 
@@ -41,7 +42,7 @@ public class Parse {
   private static <T> T retryParseNumber(Object obj, Function<Number, T> getter, T backup) {
     // more expensive parser in case simple valueOf parse fails
     try {
-      return getter.apply(PARSER.parse(obj.toString()));
+      return getter.apply(PARSER.get().parse(obj.toString()));
     } catch (ParseException e) {
       return backup;
     }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/util/Parse.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/util/Parse.java
@@ -19,6 +19,9 @@ public class Parse {
     Pattern.compile(
       "(?<value>-?[\\d.]+)\\s*((?<mi>mi)|(?<m>m|$)|(?<km>km|kilom)|(?<ft>ft|')|(?<in>in|\")|(?<nmi>nmi|international nautical mile|nautical))",
       Pattern.CASE_INSENSITIVE);
+  // Ignore warnings about not removing thread local values since planetiler uses dedicated worker threads that release
+  // values when a task is finished and are not re-used.
+  @SuppressWarnings("java:S5164")
   private static final ThreadLocal<NumberFormat> PARSER =
     ThreadLocal.withInitial(() -> NumberFormat.getNumberInstance(Locale.ROOT));
 


### PR DESCRIPTION
The `NumberFormat` class isn't thread safe ([StackOverflow], [Docs]), and sharing one instance across threads allowed for races which resulted in otherwise valid OSM tags not being parsed correctly.

This surfaced as some rather strange exceptions during Planetiler runs that I wasn't able to reproduce when running each input individually. For example, both of these exceptions were not reproducible in unit tests:

```
java.lang.NumberFormatException: For input string: ""
java.lang.NumberFormatException: For input string: "1."
```

Given that it's a race condition, I'm not sure how to write a proper test for this, but this change reliably fixes the issue for me during local runs, and the existing tests for `Parse` should at least confirm that there aren't regressions.

[StackOverflow]: https://stackoverflow.com/a/1285297
[Docs]: https://docs.oracle.com/javase/8/docs/api/java/text/NumberFormat.html
