### PR TITLE
Add layer to shapefile

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/ShapefileReader.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/ShapefileReader.java
@@ -37,10 +37,12 @@ public class ShapefileReader extends SimpleReader<SimpleFeature> {
   private final FeatureCollection<SimpleFeatureType, org.opengis.feature.simple.SimpleFeature> inputSource;
   private final String[] attributeNames;
   private final ShapefileDataStore dataStore;
+  private final String layer;
   private MathTransform transformToLatLon;
 
   public ShapefileReader(String sourceProjection, String sourceName, Path input) {
     super(sourceName);
+    this.layer = input.getFileName().toString().replaceAll("\\.shp$", "");
     dataStore = open(input);
     try {
       String typeName = dataStore.getTypeNames()[0];
@@ -119,7 +121,7 @@ public class ShapefileReader extends SimpleReader<SimpleFeature> {
         }
         if (latLonGeometry != null) {
           SimpleFeature geom = SimpleFeature.create(latLonGeometry, new HashMap<>(attributeNames.length),
-            sourceName, null, ++id);
+            sourceName, layer, ++id);
           for (int i = 1; i < attributeNames.length; i++) {
             geom.setTag(attributeNames[i], feature.getAttribute(i));
           }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
@@ -1697,7 +1697,8 @@ class PlanetilerTests {
         public void processFeature(SourceFeature source, FeatureCollector features) {
           features.point("stations")
             .setZoomRange(0, 14)
-            .setAttr("source", source.getSource());
+            .setAttr("source", source.getSource())
+            .setAttr("layer", source.getSourceLayer());
         }
       })
       // Match *.shp within [shapefile.zip, shapefile-copy.zip]
@@ -1715,7 +1716,7 @@ class PlanetilerTests {
       for (var tile : tileMap.values()) {
         for (var feature : tile) {
           feature.geometry().validate();
-
+          assertEquals("stations", feature.attrs().get("layer"));
           switch ((String) feature.attrs().get("source")) {
             case "shapefile" -> fileCount++;
             case "shapefile-glob" -> globCount++;


### PR DESCRIPTION
Add source-layer attribute to features read from a shapefile parsed from the file name without ".shp" extension now that we can read more than one shapefile at a time.