### PR TITLE
Fix NPE for `OsmReader#estimateMemoryUsageBytes()`

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/osm/OsmReader.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/osm/OsmReader.java
@@ -541,7 +541,7 @@ public class OsmReader implements Closeable, MemoryEstimator.HasEstimate {
   @Override
   public long estimateMemoryUsageBytes() {
     long size = 0;
-    size += waysInMultipolygon.serializedSizeInBytes();
+    size += waysInMultipolygon == null ? 0 : waysInMultipolygon.serializedSizeInBytes();
     // multipolygonWayGeometries is reported separately
     size += estimateSize(wayToRelations);
     size += estimateSize(relationInfo);


### PR DESCRIPTION
A `NullPointerException` was thrown when this method was called after calling `close()` (which happens when using the `PrometheusStats` client).

```
Exception in thread "main" java.lang.NullPointerException: Cannot invoke "org.roaringbitmap.longlong.Roaring64Bitmap.serializedSizeInBytes()" because "this.waysInMultipolygon" is null
	at com.onthegomap.planetiler.reader.osm.OsmReader.estimateMemoryUsageBytes(OsmReader.java:545)
	at com.onthegomap.planetiler.stats.PrometheusStats$HeapObjectSizeCollector.collect(PrometheusStats.java:288)
	at io.prometheus.client.Collector.collect(Collector.java:45)
	at io.prometheus.client.CollectorRegistry$MetricFamilySamplesEnumeration.findNextElement(CollectorRegistry.java:204)
	at io.prometheus.client.CollectorRegistry$MetricFamilySamplesEnumeration.nextElement(CollectorRegistry.java:219)
	at io.prometheus.client.CollectorRegistry$MetricFamilySamplesEnumeration.nextElement(CollectorRegistry.java:152)
	at io.prometheus.client.exporter.common.TextFormat.write004(TextFormat.java:71)
	at io.prometheus.client.exporter.PushGateway.doRequest(PushGateway.java:248)
	at io.prometheus.client.exporter.PushGateway.push(PushGateway.java:112)
	at com.onthegomap.planetiler.stats.PrometheusStats.push(PrometheusStats.java:98)
	at com.onthegomap.planetiler.stats.PrometheusStats.close(PrometheusStats.java:209)
	at com.onthegomap.planetiler.Planetiler.run(Planetiler.java:588)
	at org.openmaptiles.OpenMapTilesMain.run(OpenMapTilesMain.java:55)
```