### PR TITLE
Add planetiler-specific metadata

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/config/MbtilesMetadata.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/config/MbtilesMetadata.java
@@ -2,6 +2,9 @@ package com.onthegomap.planetiler.config;
 
 import com.onthegomap.planetiler.Profile;
 import com.onthegomap.planetiler.mbtiles.MbtilesWriter;
+import com.onthegomap.planetiler.util.BuildInfo;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /** Controls information that {@link MbtilesWriter} will write to the mbtiles metadata table. */
 public record MbtilesMetadata(
@@ -9,7 +12,8 @@ public record MbtilesMetadata(
   String description,
   String attribution,
   String version,
-  String type
+  String type,
+  Map<String, String> planetilerSpecific
 ) {
 
   public MbtilesMetadata(Profile profile) {
@@ -18,7 +22,8 @@ public record MbtilesMetadata(
       profile.description(),
       profile.attribution(),
       profile.version(),
-      profile.isOverlay() ? "overlay" : "baselayer"
+      profile.isOverlay() ? "overlay" : "baselayer",
+      mapWithBuildInfo()
     );
   }
 
@@ -29,7 +34,32 @@ public record MbtilesMetadata(
       args.getString("mbtiles_attribution", "'attribution' attribute for mbtiles metadata", profile.attribution()),
       args.getString("mbtiles_version", "'version' attribute for mbtiles metadata", profile.version()),
       args.getString("mbtiles_type", "'type' attribute for mbtiles metadata",
-        profile.isOverlay() ? "overlay" : "baselayer")
+        profile.isOverlay() ? "overlay" : "baselayer"),
+      mapWithBuildInfo()
     );
+  }
+
+  private static Map<String, String> mapWithBuildInfo() {
+    Map<String, String> result = new LinkedHashMap<>();
+    var buildInfo = BuildInfo.get();
+    if (buildInfo != null) {
+      if (buildInfo.version() != null) {
+        result.put("planetiler:version", buildInfo.version());
+      }
+      if (buildInfo.githash() != null) {
+        result.put("planetiler:githash", buildInfo.githash());
+      }
+      if (buildInfo.buildTimeString() != null) {
+        result.put("planetiler:buildtime", buildInfo.buildTimeString());
+      }
+    }
+    return result;
+  }
+
+  public MbtilesMetadata set(String key, Object value) {
+    if (key != null && value != null) {
+      planetilerSpecific.put(key, value.toString());
+    }
+    return this;
   }
 }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/mbtiles/MbtilesWriter.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/mbtiles/MbtilesWriter.java
@@ -326,7 +326,7 @@ public class MbtilesWriter {
       db.createTablesWithIndexes();
     }
 
-    db.metadata()
+    var metadata = db.metadata()
       .setName(mbtilesMetadata.name())
       .setFormat("pbf")
       .setDescription(mbtilesMetadata.description())
@@ -337,6 +337,10 @@ public class MbtilesWriter {
       .setMinzoom(config.minzoom())
       .setMaxzoom(config.maxzoom())
       .setJson(layerStats.getTileStats());
+
+    for (var entry : mbtilesMetadata.planetilerSpecific().entrySet()) {
+      metadata.setMetadata(entry.getKey(), entry.getValue());
+    }
 
     TileCoord lastTile = null;
     Timer time = null;

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/util/BuildInfo.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/util/BuildInfo.java
@@ -1,0 +1,45 @@
+package com.onthegomap.planetiler.util;
+
+import com.onthegomap.planetiler.Planetiler;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Properties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/** Accessor for the build info inserted by maven into the {@code buildinfo.properties} file. */
+public record BuildInfo(String githash, String version, Long buildTime) {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(BuildInfo.class);
+
+  private static final BuildInfo instance;
+  static {
+    BuildInfo result = null;
+    try (var properties = Planetiler.class.getResourceAsStream("/buildinfo.properties")) {
+      var parsed = new Properties();
+      parsed.load(properties);
+      String githash = parsed.getProperty("githash");
+      String version = parsed.getProperty("version");
+      String epochMs = parsed.getProperty("timestamp");
+      Long buildTime = null;
+
+      if (epochMs != null && !epochMs.isBlank() && epochMs.matches("^\\d+$")) {
+        buildTime = Long.parseLong(epochMs);
+      }
+      result = new BuildInfo(githash, version, buildTime);
+    } catch (IOException e) {
+      LOGGER.error("Error getting build properties");
+    }
+    instance = result;
+  }
+
+  public String buildTimeString() {
+    return buildTime == null ? null : Instant.ofEpochMilli(buildTime).toString();
+  }
+
+  /** Returns info inserted by maven at build-time into the {@code buildinfo.properties} file. */
+  public static BuildInfo get() {
+    return instance;
+  }
+}

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
@@ -23,6 +23,7 @@ import com.onthegomap.planetiler.reader.osm.OsmElement;
 import com.onthegomap.planetiler.reader.osm.OsmReader;
 import com.onthegomap.planetiler.reader.osm.OsmRelationInfo;
 import com.onthegomap.planetiler.stats.Stats;
+import com.onthegomap.planetiler.util.BuildInfo;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -247,6 +248,9 @@ class PlanetilerTests {
       "maxzoom", "14",
       "center", "0,0,0",
       "bounds", "-180,-85.05113,180,85.05113"
+    ), results.metadata);
+    assertSubmap(Map.of(
+      "planetiler:version", BuildInfo.get().version()
     ), results.metadata);
     assertSameJson(
       """
@@ -1683,6 +1687,12 @@ class PlanetilerTests {
 
       assertEquals(11, tileMap.size(), "num tiles");
       assertEquals(2146, features, "num buildings");
+      assertSubmap(Map.of(
+        "planetiler:version", BuildInfo.get().version(),
+        "planetiler:osm:osmosisreplicationtime", "2021-04-21T20:21:46Z",
+        "planetiler:osm:osmosisreplicationseq", "2947",
+        "planetiler:osm:osmosisreplicationurl", "http://download.geofabrik.de/europe/monaco-updates"
+      ), db.metadata().getAll());
     }
   }
 


### PR DESCRIPTION
Fix #120 by adding planetiler-specific metadata (planetiler and OSM build times and version numbers) to generated mbtiles files.

The metadata table now looks like:

```
sqlite> select * from metadata where name like 'planetiler:%';
planetiler:version|0.6-SNAPSHOT
planetiler:githash|89de82244e151ddb821f176862bc2f7c4a5439b0
planetiler:buildtime|2023-01-02T15:36:21.869Z
planetiler:osm:osmosisreplicationtime|2022-07-19T20:21:59Z
planetiler:osm:osmosisreplicationseq|3397
planetiler:osm:osmosisreplicationurl|http://download.geofabrik.de/europe/monaco-updates
```

And the tilejson endpoint from tileserver-gl includes:

```json
{
  "planetiler:version": "0.6-SNAPSHOT",
  "planetiler:githash": "89de82244e151ddb821f176862bc2f7c4a5439b0",
  "planetiler:buildtime": "2023-01-02T15:36:21.869Z",
  "planetiler:osm:osmosisreplicationtime": "2022-07-19T20:21:59Z",
  "planetiler:osm:osmosisreplicationseq": "3397",
  "planetiler:osm:osmosisreplicationurl": "http://download.geofabrik.de/europe/monaco-updates"
}
```