### PR TITLE
Support disabling colors in terminal output

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
@@ -18,6 +18,7 @@ import com.onthegomap.planetiler.reader.osm.OsmReader;
 import com.onthegomap.planetiler.stats.ProcessInfo;
 import com.onthegomap.planetiler.stats.Stats;
 import com.onthegomap.planetiler.stats.Timers;
+import com.onthegomap.planetiler.util.AnsiColors;
 import com.onthegomap.planetiler.util.BuildInfo;
 import com.onthegomap.planetiler.util.ByteBufferUtil;
 import com.onthegomap.planetiler.util.Downloader;
@@ -104,6 +105,9 @@ public class Planetiler {
     stats = arguments.getStats();
     overallTimer = stats.startStageQuietly("overall");
     config = PlanetilerConfig.from(arguments);
+    if (config.color() != null) {
+      AnsiColors.NO_COLOR = config.color();
+    }
     tmpDir = arguments.file("tmpdir", "temp directory", Path.of("data", "tmp"));
     onlyDownloadSources = arguments.getBoolean("only_download", "download source data then exit", false);
     downloadSources = onlyDownloadSources || arguments.getBoolean("download", "download sources", false);

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
@@ -106,7 +106,7 @@ public class Planetiler {
     overallTimer = stats.startStageQuietly("overall");
     config = PlanetilerConfig.from(arguments);
     if (config.color() != null) {
-      AnsiColors.NO_COLOR = config.color();
+      AnsiColors.setUseColors(config.color());
     }
     tmpDir = arguments.file("tmpdir", "temp directory", Path.of("data", "tmp"));
     onlyDownloadSources = arguments.getBoolean("only_download", "download source data then exit", false);

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/config/Arguments.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/config/Arguments.java
@@ -354,6 +354,14 @@ public class Arguments {
     return value;
   }
 
+  /** Returns a boolean parsed from {@code key} or {@code null} if not specified. */
+  public Boolean getBooleanObject(String key, String description) {
+    var arg = getArg(key);
+    Boolean value = arg == null ? null : "true".equalsIgnoreCase(arg);
+    logArgValue(key, description, value);
+    return value;
+  }
+
   /** Returns a {@link List} parsed from {@code key} argument where values are separated by commas. */
   public List<String> getList(String key, String description, List<String> defaultValue) {
     String value = getArg(key, String.join(",", defaultValue));

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/config/PlanetilerConfig.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/config/PlanetilerConfig.java
@@ -49,7 +49,8 @@ public record PlanetilerConfig(
   boolean osmLazyReads,
   boolean compactDb,
   boolean skipFilledTiles,
-  int tileWarningSizeBytes
+  int tileWarningSizeBytes,
+  Boolean color
 ) {
 
   public static final int MIN_MINZOOM = 0;
@@ -175,7 +176,8 @@ public record PlanetilerConfig(
         false),
       (int) (arguments.getDouble("tile_warning_size_mb",
         "Maximum size in megabytes of a tile to emit a warning about",
-        1d) * 1024 * 1024)
+        1d) * 1024 * 1024),
+      arguments.getBooleanObject("color", "Color the terminal output")
     );
   }
 

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/util/AnsiColors.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/util/AnsiColors.java
@@ -1,9 +1,16 @@
 package com.onthegomap.planetiler.util;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 /** Utilities for styling terminal output. */
 public class AnsiColors {
   // Support NO_COLOR env var (https://no-color.org/)
-  public static boolean NO_COLOR = System.getenv("NO_COLOR") != null && !"\0".equals(System.getenv("NO_COLOR"));
+  private static final AtomicBoolean useColors =
+    new AtomicBoolean(System.getenv("NO_COLOR") == null || "\0".equals(System.getenv("NO_COLOR")));
+
+  public static void setUseColors(boolean colors) {
+    useColors.set(colors);
+  }
 
   private AnsiColors() {}
 
@@ -16,7 +23,7 @@ public class AnsiColors {
   private static final String BOLD = "\u001B[1m";
 
   private static String color(String fg, String string) {
-    return NO_COLOR ? string : (fg + string + COLOR_RESET);
+    return useColors.get() ? (fg + string + COLOR_RESET) : string;
   }
 
   public static String red(String string) {

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/util/AnsiColors.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/util/AnsiColors.java
@@ -2,6 +2,9 @@ package com.onthegomap.planetiler.util;
 
 /** Utilities for styling terminal output. */
 public class AnsiColors {
+  // Support NO_COLOR env var (https://no-color.org/)
+  public static boolean NO_COLOR = System.getenv("NO_COLOR") != null && !"\0".equals(System.getenv("NO_COLOR"));
+
   private AnsiColors() {}
 
   private static final String COLOR_RESET = "\u001B[0m";
@@ -13,7 +16,7 @@ public class AnsiColors {
   private static final String BOLD = "\u001B[1m";
 
   private static String color(String fg, String string) {
-    return fg + string + COLOR_RESET;
+    return NO_COLOR ? string : (fg + string + COLOR_RESET);
   }
 
   public static String red(String string) {

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/config/ArgumentsTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/config/ArgumentsTest.java
@@ -279,4 +279,18 @@ class ArgumentsTest {
     assertEquals("value1", args.getString("key1", ""));
     assertThrows(ExpectedException.class, args::toMap);
   }
+
+  @Test
+  void testBooleanObject() {
+    Map<String, String> env = Map.of(
+      "BOOL_TRUE", "true",
+      "BOOL_FALSE", "false",
+      "BOOL_NO", "no"
+    );
+    Arguments args = Arguments.of(env);
+    assertNull(args.getBooleanObject("BOOL_NULL", "test"));
+    assertEquals(true, args.getBooleanObject("BOOL_TRUE", "test"));
+    assertEquals(false, args.getBooleanObject("BOOL_FALSE", "test"));
+    assertEquals(false, args.getBooleanObject("BOOL_NO", "test"));
+  }
 }


### PR DESCRIPTION
Fix #481 by disabling output colors when [`NO_COLOR`](https://no-color.org/) env var is set, which gets overridden by the `--color=true/false` planetiler command-line argument if set.