### PR TITLE
Add `metadataTable` alias

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/mbtiles/Mbtiles.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/mbtiles/Mbtiles.java
@@ -346,6 +346,11 @@ public final class Mbtiles implements WriteableTileArchive, ReadableTileArchive 
     return new Metadata();
   }
 
+  /** Returns the contents of the metadata table. */
+  public Metadata metadataTable() {
+    return new Metadata();
+  }
+
   private PreparedStatement getTileStatement() {
     if (getTileStatement == null) {
       try {


### PR DESCRIPTION
Precursor for genericizing metadata handling across pmtiles/mbtiles.