### PR TITLE
Add shapefile directory source

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/NaturalEarthReader.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/NaturalEarthReader.java
@@ -76,7 +76,7 @@ public class NaturalEarthReader extends SimpleReader {
   public static void process(String sourceName, Path input, Path tmpDir, FeatureGroup writer, PlanetilerConfig config,
     Profile profile, Stats stats) {
     try (var reader = new NaturalEarthReader(sourceName, input, tmpDir, profile, stats)) {
-      reader.process(writer, config);
+      reader.process(writer, config, true);
     }
   }
 

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/ShapefileReader.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/ShapefileReader.java
@@ -87,12 +87,13 @@ public class ShapefileReader extends SimpleReader implements Closeable {
    * @param config           user-defined parameters controlling number of threads and log interval
    * @param profile          logic that defines what map features to emit for each source feature
    * @param stats            to keep track of counters and timings
+   * @param logStage         whether to start a new logging stage for this shapefile
    * @throws IllegalArgumentException if a problem occurs reading the input file
    */
   public static void processWithProjection(String sourceProjection, String sourceName, Path input, FeatureGroup writer,
-    PlanetilerConfig config, Profile profile, Stats stats) {
+    PlanetilerConfig config, Profile profile, Stats stats, boolean logStage) {
     try (var reader = new ShapefileReader(sourceProjection, sourceName, input, profile, stats)) {
-      reader.process(writer, config);
+      reader.process(writer, config, logStage);
     }
   }
 
@@ -111,7 +112,7 @@ public class ShapefileReader extends SimpleReader implements Closeable {
   public static void process(String sourceName, Path input, FeatureGroup writer, PlanetilerConfig config,
     Profile profile,
     Stats stats) {
-    processWithProjection(null, sourceName, input, writer, config, profile, stats);
+    processWithProjection(null, sourceName, input, writer, config, profile, stats, true);
   }
 
   private static URI findShpFile(Path path, Stream<Path> walkStream) {

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/SimpleReader.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/SimpleReader.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
  * multi-pass processing.
  * <p>
  * Implementations provide features through {@link #read()} and {@link #getCount()} and this class handles processing
- * them in parallel according to the profile in {@link #process(FeatureGroup, PlanetilerConfig)}.
+ * them in parallel according to the profile in {@link #process(FeatureGroup, PlanetilerConfig, boolean)}.
  */
 public abstract class SimpleReader implements Closeable {
 
@@ -43,11 +43,12 @@ public abstract class SimpleReader implements Closeable {
   /**
    * Renders map features for all elements from this data source based on the mapping logic defined in {@code profile}.
    *
-   * @param writer consumer for rendered features
-   * @param config user-defined parameters controlling number of threads and log interval
+   * @param writer   consumer for rendered features
+   * @param config   user-defined parameters controlling number of threads and log interval
+   * @param logStage whether to start a new logging stage when processing this source
    */
-  public final void process(FeatureGroup writer, PlanetilerConfig config) {
-    var timer = stats.startStage(sourceName);
+  public final void process(FeatureGroup writer, PlanetilerConfig config, boolean logStage) {
+    var timer = stats.startStage(sourceName, logStage);
     long featureCount = getCount();
     int writeThreads = config.featureWriteThreads();
     int processThreads = config.featureProcessThreads();

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
@@ -108,7 +108,7 @@ class PlanetilerTests {
 
       @Override
       public void close() {}
-    }.process(featureGroup, config);
+    }.process(featureGroup, config, true);
   }
 
   private void processOsmFeatures(FeatureGroup featureGroup, Profile profile, PlanetilerConfig config,

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
@@ -1661,6 +1661,7 @@ class PlanetilerTests {
       .addOsmSource("osm", tempOsm)
       .addNaturalEarthSource("ne", TestUtils.pathToResource("natural_earth_vector.sqlite"))
       .addShapefileSource("shapefile", TestUtils.pathToResource("shapefile.zip"))
+      .addShapefileDirectorySource("shapefiledir", TestUtils.pathToResource(""), "shapefile*.zip")
       .setOutput("mbtiles", mbtiles)
       .run();
 


### PR DESCRIPTION
This PR adds `Planetiler.addShapefileDirectorySource`, which can be used to add all Shapefiles matching a glob pattern in a directory to a single named source. Other than grouping related shapefiles together, the main benefit here is that the files can then be processed concurrently.

Was mentioned in Slack a couple weeks back: https://osmus.slack.com/archives/C031V9E9RMG/p1668717797875339