### PR TITLE
Remove outdated reference to "relation_member" type

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/expression/Expression.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/expression/Expression.java
@@ -117,7 +117,6 @@ public interface Expression extends Simplifiable<Expression> {
    * <li>"linestring"</li>
    * <li>"point"</li>
    * <li>"polygon"</li>
-   * <li>"relation_member"</li>
    * </ul>
    */
   static MatchType matchType(String type) {


### PR DESCRIPTION
Support was removed in #323, and trying to use `matchType("relation_member")` will currently throw an exception