### PR TITLE
FeatureGroup can emit in either TMS or Hilbert order. [#98]

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
@@ -615,7 +615,8 @@ public class Planetiler {
       bounds.addFallbackProvider(new OsmNodeBoundsProvider(osmInputFile, config, stats));
     }
 
-    featureGroup = FeatureGroup.newDiskBackedFeatureGroup(featureDbPath, profile, config, stats);
+    featureGroup =
+      FeatureGroup.newDiskBackedFeatureGroup(FeatureGroup.TileOrder.TMS, featureDbPath, profile, config, stats);
     stats.monitorFile("nodes", nodeDbPath);
     stats.monitorFile("features", featureDbPath);
     stats.monitorFile("multipolygons", multipolygonPath);

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
@@ -617,7 +617,7 @@ public class Planetiler {
 
     try (TileArchive archive = Mbtiles.newWriteToFileDatabase(output, config.compactDb())) {
       featureGroup =
-        FeatureGroup.newDiskBackedFeatureGroup(archive.preferredTileOrder(), featureDbPath, profile, config, stats);
+        FeatureGroup.newDiskBackedFeatureGroup(archive.tileOrder(), featureDbPath, profile, config, stats);
       stats.monitorFile("nodes", nodeDbPath);
       stats.monitorFile("features", featureDbPath);
       stats.monitorFile("multipolygons", multipolygonPath);

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
@@ -615,29 +615,29 @@ public class Planetiler {
       bounds.addFallbackProvider(new OsmNodeBoundsProvider(osmInputFile, config, stats));
     }
 
-    featureGroup =
-      FeatureGroup.newDiskBackedFeatureGroup(FeatureGroup.TileOrder.TMS, featureDbPath, profile, config, stats);
-    stats.monitorFile("nodes", nodeDbPath);
-    stats.monitorFile("features", featureDbPath);
-    stats.monitorFile("multipolygons", multipolygonPath);
-    stats.monitorFile("archive", output);
-
-    for (Stage stage : stages) {
-      stage.task.run();
-    }
-
-    LOGGER.info("Deleting node.db to make room for output file");
-    profile.release();
-    for (var inputPath : inputPaths) {
-      if (inputPath.freeAfterReading()) {
-        LOGGER.info("Deleting {} ({}) to make room for output file", inputPath.id, inputPath.path);
-        FileUtils.delete(inputPath.path());
-      }
-    }
-
-    featureGroup.prepare();
-
     try (TileArchive archive = Mbtiles.newWriteToFileDatabase(output, config.compactDb())) {
+      featureGroup =
+        FeatureGroup.newDiskBackedFeatureGroup(archive.preferredTileOrder(), featureDbPath, profile, config, stats);
+      stats.monitorFile("nodes", nodeDbPath);
+      stats.monitorFile("features", featureDbPath);
+      stats.monitorFile("multipolygons", multipolygonPath);
+      stats.monitorFile("archive", output);
+
+      for (Stage stage : stages) {
+        stage.task.run();
+      }
+
+      LOGGER.info("Deleting node.db to make room for output file");
+      profile.release();
+      for (var inputPath : inputPaths) {
+        if (inputPath.freeAfterReading()) {
+          LOGGER.info("Deleting {} ({}) to make room for output file", inputPath.id, inputPath.path);
+          FileUtils.delete(inputPath.path());
+        }
+      }
+
+      featureGroup.prepare();
+
       TileArchiveWriter.writeOutput(featureGroup, archive, () -> FileUtils.fileSize(output), tileArchiveMetadata,
         config,
         stats);

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/TileCoord.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/TileCoord.java
@@ -39,11 +39,11 @@ public record TileCoord(int encoded, int x, int y, int z) implements Comparable<
     }
   }
 
-  public static int startIndexForZoom(int z) {
+  private static int startIndexForZoom(int z) {
     return ZOOM_START_INDEX[z];
   }
 
-  public static int zoomForIndex(int idx) {
+  private static int zoomForIndex(int idx) {
     for (int z = MAX_MAXZOOM; z >= 0; z--) {
       if (ZOOM_START_INDEX[z] <= idx) {
         return z;

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/TileCoord.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/TileCoord.java
@@ -38,11 +38,11 @@ public record TileCoord(int encoded, int x, int y, int z) implements Comparable<
     }
   }
 
-  private static int startIndexForZoom(int z) {
+  public static int startIndexForZoom(int z) {
     return ZOOM_START_INDEX[z];
   }
 
-  private static int zoomForIndex(int idx) {
+  public static int zoomForIndex(int idx) {
     for (int z = MAX_MAXZOOM; z >= 0; z--) {
       if (ZOOM_START_INDEX[z] <= idx) {
         return z;

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/TileCoord.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/TileCoord.java
@@ -109,16 +109,14 @@ public record TileCoord(int encoded, int x, int y, int z) implements Comparable<
     return "{x=" + x + " y=" + y + " z=" + z + '}';
   }
 
-  public double progressOnLevel(TileOrder order, TileExtents extents) {
-    if (order == TileOrder.TMS) {
-      // approximate percent complete within a bounding box by computing what % of the way through the columns we are
-      var zoomBounds = extents.getForZoom(z);
-      return 1d * (x - zoomBounds.minX()) / (zoomBounds.maxX() - zoomBounds.minX());
-    } else {
-      // this assumes extents is the whole world, so will be wrong when tiling a limited bbox
-      // we could improve this by making TileExtents store an exact set of all encoded coordinates.
-      return 1d * Hilbert.hilbertXYToIndex(this.z, this.x, this.y) / (2 << this.z);
-    }
+  public double progressOnLevel(TileExtents extents) {
+    // approximate percent complete within a bounding box by computing what % of the way through the columns we are
+    var zoomBounds = extents.getForZoom(z);
+    return 1d * (x - zoomBounds.minX()) / (zoomBounds.maxX() - zoomBounds.minX());
+  }
+
+  public double hilbertProgressOnLevel(TileExtents extents) {
+    return 1d * Hilbert.hilbertXYToIndex(this.z, this.x, this.y) / (1 << 2 * this.z);
   }
 
   @Override

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/TileOrder.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/TileOrder.java
@@ -1,6 +1,7 @@
 package com.onthegomap.planetiler.geo;
 
 import java.util.function.IntFunction;
+import java.util.function.ToDoubleBiFunction;
 import java.util.function.ToIntFunction;
 
 /**
@@ -9,15 +10,18 @@ import java.util.function.ToIntFunction;
  * {@link com.onthegomap.planetiler.writer.TileArchive.TileWriter}.
  */
 public enum TileOrder {
-  TMS(TileCoord::encoded, TileCoord::decode),
-  HILBERT(TileCoord::hilbertEncoded, TileCoord::hilbertDecode);
+  TMS(TileCoord::encoded, TileCoord::decode, TileCoord::progressOnLevel),
+  HILBERT(TileCoord::hilbertEncoded, TileCoord::hilbertDecode, TileCoord::hilbertProgressOnLevel);
 
   private final ToIntFunction<TileCoord> encode;
   private final IntFunction<TileCoord> decode;
+  private final ToDoubleBiFunction<TileCoord, TileExtents> progressOnLevel;
 
-  private TileOrder(ToIntFunction<TileCoord> encode, IntFunction<TileCoord> decode) {
+  private TileOrder(ToIntFunction<TileCoord> encode, IntFunction<TileCoord> decode,
+    ToDoubleBiFunction<TileCoord, TileExtents> progressOnLevel) {
     this.encode = encode;
     this.decode = decode;
+    this.progressOnLevel = progressOnLevel;
   }
 
   public int encode(TileCoord coord) {
@@ -26,5 +30,9 @@ public enum TileOrder {
 
   public TileCoord decode(int encoded) {
     return decode.apply(encoded);
+  }
+
+  public double progressOnLevel(TileCoord coord, TileExtents extents) {
+    return progressOnLevel.applyAsDouble(coord, extents);
   }
 }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/TileOrder.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/TileOrder.java
@@ -1,0 +1,25 @@
+package com.onthegomap.planetiler.geo;
+
+import java.util.function.IntFunction;
+import java.util.function.ToIntFunction;
+
+public enum TileOrder {
+  TMS(TileCoord::encoded, TileCoord::decode),
+  HILBERT(TileCoord::hilbertEncoded, TileCoord::hilbertDecode);
+
+  private final ToIntFunction<TileCoord> encode;
+  private final IntFunction<TileCoord> decode;
+
+  private TileOrder(ToIntFunction<TileCoord> encode, IntFunction<TileCoord> decode) {
+    this.encode = encode;
+    this.decode = decode;
+  }
+
+  public int encode(TileCoord coord) {
+    return encode.applyAsInt(coord);
+  }
+
+  public TileCoord decode(int encoded) {
+    return decode.apply(encoded);
+  }
+}

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/TileOrder.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/TileOrder.java
@@ -3,6 +3,11 @@ package com.onthegomap.planetiler.geo;
 import java.util.function.IntFunction;
 import java.util.function.ToIntFunction;
 
+/**
+ * Controls the sort order of {@link com.onthegomap.planetiler.collection.FeatureGroup}, which determines the ordering
+ * of {@link com.onthegomap.planetiler.writer.TileEncodingResult}s when written to
+ * {@link com.onthegomap.planetiler.writer.TileArchive.TileWriter}.
+ */
 public enum TileOrder {
   TMS(TileCoord::encoded, TileCoord::decode),
   HILBERT(TileCoord::hilbertEncoded, TileCoord::hilbertDecode);

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/mbtiles/Mbtiles.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/mbtiles/Mbtiles.java
@@ -94,7 +94,6 @@ public final class Mbtiles implements TileArchive {
   private PreparedStatement getTileStatement = null;
   private final boolean compactDb;
 
-  /** Inserts will be ordered to match the MBTiles index (TMS) */
   @Override
   public TileOrder tileOrder() {
     return TileOrder.TMS;

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/mbtiles/Mbtiles.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/mbtiles/Mbtiles.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.onthegomap.planetiler.collection.FeatureGroup;
 import com.onthegomap.planetiler.config.PlanetilerConfig;
 import com.onthegomap.planetiler.geo.GeoUtils;
 import com.onthegomap.planetiler.geo.TileCoord;
@@ -92,6 +93,12 @@ public final class Mbtiles implements TileArchive {
   private final Connection connection;
   private PreparedStatement getTileStatement = null;
   private final boolean compactDb;
+
+  /** Inserts will be ordered to match the MBTiles index (TMS) */
+  @Override
+  public FeatureGroup.TileOrder preferredTileOrder() {
+    return FeatureGroup.TileOrder.TMS;
+  }
 
   private Mbtiles(Connection connection, boolean compactDb) {
     this.connection = connection;

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/mbtiles/Mbtiles.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/mbtiles/Mbtiles.java
@@ -7,10 +7,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.onthegomap.planetiler.collection.FeatureGroup;
 import com.onthegomap.planetiler.config.PlanetilerConfig;
 import com.onthegomap.planetiler.geo.GeoUtils;
 import com.onthegomap.planetiler.geo.TileCoord;
+import com.onthegomap.planetiler.geo.TileOrder;
 import com.onthegomap.planetiler.util.Format;
 import com.onthegomap.planetiler.util.LayerStats;
 import com.onthegomap.planetiler.writer.TileArchive;
@@ -96,8 +96,8 @@ public final class Mbtiles implements TileArchive {
 
   /** Inserts will be ordered to match the MBTiles index (TMS) */
   @Override
-  public FeatureGroup.TileOrder preferredTileOrder() {
-    return FeatureGroup.TileOrder.TMS;
+  public TileOrder tileOrder() {
+    return TileOrder.TMS;
   }
 
   private Mbtiles(Connection connection, boolean compactDb) {

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/writer/TileArchive.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/writer/TileArchive.java
@@ -26,7 +26,7 @@ public interface TileArchive extends Closeable {
 
 
   /**
-   * specify the preferred insertion order for this archive, e.g. TMS or HILBERT. See {@link TileOrder}.
+   * Specify the preferred insertion order for this archive, e.g. {@link TileOrder#TMS} or {@link TileOrder#HILBERT}.
    */
   TileOrder tileOrder();
 

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/writer/TileArchive.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/writer/TileArchive.java
@@ -1,7 +1,7 @@
 package com.onthegomap.planetiler.writer;
 
-import com.onthegomap.planetiler.collection.FeatureGroup;
 import com.onthegomap.planetiler.config.PlanetilerConfig;
+import com.onthegomap.planetiler.geo.TileOrder;
 import com.onthegomap.planetiler.util.LayerStats;
 import java.io.Closeable;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -26,9 +26,9 @@ public interface TileArchive extends Closeable {
 
 
   /**
-   * specify the preferred insertion order for this archive, e.g. TMS or HILBERT. See {@link FeatureGroup.TileOrder}.
+   * specify the preferred insertion order for this archive, e.g. TMS or HILBERT. See {@link TileOrder}.
    */
-  FeatureGroup.TileOrder preferredTileOrder();
+  TileOrder tileOrder();
 
   /**
    * Called before any tiles are written into {@link TileWriter}. Implementations of TileArchive should set up any

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/writer/TileArchive.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/writer/TileArchive.java
@@ -1,5 +1,6 @@
 package com.onthegomap.planetiler.writer;
 
+import com.onthegomap.planetiler.collection.FeatureGroup;
 import com.onthegomap.planetiler.config.PlanetilerConfig;
 import com.onthegomap.planetiler.util.LayerStats;
 import java.io.Closeable;
@@ -23,6 +24,11 @@ public interface TileArchive extends Closeable {
     default void printStats() {}
   }
 
+
+  /**
+   * specify the preferred insertion order for this archive, e.g. TMS or HILBERT. See {@link FeatureGroup.TileOrder}.
+   */
+  FeatureGroup.TileOrder preferredTileOrder();
 
   /**
    * Called before any tiles are written into {@link TileWriter}. Implementations of TileArchive should set up any

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/writer/TileArchiveWriter.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/writer/TileArchiveWriter.java
@@ -194,7 +194,8 @@ public class TileArchiveWriter {
     } else {
       blurb = "%d/%d/%d (z%d %s) %s".formatted(
         lastTile.z(), lastTile.x(), lastTile.y(),
-        lastTile.z(), Format.defaultInstance().percent(lastTile.progressOnLevel(config.bounds().tileExtents())),
+        lastTile.z(),
+        Format.defaultInstance().percent(lastTile.progressOnLevel(archive.tileOrder(), config.bounds().tileExtents())),
         lastTile.getDebugUrl()
       );
     }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/writer/TileArchiveWriter.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/writer/TileArchiveWriter.java
@@ -195,7 +195,7 @@ public class TileArchiveWriter {
       blurb = "%d/%d/%d (z%d %s) %s".formatted(
         lastTile.z(), lastTile.x(), lastTile.y(),
         lastTile.z(),
-        Format.defaultInstance().percent(lastTile.progressOnLevel(archive.tileOrder(), config.bounds().tileExtents())),
+        Format.defaultInstance().percent(archive.tileOrder().progressOnLevel(lastTile, config.bounds().tileExtents())),
         lastTile.getDebugUrl()
       );
     }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
@@ -11,6 +11,7 @@ import com.onthegomap.planetiler.config.PlanetilerConfig;
 import com.onthegomap.planetiler.geo.GeoUtils;
 import com.onthegomap.planetiler.geo.GeometryException;
 import com.onthegomap.planetiler.geo.TileCoord;
+import com.onthegomap.planetiler.geo.TileOrder;
 import com.onthegomap.planetiler.mbtiles.Mbtiles;
 import com.onthegomap.planetiler.reader.SimpleFeature;
 import com.onthegomap.planetiler.reader.SimpleReader;
@@ -137,7 +138,7 @@ class PlanetilerTests {
     Profile profile
   ) throws Exception {
     PlanetilerConfig config = PlanetilerConfig.from(Arguments.of(args));
-    FeatureGroup featureGroup = FeatureGroup.newInMemoryFeatureGroup(FeatureGroup.TileOrder.TMS, profile, stats);
+    FeatureGroup featureGroup = FeatureGroup.newInMemoryFeatureGroup(TileOrder.TMS, profile, stats);
     runner.run(featureGroup, profile, config);
     featureGroup.prepare();
     try (Mbtiles db = Mbtiles.newInMemoryDatabase(config.compactDb())) {

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
@@ -137,7 +137,7 @@ class PlanetilerTests {
     Profile profile
   ) throws Exception {
     PlanetilerConfig config = PlanetilerConfig.from(Arguments.of(args));
-    FeatureGroup featureGroup = FeatureGroup.newInMemoryFeatureGroup(profile, stats);
+    FeatureGroup featureGroup = FeatureGroup.newInMemoryFeatureGroup(FeatureGroup.TileOrder.TMS, profile, stats);
     runner.run(featureGroup, profile, config);
     featureGroup.prepare();
     try (Mbtiles db = Mbtiles.newInMemoryDatabase(config.compactDb())) {

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/collection/FeatureGroupTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/collection/FeatureGroupTest.java
@@ -301,9 +301,9 @@ class FeatureGroupTest {
     features = new FeatureGroup(sorter, TileOrder.HILBERT, new Profile.NullProfile() {}, Stats.inMemory());
     featureWriter = features.writerForThread();
 
-    // TMS tile IDs at zoom level 1:
-    // 2 4
-    // 1 3
+    // Hilbert tile IDs at zoom level 1:
+    // 1 4
+    // 2 3
 
     put(
       1, "layer", Map.of("id", 1), newPoint(0, 0)

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/collection/FeatureGroupTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/collection/FeatureGroupTest.java
@@ -12,6 +12,7 @@ import com.onthegomap.planetiler.Profile;
 import com.onthegomap.planetiler.VectorTile;
 import com.onthegomap.planetiler.geo.GeometryType;
 import com.onthegomap.planetiler.geo.TileCoord;
+import com.onthegomap.planetiler.geo.TileOrder;
 import com.onthegomap.planetiler.render.RenderedFeature;
 import com.onthegomap.planetiler.stats.Stats;
 import com.onthegomap.planetiler.util.CloseableConsumer;
@@ -41,7 +42,7 @@ class FeatureGroupTest {
   private final FeatureSort sorter = FeatureSort.newInMemory();
 
   private FeatureGroup features =
-    new FeatureGroup(sorter, FeatureGroup.TileOrder.TMS, new Profile.NullProfile(), Stats.inMemory());
+    new FeatureGroup(sorter, TileOrder.TMS, new Profile.NullProfile(), Stats.inMemory());
   private CloseableConsumer<SortableFeature> featureWriter = features.writerForThread();
 
   @Test
@@ -267,7 +268,7 @@ class FeatureGroupTest {
 
   @Test
   void testProfileChangesGeometry() {
-    features = new FeatureGroup(sorter, FeatureGroup.TileOrder.TMS, new Profile.NullProfile() {
+    features = new FeatureGroup(sorter, TileOrder.TMS, new Profile.NullProfile() {
       @Override
       public List<VectorTile.Feature> postProcessLayerFeatures(String layer, int zoom, List<VectorTile.Feature> items) {
         Collections.reverse(items);
@@ -297,7 +298,7 @@ class FeatureGroupTest {
 
   @Test
   void testHilbertOrdering() {
-    features = new FeatureGroup(sorter, FeatureGroup.TileOrder.HILBERT, new Profile.NullProfile() {}, Stats.inMemory());
+    features = new FeatureGroup(sorter, TileOrder.HILBERT, new Profile.NullProfile() {}, Stats.inMemory());
     featureWriter = features.writerForThread();
 
     // TMS tile IDs at zoom level 1:

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/collection/FeatureGroupTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/collection/FeatureGroupTest.java
@@ -335,6 +335,45 @@ class FeatureGroupTest {
     assertEquals(0, tile.y());
   }
 
+  @Test
+  void testTMSOrdering() {
+    features = new FeatureGroup(sorter, TileOrder.TMS, new Profile.NullProfile() {}, Stats.inMemory());
+    featureWriter = features.writerForThread();
+
+    // TMS tile IDs at zoom level 1:
+    // 2 4
+    // 1 3
+
+    put(
+      1, "layer", Map.of("id", 1), newPoint(0, 0)
+    );
+    put(
+      2, "layer", Map.of("id", 2), newPoint(0, 0)
+    );
+    put(
+      3, "layer", Map.of("id", 3), newPoint(0, 0)
+    );
+    put(
+      4, "layer", Map.of("id", 4), newPoint(0, 0)
+    );
+
+    // calls sort()
+    var iter = features.iterator();
+
+    var tile = iter.next().tileCoord();
+    assertEquals(0, tile.x());
+    assertEquals(1, tile.y());
+    tile = iter.next().tileCoord();
+    assertEquals(0, tile.x());
+    assertEquals(0, tile.y());
+    tile = iter.next().tileCoord();
+    assertEquals(1, tile.x());
+    assertEquals(1, tile.y());
+    tile = iter.next().tileCoord();
+    assertEquals(1, tile.x());
+    assertEquals(0, tile.y());
+  }
+
   @TestFactory
   List<DynamicTest> testEncodeLongKey() {
     List<TileCoord> tiles = List.of(

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/TileCoordTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/TileCoordTest.java
@@ -38,7 +38,7 @@ class TileCoordTest {
     "32767,0,15,1431655764",
     "32767,32767,15,1431622997"
   })
-  void testTileOrder(int x, int y, int z, int i) {
+  void testTileCoordEncode(int x, int y, int z, int i) {
     int encoded = TileCoord.ofXYZ(x, y, z).encoded();
     assertEquals(i, encoded);
     TileCoord decoded = TileCoord.decode(i);
@@ -57,6 +57,39 @@ class TileCoordTest {
       }
       last = encoded;
     }
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "0,0,0,0",
+    "0,0,1,1",
+    "0,1,1,2",
+    "1,1,1,3",
+    "1,0,1,4",
+    "0,0,2,5",
+    "1,0,2,6",
+    "1,1,2,7",
+    "0,1,2,8",
+    "0,2,2,9",
+    "0,3,2,10",
+    "1,3,2,11",
+    "1,2,2,12",
+    "2,2,2,13",
+    "2,3,2,14",
+    "3,3,2,15",
+    "3,2,2,16",
+    "3,1,2,17",
+    "2,1,2,18",
+    "2,0,2,19",
+    "3,0,2,20"
+  })
+  void testTileCoordHilbert(int x, int y, int z, int i) {
+    int encoded = TileCoord.ofXYZ(x, y, z).hilbertEncoded();
+    assertEquals(i, encoded);
+    TileCoord decoded = TileCoord.hilbertDecode(i);
+    assertEquals(decoded.x(), x, "x");
+    assertEquals(decoded.y(), y, "y");
+    assertEquals(decoded.z(), z, "z");
   }
 
   @ParameterizedTest

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/TileCoordTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/TileCoordTest.java
@@ -99,9 +99,23 @@ class TileCoordTest {
     "1,1,1,0.5",
     "0,3,2,0"
   })
-  void testTileProgressOnLevel(int x, int y, int z, double p) {
+  void testTileProgressOnLevelTMS(int x, int y, int z, double p) {
     double progress =
       TileCoord.ofXYZ(x, y, z).progressOnLevel(TileOrder.TMS,
+        TileExtents.computeFromWorldBounds(15, GeoUtils.WORLD_BOUNDS));
+    assertEquals(p, progress);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "0,0,1,0",
+    "0,1,1,0.25",
+    "1,1,1,0.5",
+    "0,0,2,0"
+  })
+  void testTileProgressOnLevelHilbert(int x, int y, int z, double p) {
+    double progress =
+      TileCoord.ofXYZ(x, y, z).progressOnLevel(TileOrder.HILBERT,
         TileExtents.computeFromWorldBounds(15, GeoUtils.WORLD_BOUNDS));
     assertEquals(p, progress);
   }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/TileCoordTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/TileCoordTest.java
@@ -101,7 +101,7 @@ class TileCoordTest {
   })
   void testTileProgressOnLevelTMS(int x, int y, int z, double p) {
     double progress =
-      TileCoord.ofXYZ(x, y, z).progressOnLevel(TileOrder.TMS,
+      TileOrder.TMS.progressOnLevel(TileCoord.ofXYZ(x, y, z),
         TileExtents.computeFromWorldBounds(15, GeoUtils.WORLD_BOUNDS));
     assertEquals(p, progress);
   }
@@ -111,11 +111,12 @@ class TileCoordTest {
     "0,0,1,0",
     "0,1,1,0.25",
     "1,1,1,0.5",
-    "0,0,2,0"
+    "0,0,2,0",
+    "2,2,2,0.5",
   })
   void testTileProgressOnLevelHilbert(int x, int y, int z, double p) {
     double progress =
-      TileCoord.ofXYZ(x, y, z).progressOnLevel(TileOrder.HILBERT,
+      TileOrder.HILBERT.progressOnLevel(TileCoord.ofXYZ(x, y, z),
         TileExtents.computeFromWorldBounds(15, GeoUtils.WORLD_BOUNDS));
     assertEquals(p, progress);
   }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/TileCoordTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/TileCoordTest.java
@@ -68,7 +68,8 @@ class TileCoordTest {
   })
   void testTileProgressOnLevel(int x, int y, int z, double p) {
     double progress =
-      TileCoord.ofXYZ(x, y, z).progressOnLevel(TileExtents.computeFromWorldBounds(15, GeoUtils.WORLD_BOUNDS));
+      TileCoord.ofXYZ(x, y, z).progressOnLevel(TileOrder.TMS,
+        TileExtents.computeFromWorldBounds(15, GeoUtils.WORLD_BOUNDS));
     assertEquals(p, progress);
   }
 }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/reader/SourceFeatureProcessorTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/reader/SourceFeatureProcessorTest.java
@@ -6,6 +6,7 @@ import com.onthegomap.planetiler.Profile;
 import com.onthegomap.planetiler.collection.FeatureGroup;
 import com.onthegomap.planetiler.config.PlanetilerConfig;
 import com.onthegomap.planetiler.geo.GeoUtils;
+import com.onthegomap.planetiler.geo.TileOrder;
 import com.onthegomap.planetiler.stats.Stats;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -68,7 +69,7 @@ class SourceFeatureProcessorTest {
   void testProcessMultipleInputs() {
     var profile = new Profile.NullProfile();
     var stats = Stats.inMemory();
-    var featureGroup = FeatureGroup.newInMemoryFeatureGroup(FeatureGroup.TileOrder.TMS, profile, stats);
+    var featureGroup = FeatureGroup.newInMemoryFeatureGroup(TileOrder.TMS, profile, stats);
 
     var emittedFeatures = new ArrayList<SimpleFeature>();
     var paths = List.of(

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/reader/SourceFeatureProcessorTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/reader/SourceFeatureProcessorTest.java
@@ -68,7 +68,7 @@ class SourceFeatureProcessorTest {
   void testProcessMultipleInputs() {
     var profile = new Profile.NullProfile();
     var stats = Stats.inMemory();
-    var featureGroup = FeatureGroup.newInMemoryFeatureGroup(profile, stats);
+    var featureGroup = FeatureGroup.newInMemoryFeatureGroup(FeatureGroup.TileOrder.TMS, profile, stats);
 
     var emittedFeatures = new ArrayList<SimpleFeature>();
     var paths = List.of(

--- a/planetiler-examples/src/main/java/com/onthegomap/planetiler/examples/ToiletsOverlayLowLevelApi.java
+++ b/planetiler-examples/src/main/java/com/onthegomap/planetiler/examples/ToiletsOverlayLowLevelApi.java
@@ -74,6 +74,7 @@ public class ToiletsOverlayLowLevelApi {
      * option too.
      */
     FeatureGroup featureGroup = FeatureGroup.newDiskBackedFeatureGroup(
+      FeatureGroup.TileOrder.TMS,
       tmpDir.resolve("feature.db"),
       profile, config, stats
     );

--- a/planetiler-examples/src/main/java/com/onthegomap/planetiler/examples/ToiletsOverlayLowLevelApi.java
+++ b/planetiler-examples/src/main/java/com/onthegomap/planetiler/examples/ToiletsOverlayLowLevelApi.java
@@ -7,6 +7,7 @@ import com.onthegomap.planetiler.collection.LongLongMap;
 import com.onthegomap.planetiler.collection.LongLongMultimap;
 import com.onthegomap.planetiler.config.Arguments;
 import com.onthegomap.planetiler.config.PlanetilerConfig;
+import com.onthegomap.planetiler.geo.TileOrder;
 import com.onthegomap.planetiler.mbtiles.Mbtiles;
 import com.onthegomap.planetiler.reader.osm.OsmInputFile;
 import com.onthegomap.planetiler.reader.osm.OsmReader;
@@ -74,7 +75,7 @@ public class ToiletsOverlayLowLevelApi {
      * option too.
      */
     FeatureGroup featureGroup = FeatureGroup.newDiskBackedFeatureGroup(
-      FeatureGroup.TileOrder.TMS,
+      TileOrder.TMS,
       tmpDir.resolve("feature.db"),
       profile, config, stats
     );


### PR DESCRIPTION
Another prerequisite for #98 that is not strictly required but PMTiles is much more efficient with clustered order. 

This isolates the ordering to `FeatureGroup` only; from the TileArchive side you're still dealing with `TileCoord` that is TMS order. This should also mean non-PMTiles archive formats should never touch the slower Hilbert codepaths. 