### PR TITLE
Add `--download-max-bandwidth` option

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/config/PlanetilerConfig.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/config/PlanetilerConfig.java
@@ -151,7 +151,7 @@ public record PlanetilerConfig(
       arguments.getLong("download_chunk_size_mb", "Size of file chunks to download in parallel in megabytes", 100),
       arguments.getInteger("download_threads", "Number of parallel threads to use when downloading each file", 1),
       Parse.bandwidth(arguments.getString("download_max_bandwidth",
-        "Maximum bandwidth to consume when downloading files", "")),
+        "Maximum bandwidth to consume when downloading files in units mb/s, mbps, kbps, etc.", "")),
       arguments.getDouble("min_feature_size_at_max_zoom",
         "Default value for the minimum size in tile pixels of features to emit at the maximum zoom level to allow for overzooming",
         256d / 4096),

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/config/PlanetilerConfig.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/config/PlanetilerConfig.java
@@ -3,6 +3,7 @@ package com.onthegomap.planetiler.config;
 import com.onthegomap.planetiler.collection.LongLongMap;
 import com.onthegomap.planetiler.collection.Storage;
 import com.onthegomap.planetiler.reader.osm.PolyFileReader;
+import com.onthegomap.planetiler.util.Parse;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
@@ -40,6 +41,7 @@ public record PlanetilerConfig(
   int httpRetries,
   long downloadChunkSizeMB,
   int downloadThreads,
+  double downloadMaxBandwidth,
   double minFeatureSizeAtMaxZoom,
   double minFeatureSizeBelowMaxZoom,
   double simplifyToleranceAtMaxZoom,
@@ -148,6 +150,8 @@ public record PlanetilerConfig(
       arguments.getInteger("http_retries", "Retries to use when downloading files over HTTP", 1),
       arguments.getLong("download_chunk_size_mb", "Size of file chunks to download in parallel in megabytes", 100),
       arguments.getInteger("download_threads", "Number of parallel threads to use when downloading each file", 1),
+      Parse.bandwidth(arguments.getString("download_max_bandwidth",
+        "Maximum bandwidth to consume when downloading files", "")),
       arguments.getDouble("min_feature_size_at_max_zoom",
         "Default value for the minimum size in tile pixels of features to emit at the maximum zoom level to allow for overzooming",
         256d / 4096),

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/util/ParseTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/util/ParseTest.java
@@ -140,4 +140,28 @@ class ParseTest {
   void testParseInvalidJvmSize(String input) {
     assertThrows(IllegalArgumentException.class, () -> Parse.jvmMemoryStringToBytes(input));
   }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "0, 0",
+    "1, 1",
+    "999999999999, 999999999999",
+    "2b/s, 2",
+    "2kib/s, 2048",
+    "4mib/s, 4194304",
+    "8GiB/s, 8589934592",
+    "2kb/s, 2000",
+    "4mb/s, 4000000",
+    "8Gb/s, 8000000000",
+    "2bps, 0.25",
+    "8bps, 1",
+    "16bps, 2",
+    "8kbps, 1000",
+    "8mbps, 1000000",
+    "8gbps, 1000000000",
+    "garbage, 0"
+  }, nullValues = {"null"})
+  void testParseBandwidth(String input, double expectedOutput) {
+    assertEquals(expectedOutput, Parse.bandwidth(input));
+  }
 }

--- a/planetiler-custommap/planetiler.schema.json
+++ b/planetiler-custommap/planetiler.schema.json
@@ -279,6 +279,9 @@
         "download_threads": {
           "description": "Number of parallel threads to use when downloading each file"
         },
+        "download_max_bandwidth": {
+          "description": "Maximum bandwidth to consume when downloading files in bytes per second"
+        },
         "min_feature_size_at_max_zoom": {
           "description": "Default value for the minimum size in tile pixels of features to emit at the maximum zoom level to allow for overzooming"
         },

--- a/planetiler-custommap/planetiler.schema.json
+++ b/planetiler-custommap/planetiler.schema.json
@@ -280,7 +280,7 @@
           "description": "Number of parallel threads to use when downloading each file"
         },
         "download_max_bandwidth": {
-          "description": "Maximum bandwidth to consume when downloading files in bytes per second"
+          "description": "Maximum bandwidth to consume when downloading files in units mb/s, mbps, kbps, etc."
         },
         "min_feature_size_at_max_zoom": {
           "description": "Default value for the minimum size in tile pixels of features to emit at the maximum zoom level to allow for overzooming"

--- a/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/Contexts.java
+++ b/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/Contexts.java
@@ -204,6 +204,7 @@ public class Contexts {
       argumentValues.put("http_retries", config.httpRetries());
       argumentValues.put("download_chunk_size_mb", config.downloadChunkSizeMB());
       argumentValues.put("download_threads", config.downloadThreads());
+      argumentValues.put("download_max_bandwidth", config.downloadMaxBandwidth());
       argumentValues.put("min_feature_size_at_max_zoom", config.minFeatureSizeAtMaxZoom());
       argumentValues.put("min_feature_size", config.minFeatureSizeBelowMaxZoom());
       argumentValues.put("simplify_tolerance_at_max_zoom", config.simplifyToleranceAtMaxZoom());


### PR DESCRIPTION
Fix #132 by adding a `--download-max-bandwith` option where you can specify a maximum bandwidth to limit all downloads to in units of mb/s, kbps, etc.