### PR TITLE
Revert "fix is convex negated (#241)"

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/GeoUtils.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/GeoUtils.java
@@ -403,20 +403,11 @@ public class GeoUtils {
     return JTS_FACTORY.createPolygon(exteriorRing, rings.toArray(LinearRing[]::new));
   }
 
-
-  /**
-   * Returns {@code false} if the signed area of the triangle formed by 3 sequential points changes sign anywhere along
-   * {@code ring}, ignoring repeated and collinear points.
-   */
-  public static boolean isConvex(LinearRing ring) {
-    return !isConcave(ring);
-  }
-
   /**
    * Returns {@code true} if the signed area of the triangle formed by 3 sequential points changes sign anywhere along
    * {@code ring}, ignoring repeated and collinear points.
    */
-  public static boolean isConcave(LinearRing ring) {
+  public static boolean isConvex(LinearRing ring) {
     CoordinateSequence seq = ring.getCoordinateSequence();
     if (seq.size() <= 3) {
       return false;

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/GeoUtilsTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/GeoUtilsTest.java
@@ -117,7 +117,7 @@ class GeoUtilsTest {
 
   @Test
   void testIsConvexTriangle() {
-    assertConcave(true, newLinearRing(
+    assertConvex(true, newLinearRing(
       0, 0,
       1, 0,
       0, 1,
@@ -127,7 +127,7 @@ class GeoUtilsTest {
 
   @Test
   void testIsConvexRectangle() {
-    assertConcave(true, newLinearRing(
+    assertConvex(true, newLinearRing(
       0, 0,
       1, 0,
       1, 1,
@@ -138,21 +138,21 @@ class GeoUtilsTest {
 
   @Test
   void testBarelyConvexRectangle() {
-    assertConcave(true, newLinearRing(
+    assertConvex(true, newLinearRing(
       0, 0,
       1, 0,
       1, 1,
       0.5, 0.5,
       0, 0
     ));
-    assertConcave(true, newLinearRing(
+    assertConvex(true, newLinearRing(
       0, 0,
       1, 0,
       1, 1,
       0.4, 0.4,
       0, 0
     ));
-    assertConcave(true, newLinearRing(
+    assertConvex(true, newLinearRing(
       0, 0,
       1, 0,
       1, 1,
@@ -163,7 +163,7 @@ class GeoUtilsTest {
 
   @Test
   void testConcaveRectangleDoublePoints() {
-    assertConcave(true, newLinearRing(
+    assertConvex(true, newLinearRing(
       0, 0,
       0, 0,
       1, 0,
@@ -171,7 +171,7 @@ class GeoUtilsTest {
       0, 1,
       0, 0
     ));
-    assertConcave(true, newLinearRing(
+    assertConvex(true, newLinearRing(
       0, 0,
       1, 0,
       1, 0,
@@ -179,7 +179,7 @@ class GeoUtilsTest {
       0, 1,
       0, 0
     ));
-    assertConcave(true, newLinearRing(
+    assertConvex(true, newLinearRing(
       0, 0,
       1, 0,
       1, 1,
@@ -187,7 +187,7 @@ class GeoUtilsTest {
       0, 1,
       0, 0
     ));
-    assertConcave(true, newLinearRing(
+    assertConvex(true, newLinearRing(
       0, 0,
       1, 0,
       1, 1,
@@ -195,7 +195,7 @@ class GeoUtilsTest {
       0, 1,
       0, 0
     ));
-    assertConcave(true, newLinearRing(
+    assertConvex(true, newLinearRing(
       0, 0,
       1, 0,
       1, 1,
@@ -207,7 +207,7 @@ class GeoUtilsTest {
 
   @Test
   void testBarelyConcaveRectangle() {
-    assertConcave(false, newLinearRing(
+    assertConvex(false, newLinearRing(
       0, 0,
       1, 0,
       1, 1,
@@ -218,7 +218,7 @@ class GeoUtilsTest {
 
   @Test
   void test5PointsConcave() {
-    assertConcave(false, newLinearRing(
+    assertConvex(false, newLinearRing(
       0, 0,
       0.5, 0.1,
       1, 0,
@@ -226,7 +226,7 @@ class GeoUtilsTest {
       0, 1,
       0, 0
     ));
-    assertConcave(false, newLinearRing(
+    assertConvex(false, newLinearRing(
       0, 0,
       1, 0,
       0.9, 0.5,
@@ -234,7 +234,7 @@ class GeoUtilsTest {
       0, 1,
       0, 0
     ));
-    assertConcave(false, newLinearRing(
+    assertConvex(false, newLinearRing(
       0, 0,
       1, 0,
       1, 1,
@@ -242,7 +242,7 @@ class GeoUtilsTest {
       0, 1,
       0, 0
     ));
-    assertConcave(false, newLinearRing(
+    assertConvex(false, newLinearRing(
       0, 0,
       1, 0,
       1, 1,
@@ -254,7 +254,7 @@ class GeoUtilsTest {
 
   @Test
   void test5PointsColinear() {
-    assertConcave(true, newLinearRing(
+    assertConvex(true, newLinearRing(
       0, 0,
       0.5, 0,
       1, 0,
@@ -262,7 +262,7 @@ class GeoUtilsTest {
       0, 1,
       0, 0
     ));
-    assertConcave(true, newLinearRing(
+    assertConvex(true, newLinearRing(
       0, 0,
       1, 0,
       1, 0.5,
@@ -270,7 +270,7 @@ class GeoUtilsTest {
       0, 1,
       0, 0
     ));
-    assertConcave(true, newLinearRing(
+    assertConvex(true, newLinearRing(
       0, 0,
       1, 0,
       1, 1,
@@ -278,7 +278,7 @@ class GeoUtilsTest {
       0, 1,
       0, 0
     ));
-    assertConcave(true, newLinearRing(
+    assertConvex(true, newLinearRing(
       0, 0,
       1, 0,
       1, 1,
@@ -288,17 +288,14 @@ class GeoUtilsTest {
     ));
   }
 
-  private static void assertConcave(boolean isConcave, LinearRing ring) {
+  private static void assertConvex(boolean isConvex, LinearRing ring) {
     for (double rotation : new double[]{0, 90, 180, 270}) {
       LinearRing rotated = (LinearRing) AffineTransformation.rotationInstance(Math.toRadians(rotation)).transform(ring);
       for (boolean flip : new boolean[]{false, true}) {
         LinearRing flipped = flip ? (LinearRing) AffineTransformation.scaleInstance(-1, 1).transform(rotated) : rotated;
         for (boolean reverse : new boolean[]{false, true}) {
           LinearRing reversed = reverse ? flipped.reverse() : flipped;
-          assertEquals(isConcave, isConcave(reversed),
-            "rotation=" + rotation + " flip=" + flip + " reverse=" + reverse);
-          assertEquals(!isConcave, isConvex(reversed),
-            "rotation=" + rotation + " flip=" + flip + " reverse=" + reverse);
+          assertEquals(isConvex, isConvex(reversed), "rotation=" + rotation + " flip=" + flip + " reverse=" + reverse);
         }
       }
     }


### PR DESCRIPTION
This reverts commit f93e5221f8a576bbce108385a7c0387216f145ba.

The original name of this function was correct, it was returning `true` when given a convex polygon and `false` given a concave polygon. This is confirmed by the test cases in `GeoUtilsTest`. 

The issue described in #237 is likely still present, perhaps due to failing when given self intersecting polygons.

Some more context in [this slack thread](https://osmus.slack.com/archives/C031V9E9RMG/p1674677909284199)