### PR TITLE
Support `--area=planet` in shortbread schema

### DIFF
--- a/planetiler-custommap/src/main/resources/samples/shortbread.yml
+++ b/planetiler-custommap/src/main/resources/samples/shortbread.yml
@@ -8,7 +8,7 @@ args:
     default: massachusetts
   osm_url:
     description: OSM URL to download
-    default: '${ "geofabrik:" + args.area }'
+    default: '${ args.area == "planet" ? "aws:latest" : ("geofabrik:" + args.area) }'
 sources:
   ocean:
     type: shapefile


### PR DESCRIPTION
Fix #417 by mapping `--area=planet` to download it's input from the latest AWS open data registry file.