### PR TITLE
Fix regex escaping in polygon file parsing

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/osm/PolyFileReader.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/osm/PolyFileReader.java
@@ -74,7 +74,7 @@ public class PolyFileReader {
             inRing = false;
           } else {
             // we are in a ring and picking up new coordinates.
-            String[] splitted = line.trim().split("\s+");
+            String[] splitted = line.trim().split("\\s+");
             currentRing.addPoint(Double.parseDouble(splitted[0]), Double.parseDouble(splitted[1]));
           }
         } else {


### PR DESCRIPTION
Escape the character once for the regex, and a second time for Java.

Without the fix, polygon files delimited by tab characters fail to parse.