### PR TITLE
Extract ZIP file walker out of ShapefileReader.

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
@@ -328,7 +328,10 @@ public class Planetiler {
     Path path = getPath(name, "shapefile", defaultPath, defaultUrl);
     return addStage(name, "Process features in " + path,
       ifSourceUsed(name, () -> {
-        var sourcePaths = FileUtils.hasExtension(path, "zip") ? globMatchPath(path, "*.shp") : List.of(path);
+        List<Path> sourcePaths = List.of(path);
+        if (FileUtils.hasExtension(path, "zip") || Files.isDirectory(path)) {
+          sourcePaths = globMatchPath(path, "*.shp");
+        }
 
         ShapefileReader.processWithProjection(projection, name, sourcePaths, featureGroup, config, profile, stats);
       }));

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/ShapefileReader.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/ShapefileReader.java
@@ -4,17 +4,12 @@ import com.onthegomap.planetiler.Profile;
 import com.onthegomap.planetiler.collection.FeatureGroup;
 import com.onthegomap.planetiler.config.PlanetilerConfig;
 import com.onthegomap.planetiler.stats.Stats;
-import com.onthegomap.planetiler.util.FileUtils;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.net.URI;
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.function.Consumer;
-import java.util.stream.Stream;
 import org.geotools.data.FeatureSource;
 import org.geotools.data.shapefile.ShapefileDataStore;
 import org.geotools.feature.FeatureCollection;
@@ -96,34 +91,9 @@ public class ShapefileReader extends SimpleReader<SimpleFeature> {
     );
   }
 
-  private static URI findShpFile(Path path, Stream<Path> walkStream) {
-    return walkStream
-      .filter(z -> FileUtils.hasExtension(z, "shp"))
-      .findFirst()
-      .orElseThrow(() -> new IllegalArgumentException("No .shp file found inside " + path))
-      .toUri();
-  }
-
   private ShapefileDataStore open(Path path) {
     try {
-      URI uri;
-      if (Files.isDirectory(path)) {
-        try (var walkStream = Files.walk(path)) {
-          uri = findShpFile(path, walkStream);
-        }
-      } else if (FileUtils.hasExtension(path, "zip")) {
-        try (
-          var zipFs = FileSystems.newFileSystem(path);
-          var walkStream = FileUtils.walkFileSystem(zipFs)
-        ) {
-          uri = findShpFile(path, walkStream);
-        }
-      } else if (FileUtils.hasExtension(path, "shp")) {
-        uri = path.toUri();
-      } else {
-        throw new IllegalArgumentException("Invalid shapefile input: " + path + " must be zip or shp");
-      }
-      var store = new ShapefileDataStore(uri.toURL());
+      var store = new ShapefileDataStore(path.toUri().toURL());
       store.setTryCPGFile(true);
       return store;
     } catch (IOException e) {

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/reader/ShapefileReaderTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/reader/ShapefileReaderTest.java
@@ -29,16 +29,9 @@ class ShapefileReaderTest {
 
   @Test
   @Timeout(30)
-  void testReadShapefile() {
-    testReadShapefile(TestUtils.pathToResource("shapefile.zip"));
-  }
-
-  @Test
-  @Timeout(30)
   @DisabledOnOs(OS.WINDOWS) // the zip file doesn't fully close, which causes trouble running test on windows
   void testReadShapefileExtracted() throws IOException {
     var extracted = TestUtils.extractPathToResource(tempDir, "shapefile.zip");
-    testReadShapefile(extracted);
     try (var fs = FileSystems.newFileSystem(extracted)) {
       var path = fs.getPath("shapefile", "stations.shp");
       testReadShapefile(path);
@@ -50,7 +43,6 @@ class ShapefileReaderTest {
   void testReadShapefileUnzipped() throws IOException {
     var dest = tempDir.resolve("shapefile.zip");
     FileUtils.unzipResource("/shapefile.zip", dest);
-    testReadShapefile(dest);
     testReadShapefile(dest.resolve("shapefile").resolve("stations.shp"));
   }
 

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/util/FileUtilsTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/util/FileUtilsTest.java
@@ -4,11 +4,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.onthegomap.planetiler.TestUtils;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -84,5 +88,58 @@ class FileUtilsTest {
       "UTF8",
       Files.readString(dest.resolve("shapefile").resolve("stations.cpg"))
     );
+  }
+
+  @Test
+  void testWalkPathWithPatternDirectory() throws IOException {
+    Path parent = tmpDir.resolve(Path.of("a", "b", "c"));
+    FileUtils.createDirectory(parent);
+
+    List<Path> txtFiles = Stream.of("1.txt", "2.txt").map(parent::resolve).toList();
+
+    for (var file : txtFiles) {
+      Files.write(file, new byte[]{});
+    }
+
+    Files.write(parent.resolve("something-that-doesnt-match.blah"), new byte[]{});
+
+    var matchingPaths = FileUtils.walkPathWithPattern(parent, "*.txt");
+
+    assertEquals(
+      txtFiles.stream().sorted().toList(),
+      matchingPaths.stream().sorted().toList()
+    );
+  }
+
+  @Test
+  void testWalkPathWithPatternDirectoryZip() throws IOException {
+    Path parent = tmpDir.resolve(Path.of("a", "b", "c"));
+    FileUtils.createDirectory(parent);
+
+    Path zipFile = parent.resolve("fake-zip-file.zip");
+
+    Files.write(zipFile, new byte[]{});
+    Files.write(parent.resolve("something-that-doesnt-match.blah"), new byte[]{});
+
+    Function<Path, List<Path>> mockWalkZipFile = zipPath -> List.of(zipPath.resolve("inner.txt"));
+
+    // When we don't provide a callback to recurse into zip files, the path to the zip
+    // itself should be returned.
+    assertEquals(List.of(zipFile), FileUtils.walkPathWithPattern(parent, "*.zip"));
+
+    // Otherwise, the files inside the zip should be returned.
+    assertEquals(List.of(zipFile.resolve("inner.txt")),
+      FileUtils.walkPathWithPattern(parent, "*.zip", mockWalkZipFile));
+  }
+
+  @Test
+  void testWalkPathWithPatternSingleZip() {
+    Path zipPath = TestUtils.pathToResource("shapefile.zip");
+
+    var matchingPaths = FileUtils.walkPathWithPattern(zipPath, "stations.sh[px]");
+
+    assertEquals(
+      List.of("/shapefile/stations.shp", "/shapefile/stations.shx"),
+      matchingPaths.stream().map(Path::toString).sorted().toList());
   }
 }


### PR DESCRIPTION
This PR pulls ZIP file handling out of `ShapefileReader` so that it can be reused for different readers. The changes here can be applied to other reader types as we add them.

Added:

- support for reading multiple `.shp` files from a single `.zip`
- support glob matching within a `.zip` file

There's a breaking change in naming: `addShapefileDirectorySource` becomes `addShapefileGlobSource`. I figured `addShapefileDirectorySource` was new enough that the more accurate name was worth the churn, as the pattern can now be applied both to ZIP archives and directories.

Another change in behavior: previously, if you had a `.zip` with two `.shp` files, only one would be read. Now (unless a glob pattern filters one out), both will be read.