### PR TITLE
Improve is convex logic

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/GeoUtils.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/GeoUtils.java
@@ -451,16 +451,16 @@ public class GeoUtils {
       // but, we want to allow for rounding errors and small concavities relative to the overall shape
       // so track the largest positive and negative threshold for triangle area and compare them once we
       // have enough points
-      boolean check = i >= minPointsToCheck;
+      boolean extendedBounds = false;
       if (z < 0 && absZ > negZ) {
         negZ = absZ;
+        extendedBounds = true;
       } else if (z > 0 && absZ > posZ) {
         posZ = absZ;
-      } else if (i > minPointsToCheck) { // always check at i=minPointsToCheck
-        check = false;
+        extendedBounds = true;
       }
 
-      if (check) {
+      if (i == minPointsToCheck || (i > minPointsToCheck && extendedBounds)) {
         double ratio = negZ < posZ ? negZ / posZ : posZ / negZ;
         if (ratio > threshold) {
           return false;

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/GeoUtilsTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/GeoUtilsTest.java
@@ -206,12 +206,30 @@ class GeoUtilsTest {
   }
 
   @Test
-  void testBarelyConcaveRectangle() {
+  void testBarelyConcaveTriangle() {
     assertConvex(false, newLinearRing(
       0, 0,
       1, 0,
       1, 1,
       0.51, 0.5,
+      0, 0
+    ));
+  }
+
+  @Test
+  void testAllowVerySmallConcavity() {
+    assertConvex(true, newLinearRing(
+      0, 0,
+      1, 0,
+      1, 1,
+      0.5001, 0.5,
+      0, 0
+    ));
+    assertConvex(true, newLinearRing(
+      0, 0,
+      1, 0,
+      1, 1,
+      0.5, 0.4999,
       0, 0
     ));
   }
@@ -295,7 +313,11 @@ class GeoUtilsTest {
         LinearRing flipped = flip ? (LinearRing) AffineTransformation.scaleInstance(-1, 1).transform(rotated) : rotated;
         for (boolean reverse : new boolean[]{false, true}) {
           LinearRing reversed = reverse ? flipped.reverse() : flipped;
-          assertEquals(isConvex, isConvex(reversed), "rotation=" + rotation + " flip=" + flip + " reverse=" + reverse);
+          for (double scale : new double[]{1, 1e-2, 1 / Math.pow(2, 14) / 4096}) {
+            LinearRing scaled = (LinearRing) AffineTransformation.scaleInstance(scale, scale).transform(reversed);
+            assertEquals(isConvex, isConvex(scaled),
+              "rotation=" + rotation + " flip=" + flip + " reverse=" + reverse + " scale=" + scale);
+          }
         }
       }
     }


### PR DESCRIPTION
Better fix for #237 by adapting the threshold at which we consider a polygon concave (and throw out noise due to rounding errors) based on the size of the polygon. Instead of returning false for isConvex as soon as the sign of sequential triangles change, track the minimum negative sign and maximum positive sign and compare the magnitudes once we have enough points.