### PR TITLE
Fix max tile size in stats output.

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/mbtiles/MbtilesWriter.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/mbtiles/MbtilesWriter.java
@@ -391,6 +391,7 @@ public class MbtilesWriter {
       sumSize += totalSize;
       sumCount += totalCount;
       long maxSize = maxTileSizesByZoom[z].get();
+      maxMax = Math.max(maxMax, maxSize);
       LOGGER.debug("z{} avg:{} max:{}",
         z,
         format.storage(totalCount == 0 ? 0 : (totalSize / totalCount), false),


### PR DESCRIPTION
Another tiny fix - `printTileStats()` was always printing something like `0:01:12 DEB [mbtiles] - all avg:715 max:0` because the variable wasn't being updated.