### PR TITLE
Exclude relations with invalid multipolygon geometry

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/osm/OsmReader.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/osm/OsmReader.java
@@ -293,7 +293,8 @@ public class OsmReader implements Closeable, MemoryEstimator.HasEstimate {
   }
 
   private static boolean isMultipolygon(OsmElement.Relation relation) {
-    return relation.hasTag("type", "multipolygon", "boundary", "land_area");
+    return relation.hasTag("type", "multipolygon", "boundary", "land_area") &&
+      relation.members().stream().anyMatch(m -> m.type() == OsmElement.Type.WAY && "outer".equals(m.role()));
   }
 
   /**

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/osm/OsmReader.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/osm/OsmReader.java
@@ -294,7 +294,7 @@ public class OsmReader implements Closeable, MemoryEstimator.HasEstimate {
 
   private static boolean isMultipolygon(OsmElement.Relation relation) {
     return relation.hasTag("type", "multipolygon", "boundary", "land_area") &&
-      relation.members().stream().anyMatch(m -> m.type() == OsmElement.Type.WAY && "outer".equals(m.role()));
+      relation.members().stream().anyMatch(m -> m.type() == OsmElement.Type.WAY);
   }
 
   /**

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/reader/osm/OsmReaderTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/reader/osm/OsmReaderTest.java
@@ -548,14 +548,10 @@ class OsmReaderTest {
 
     var childRelation = new OsmElement.Relation(17);
     var childNode = new OsmElement.Node(17, 0.0, 0.0);
-    var childWay = new OsmElement.Way(18);
-
-    childWay.nodes().add(5, 6, 7, 8, 5);
 
     relation.setTag("type", "multipolygon");
     relation.members().add(new OsmElement.Relation.Member(OsmElement.Type.RELATION, childRelation.id(), "outer"));
     relation.members().add(new OsmElement.Relation.Member(OsmElement.Type.NODE, childNode.id(), "inner"));
-    relation.members().add(new OsmElement.Relation.Member(OsmElement.Type.WAY, childWay.id(), "inner"));
 
     List<OsmElement> elements = List.of(
       node(1, 0.1, 0.1),
@@ -574,7 +570,6 @@ class OsmReaderTest {
       node(12, 0.2, 0.7),
 
       childNode,
-      childWay,
       childRelation,
 
       relation


### PR DESCRIPTION
Some multipolygon relations are tagged with invalid members, such as nodes or relations with `role="outer"`.

For example, https://www.openstreetmap.org/relation/6717413

```xml
<relation id="6717413">
  <member type="relation" ref="6717409" role="outer"/>
  <member type="relation" ref="6717412" role="outer"/>
  <tag k="name" v="蔦島"/>
  <tag k="place" v="island"/>
  <tag k="type" v="multipolygon"/>
</relation>
```

Planetiler throws an error while encountering these, which doesn't prevent the run from finishing successfully, but does clutter up the logs.

I saw a relatively small number of the following exception during a planet run.

```
ERR [osm_pass2:process] - Error processing OSM Relation 6717413
--
com.onthegomap.planetiler.geo.GeometryException$Verbose: error building multipolygon 6717413: no rings to process
at com.onthegomap.planetiler.reader.osm.OsmMultipolygon.doBuild(OsmMultipolygon.java:167)
at com.onthegomap.planetiler.reader.osm.OsmMultipolygon.build(OsmMultipolygon.java:155)
at com.onthegomap.planetiler.reader.osm.OsmMultipolygon.build(OsmMultipolygon.java:133)
at com.onthegomap.planetiler.reader.osm.OsmReader$MultipolygonSourceFeature.computeWorldGeometry(OsmReader.java:802)
at com.onthegomap.planetiler.reader.osm.OsmReader$OsmFeature.worldGeometry(OsmReader.java:650)
at com.onthegomap.planetiler.reader.SourceFeature.computePolygon(SourceFeature.java:190)
at com.onthegomap.planetiler.reader.SourceFeature.polygon(SourceFeature.java:203)
at com.onthegomap.planetiler.reader.SourceFeature.pointOnSurface(SourceFeature.java:123)
```

This PR checks that multipolygon relations have at least one `way` member with `role="outer"` before attempting to construct the geometry for them.

This won't catch all mistakes (see other possible [invalid examples](https://wiki.openstreetmap.org/wiki/Relation:multipolygon#Invalid_examples)), but should prevent some log clutter for easily filterable cases.

