### PR TITLE
Improve docs for generating custom vector tiles with a schema yaml

### DIFF
--- a/planetiler-custommap/README.md
+++ b/planetiler-custommap/README.md
@@ -5,9 +5,9 @@ file as the first argument:
 
 ```bash
 # from a java build
-java -jar planetiler.jar generate-custom schema.yml
+java -jar planetiler.jar generate-custom --schema=schema.yml
 # or with docker (put the schema in data/schema.yml to include in the attached volume)
-docker run -v "$(pwd)/data":/data ghcr.io/onthegomap/planetiler:latest generate-custom /data/schema.yml
+docker run -v "$(pwd)/data":/data ghcr.io/onthegomap/planetiler:latest generate-custom --schema=/data/schema.yml
 ```
 
 Schema files are in [YAML 1.2](https://yaml.org) format and support [anchors and aliases](#anchors-and-aliases) for

--- a/planetiler-custommap/README.md
+++ b/planetiler-custommap/README.md
@@ -5,7 +5,7 @@ file as the first argument:
 
 ```bash
 # from a java build
-java -jar planetiler.jar schema.yml
+java -jar planetiler.jar generate-custom schema.yml
 # or with docker (put the schema in data/schema.yml to include in the attached volume)
 docker run -v "$(pwd)/data":/data ghcr.io/onthegomap/planetiler:latest generate-custom /data/schema.yml
 ```

--- a/planetiler-custommap/README.md
+++ b/planetiler-custommap/README.md
@@ -7,7 +7,7 @@ file as the first argument:
 # from a java build
 java -jar planetiler.jar schema.yml
 # or with docker (put the schema in data/schema.yml to include in the attached volume)
-docker run -v "$(pwd)/data":/data ghcr.io/onthegomap/planetiler:latest /data/schema.yml
+docker run -v "$(pwd)/data":/data ghcr.io/onthegomap/planetiler:latest generate-custom /data/schema.yml
 ```
 
 Schema files are in [YAML 1.2](https://yaml.org) format and support [anchors and aliases](#anchors-and-aliases) for


### PR DESCRIPTION
I followed the documentation at `planetiler-custommap/README.md` to generate custom vector tiles. However, until I found the `generate-custom` command referenced in PR #160, the standard vector tiles were being generated.

Contributing this PR to avoid others missing this. Or if I've missed something and `generate-custom` command need not be explicitly supplied in some situations?