### PR TITLE
Fix madvise bug

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,9 @@ updates:
       - dependencies
     ignore:
       - dependency-name: "com.graphhopper:graphhopper-reader-osm"
+      # See issue #510
+      - dependency-name: "com.github.jnr:jnr-ffi"
+        versions: [ "2.2.13" ]
   - package-ecosystem: maven
     # workaround for non-standard pom.xml filename (https://github.com/dependabot/dependabot-core/issues/4425)
     directory: "/.github/planetiler-examples-dependabot"

--- a/planetiler-core/pom.xml
+++ b/planetiler-core/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-ffi</artifactId>
-      <version>2.2.13</version>
+      <version>2.2.12</version>
     </dependency>
     <dependency>
       <groupId>org.locationtech.jts</groupId>


### PR DESCRIPTION
Bump `jnr-ffi` back to 2.2.12 to fix #510 and prevent dependabot from updating to it.