### PR TITLE
Tile hashing fix

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/VectorTile.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/VectorTile.java
@@ -523,6 +523,19 @@ public class VectorTile {
     return !empty;
   }
 
+  public boolean likelyToBeDuplicate() {
+    if (layers.size() <= 0) {
+      return true;
+    } else if (layers.size() == 1 && layers.values().stream().findFirst().get().encodedFeatures.isEmpty()) {
+      return true;
+    }
+    var result = containsOnlyFillsOrEdges();
+    if (result) {
+      return true;
+    }
+    return result;
+  }
+
   private enum Command {
     MOVE_TO(1),
     LINE_TO(2),

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/VectorTile.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/VectorTile.java
@@ -532,13 +532,13 @@ public class VectorTile {
    * generating mbtiles which are too big. This method is responsible for achieving that balance.
    * <p>
    * Current understanding is, that for the whole planet, there are 267m total tiles and 38m unique tiles. The
-   * {@link #containsOnlyFills()} heuristic catches >99.9% of repeated tiles and cuts down the number of tile hashes we
-   * need to track by 98% (38m to 735k). So it is considered a good tradeoff.
+   * {@link #containsOnlyFillsOrEdges()} heuristic catches >99.9% of repeated tiles and cuts down the number of tile
+   * hashes we need to track by 98% (38m to 735k). So it is considered a good tradeoff.
    *
    * @return {@code true} if the tile might have duplicates hence we want to calculate a hash for it
    */
   public boolean likelyToBeDuplicated() {
-    return layers.values().stream().allMatch(v -> v.encodedFeatures.isEmpty()) || containsOnlyFills();
+    return layers.values().stream().allMatch(v -> v.encodedFeatures.isEmpty()) || containsOnlyFillsOrEdges();
   }
 
   private enum Command {

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/collection/FeatureGroup.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/collection/FeatureGroup.java
@@ -12,7 +12,6 @@ import com.onthegomap.planetiler.stats.Stats;
 import com.onthegomap.planetiler.util.CloseableConusmer;
 import com.onthegomap.planetiler.util.CommonStringEncoder;
 import com.onthegomap.planetiler.util.DiskBacked;
-import com.onthegomap.planetiler.util.Hashing;
 import com.onthegomap.planetiler.util.LayerStats;
 import com.onthegomap.planetiler.worker.Worker;
 import java.io.Closeable;
@@ -366,22 +365,6 @@ public final class FeatureGroup implements Iterable<FeatureGroup.TileFeatures>, 
 
     public TileCoord tileCoord() {
       return tileCoord;
-    }
-
-    /**
-     * Generates a hash over the feature's relevant data: layer, geometry, and attributes. The coordinates are
-     * <b>not</b> part of the hash.
-     * <p>
-     * Used as an optimization to avoid writing the same (ocean) tiles over and over again.
-     */
-    public long generateContentHash() {
-      long hash = Hashing.FNV1_64_INIT;
-      for (var feature : entries) {
-        byte layerId = extractLayerIdFromKey(feature.key());
-        hash = Hashing.fnv1a64(hash, layerId);
-        hash = Hashing.fnv1a64(hash, feature.value());
-      }
-      return hash;
     }
 
     /**

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/mbtiles/MbtilesWriter.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/mbtiles/MbtilesWriter.java
@@ -290,7 +290,7 @@ public class MbtilesWriter {
           lastEncoded = encoded;
           lastBytes = bytes;
           last = tileFeatures;
-          if (compactDb && en.likelyToBeDuplicate() && bytes != null) {
+          if (compactDb && en.likelyToBeDuplicated() && bytes != null) {
             tileDataHash = generateContentHash(bytes);
           } else {
             tileDataHash = null;
@@ -419,9 +419,7 @@ public class MbtilesWriter {
    * Used as an optimization to avoid writing the same (mostly ocean) tiles over and over again.
    */
   public static long generateContentHash(byte[] bytes) {
-    long hash = Hashing.FNV1_64_INIT;
-    hash = Hashing.fnv1a64(hash, bytes);
-    return hash;
+    return Hashing.fnv1a64(bytes);
   }
 
   /**

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/mbtiles/MbtilesWriter.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/mbtiles/MbtilesWriter.java
@@ -289,7 +289,7 @@ public class MbtilesWriter {
           lastEncoded = encoded;
           lastBytes = bytes;
           last = tileFeatures;
-          if (compactDb && en.containsOnlyFillsOrEdges()) {
+          if (compactDb && en.likelyToBeDuplicate()) {
             tileDataHash = tileFeatures.generateContentHash();
           } else {
             tileDataHash = null;

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/collection/FeatureGroupTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/collection/FeatureGroupTest.java
@@ -365,16 +365,16 @@ class FeatureGroupTest {
     put(args1);
     sorter.sort();
     var iter = features.iterator();
-    var tile0_hash = MbtilesWriter.generateContentHash(
+    var tileHash0 = MbtilesWriter.generateContentHash(
       Gzip.gzip(iter.next().getVectorTileEncoder().encode())
     );
-    var tile1_hash = MbtilesWriter.generateContentHash(
+    var tileHash1 = MbtilesWriter.generateContentHash(
       Gzip.gzip(iter.next().getVectorTileEncoder().encode())
     );
     if (expectSame) {
-      assertEquals(tile0_hash, tile1_hash);
+      assertEquals(tileHash0, tileHash1);
     } else {
-      assertNotEquals(tile0_hash, tile1_hash);
+      assertNotEquals(tileHash0, tileHash1);
     }
   }
 

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/collection/FeatureGroupTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/collection/FeatureGroupTest.java
@@ -12,9 +12,12 @@ import com.onthegomap.planetiler.Profile;
 import com.onthegomap.planetiler.VectorTile;
 import com.onthegomap.planetiler.geo.GeometryType;
 import com.onthegomap.planetiler.geo.TileCoord;
+import com.onthegomap.planetiler.mbtiles.MbtilesWriter;
 import com.onthegomap.planetiler.render.RenderedFeature;
 import com.onthegomap.planetiler.stats.Stats;
 import com.onthegomap.planetiler.util.CloseableConusmer;
+import com.onthegomap.planetiler.util.Gzip;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -356,17 +359,22 @@ class FeatureGroupTest {
 
   @ParameterizedTest(name = "{0}")
   @ArgumentsSource(SameFeatureGroupTestArgs.class)
-  void testGenerateContentHash(String testName, boolean expectSame, PuTileArgs args0, PuTileArgs args1) {
+  void testGenerateContentHash(String testName, boolean expectSame, PuTileArgs args0, PuTileArgs args1)
+    throws IOException {
     put(args0);
     put(args1);
     sorter.sort();
     var iter = features.iterator();
-    var tile0 = iter.next();
-    var tile1 = iter.next();
+    var tile0_hash = MbtilesWriter.generateContentHash(
+      Gzip.gzip(iter.next().getVectorTileEncoder().encode())
+    );
+    var tile1_hash = MbtilesWriter.generateContentHash(
+      Gzip.gzip(iter.next().getVectorTileEncoder().encode())
+    );
     if (expectSame) {
-      assertEquals(tile0.generateContentHash(), tile1.generateContentHash());
+      assertEquals(tile0_hash, tile1_hash);
     } else {
-      assertNotEquals(tile0.generateContentHash(), tile1.generateContentHash());
+      assertNotEquals(tile0_hash, tile1_hash);
     }
   }
 

--- a/planetiler-examples/src/test/java/com/onthegomap/planetiler/examples/BikeRouteOverlayTest.java
+++ b/planetiler-examples/src/test/java/com/onthegomap/planetiler/examples/BikeRouteOverlayTest.java
@@ -110,6 +110,9 @@ class BikeRouteOverlayTest {
           "name", "EuroVelo 8 - Mediterranean Route - part Monaco",
           "ref", "EV8"
         ), GeoUtils.WORLD_LAT_LON_BOUNDS, 25, LineString.class);
+
+      // FIXME: we would like to have 0 duplicates
+      TestUtils.assertTileDuplicates(mbtiles, 5);
     }
   }
 }

--- a/planetiler-examples/src/test/java/com/onthegomap/planetiler/examples/BikeRouteOverlayTest.java
+++ b/planetiler-examples/src/test/java/com/onthegomap/planetiler/examples/BikeRouteOverlayTest.java
@@ -111,8 +111,7 @@ class BikeRouteOverlayTest {
           "ref", "EV8"
         ), GeoUtils.WORLD_LAT_LON_BOUNDS, 25, LineString.class);
 
-      // FIXME: we would like to have 0 duplicates
-      TestUtils.assertTileDuplicates(mbtiles, 5);
+      TestUtils.assertTileDuplicates(mbtiles, 0);
     }
   }
 }


### PR DESCRIPTION
While generating maps for Slovakia and some other countries I've noticed that certain tiles are still stored in the .mbtiles more than once, e.g. with same encoded content, despite what was done in PR #219 .

For smaller maps (like for Slovakia), following can be used directly in SQLite to detect duplicates:

```
SELECT count(tile_data_id) as id_count, group_concat(tile_data_id) as id_list, substr(hex(tile_data), 0, 200) as tile_data_hex FROM tiles_data GROUP BY hex(tile_data) ORDER BY id_count DESC LIMIT 3;
```

result:

```
5|1267,1301,4515,16422,16423|1F8B08000000000000FF9312E1E2CDCD2FCD2B49CCCC8B2F484DCCD66850A860020067B86CD116000000
3|703,2324,7959|1F8B08000000000000FF03000000000000000000
1|19366|1F8B08000000000000FFEDBD696053D5D63FDC7D4E86739234C3C9D06427CDD434C3E994A94D9B4EA0800828C8E0AC58A042055A2CA057EFE3B594A922025644ACC85011111101111011102A42412E22222222222272111111918BF8DF43B8F6E4B9FFF
```

(Query is not very nice and does not scale well to bigger maps, but works.)

First observation was, that heuristic determining when to compute hashes was skipping those tiles. Then it was observed that hash calculation done in `FeatureFroup` (see https://github.com/onthegomap/planetiler/blob/3fd094d/planetiler-core/src/main/java/com/onthegomap/planetiler/collection/FeatureGroup.java#L377 ) is producing different hashes for tiles which when encoded and compressed, are byte-to-byte same.

Hence this PR does following:

1. `BikeRouteOverlayTest` unit test was extended to count duplicates in generated .mbtiles
    - I was not able to make some new reasonable unit test to cover this case, hence `BikeRouteOverlayTest` was identified as triggering the root-causes and thus extended to determine duplicate tiles.
2. heuristic determining hash calculation was extended to cover also empty tiles and tiles with just one empty layer
3. hash computation was adjusted to use result of layer encoding
   - Layer encoded to bytes is what is at the end written to .mbtiles. And I take it is easier and more error prone than trying to adjust original hash function which is working with `FeatureGroup` and features.

Updated Planetiler seems working better (=fewer duplicates, same performance), at least based on the unit test and a test with `slovakia.mbtiles`:

```
SELECT count(tile_data_id) as id_count, group_concat(tile_data_id) as id_list, substr(hex(tile_data), 0, 200) as tile_data_hex FROM tiles_data GROUP BY hex(tile_data) ORDER BY id_count DESC LIMIT 3;
1|19360|1F8B08000000000000FFEDBD69605455D6369A7D4E0DE754556A3835A46A57A5A6546A38996A4A2AA94CA0800828C8E0AC18204204120CA0ADFDDA8630478610634444848888880888808880808848D38848D3888888883422D2888869FCF650B439F5F
1|7|1F8B08000000000000FFEDBC799865659D26F8EDDBD9CF3D778FE5C6CDD83233724F9224933549927D914DCB298B099210824C223032130AAABB15524B4DA4B4AAC4056D05C442298534052BB5102C53EC6AA60BC12E4AF429A703ADD21A977AA6797AE
1|1736|1F8B08000000000000FFEDBC79985D55992FBCDFB5A7B5F63C4F679EA79A4ECD4392AA4A659EE790040827950AA9A45215AA1220D89AC810110101111051898D083882338D880C6AA3AD69B4FB3ACB756A1BED960FD1EEAB36F75BE724206D777FF77ED
```

(No count bigger than 1, hence no duplicates.)

Side note reg. `BikeRouteOverlayTest`: While debugging, following was observed:

```
[mbtiles:encode] old hash: 8152459079797329014, new hash: -7108558662289803811
[mbtiles:encode] old hash: 8136981643901169510, new hash: -7108558662289803811
[mbtiles:encode] old hash: -4610225015425806810, new hash: -7108558662289803811
[mbtiles:encode] old hash: 8561865035814504758, new hash: -7108558662289803811
[mbtiles:encode] old hash: -7291151759222358010, new hash: -7108558662289803811
[mbtiles:encode] old hash: -8581161042698348874, new hash: -7108558662289803811
```