### PR TITLE
Sort merged vector tile features by hilbert order

### DIFF
--- a/layerstats/README.md
+++ b/layerstats/README.md
@@ -24,6 +24,7 @@ The output is a gzipped tsv with a row per layer on each tile and the following 
 | layer               | layer name                                                                                                                                      |
 | layer_bytes         | encoded size of this layer on this tile                                                                                                         |
 | layer_features      | number of features in this layer                                                                                                                |
+| layer_geometries    | number of geometries in features in this layer, including inside multipoint/multipolygons/multilinestring features                              |
 | layer_attr_bytes    | encoded size of the [attribute key/value pairs](https://github.com/mapbox/vector-tile-spec/tree/master/2.1#44-feature-attributes) in this layer |
 | layer_attr_keys     | number of distinct attribute keys in this layer on this tile                                                                                    |
 | layer_attr_values   | number of distinct attribute values in this layer on this tile                                                                                  |
@@ -42,10 +43,10 @@ Then get the biggest layers:
 SELECT * FROM layerstats ORDER BY layer_bytes DESC LIMIT 2;
 ```
 
-| z  |   x   |  y   |  hilbert  | archived_tile_bytes |    layer    | layer_bytes | layer_features | layer_attr_bytes | layer_attr_keys | layer_attr_values |
-|----|-------|------|-----------|---------------------|-------------|-------------|----------------|------------------|-----------------|-------------------|
-| 14 | 13722 | 7013 | 305278258 | 1261474             | housenumber | 2412464     | 108384         | 30764            | 1               | 3021              |
-| 14 | 13723 | 7014 | 305278256 | 1064044             | housenumber | 1848990     | 83038          | 26022            | 1               | 2542              |
+| z  |   x   |  y   |  hilbert  | archived_tile_bytes |    layer    | layer_bytes | layer_features | layer_geometries | layer_attr_bytes | layer_attr_keys | layer_attr_values |
+|----|-------|------|-----------|---------------------|-------------|-------------|----------------|------------------|------------------|-----------------|-------------------|
+| 14 | 13722 | 7013 | 305278258 | 1260526             | housenumber | 2412589     | 108390         | 108390           | 30764            | 1               | 3021              |
+| 14 | 13723 | 7014 | 305278256 | 1059752             | housenumber | 1850041     | 83038          | 83038            | 26022            | 1               | 2542              |
 
 To get a table of biggest layers by zoom:
 

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureMerge.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureMerge.java
@@ -50,6 +50,9 @@ public class FeatureMerge {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(FeatureMerge.class);
   private static final BufferParameters bufferOps = new BufferParameters();
+  // this is slightly faster than Comparator.comparingInt
+  private static final Comparator<WithIndex<?>> BY_HILBERT_INDEX =
+    (o1, o2) -> Integer.compare(o1.hilbert, o2.hilbert);
 
   static {
     bufferOps.setJoinStyle(BufferParameters.JOIN_MITRE);
@@ -113,11 +116,6 @@ public class FeatureMerge {
   public static List<VectorTile.Feature> mergeMultiLineString(List<VectorTile.Feature> features) {
     return mergeGeometries(features, GeometryType.LINE);
   }
-
-  private static final Comparator<WithIndex<?>> BY_HILBERT_INDEX =
-    (o1, o2) -> Integer.compare(o1.hilbert(), o2.hilbert());
-
-  private record WithIndex<T> (T feature, int hilbert) {}
 
   private static List<VectorTile.Feature> mergeGeometries(
     List<VectorTile.Feature> features,
@@ -188,7 +186,7 @@ public class FeatureMerge {
               if (simplified instanceof LineString simpleLineString) {
                 line = simpleLineString;
               } else {
-                LOGGER.warn("line string merge simplify emitted " + simplified.getGeometryType());
+                LOGGER.warn("line string merge simplify emitted {}", simplified.getGeometryType());
               }
             }
             if (buffer >= 0) {
@@ -573,4 +571,6 @@ public class FeatureMerge {
     }
     return result;
   }
+
+  private record WithIndex<T> (T feature, int hilbert) {}
 }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureMerge.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureMerge.java
@@ -14,6 +14,7 @@ import com.onthegomap.planetiler.stats.Stats;
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -117,6 +118,7 @@ public class FeatureMerge {
     List<VectorTile.Feature> features,
     GeometryType geometryType
   ) {
+    features = features.stream().sorted(Comparator.comparingInt(f -> f.geometry().index())).toList();
     List<VectorTile.Feature> result = new ArrayList<>(features.size());
     var groupedByAttrs = groupByAttrs(features, result, geometryType);
     for (List<VectorTile.Feature> groupedFeatures : groupedByAttrs) {

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/VectorTile.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/VectorTile.java
@@ -425,7 +425,7 @@ public class VectorTile {
    * Returns the hilbert index of the zig-zag-encoded first point of {@code geometry}.
    * <p>
    * This can be useful for sorting geometries to minimize encoded vector tile geometry command size since smaller
-   * values take fewer bytes using protobuf varint encoding.
+   * offsets take fewer bytes using protobuf varint encoding.
    */
   public static int hilbertIndex(Geometry geometry) {
     Coordinate coord = geometry.getCoordinate();
@@ -961,6 +961,12 @@ public class VectorTile {
       }
     }
 
+    /**
+     * Returns the hilbert index of the zig-zag-encoded first point of this feature.
+     * <p>
+     * This can be useful for sorting geometries to minimize encoded vector tile geometry command size since smaller
+     * offsets take fewer bytes using protobuf varint encoding.
+     */
     public int hilbertIndex() {
       if (commands.length < 3) {
         return 0;

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/VectorTile.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/VectorTile.java
@@ -26,6 +26,7 @@ import com.onthegomap.planetiler.geo.GeoUtils;
 import com.onthegomap.planetiler.geo.GeometryException;
 import com.onthegomap.planetiler.geo.GeometryType;
 import com.onthegomap.planetiler.geo.MutableCoordinateSequence;
+import com.onthegomap.planetiler.util.Hilbert;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -922,6 +923,13 @@ public class VectorTile {
       } else {
         return this;
       }
+    }
+
+    public int index() {
+      // 0 -> 4096*2*2
+      int x = commands[1];
+      int y = commands[2];
+      return Hilbert.hilbertXYToIndex(14, x, y);
     }
   }
 

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/util/TileSizeStats.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/util/TileSizeStats.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
+import com.onthegomap.planetiler.VectorTile;
 import com.onthegomap.planetiler.archive.Tile;
 import com.onthegomap.planetiler.archive.TileArchiveConfig;
 import com.onthegomap.planetiler.archive.TileArchives;
@@ -175,6 +176,7 @@ public class TileSizeStats {
         layer.layer,
         layer.layerBytes,
         layer.layerFeatures,
+        layer.layerGeometries,
         layer.layerAttrBytes,
         layer.layerAttrKeys,
         layer.layerAttrValues
@@ -220,10 +222,15 @@ public class TileSizeStats {
       for (var value : layer.getValuesList()) {
         attrSize += value.getSerializedSize();
       }
+      int geomCount = 0;
+      for (var feature : layer.getFeaturesList()) {
+        geomCount += VectorTile.countGeometries(feature);
+      }
       result.add(new LayerStats(
         layer.getName(),
         layer.getSerializedSize(),
         layer.getFeaturesCount(),
+        geomCount,
         attrSize,
         layer.getKeysCount(),
         layer.getValuesCount()
@@ -243,6 +250,7 @@ public class TileSizeStats {
     "layer",
     "layer_bytes",
     "layer_features",
+    "layer_geometries",
     "layer_attr_bytes",
     "layer_attr_keys",
     "layer_attr_values"
@@ -257,6 +265,7 @@ public class TileSizeStats {
     String layer,
     int layerBytes,
     int layerFeatures,
+    int layerGeometries,
     int layerAttrBytes,
     int layerAttrKeys,
     int layerAttrValues
@@ -267,6 +276,7 @@ public class TileSizeStats {
     String layer,
     int layerBytes,
     int layerFeatures,
+    int layerGeometries,
     int layerAttrBytes,
     int layerAttrKeys,
     int layerAttrValues

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
@@ -2028,6 +2028,7 @@ class PlanetilerTests {
         "layer",
         "layer_bytes",
         "layer_features",
+        "layer_geometries",
         "layer_attr_bytes",
         "layer_attr_keys",
         "layer_attr_values"

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/util/TileSizeStatsTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/util/TileSizeStatsTest.java
@@ -40,8 +40,8 @@ class TileSizeStatsTest {
     var formatted = TileSizeStats.formatOutputRows(TileCoord.ofXYZ(1, 2, 3), 999, stats);
     assertEquals(
       """
-        z	x	y	hilbert	archived_tile_bytes	layer	layer_bytes	layer_features	layer_attr_bytes	layer_attr_keys	layer_attr_values
-        3	1	2	34	999	layer	55	1	18	2	2
+        z	x	y	hilbert	archived_tile_bytes	layer	layer_bytes	layer_features	layer_geometries	layer_attr_bytes	layer_attr_keys	layer_attr_values
+        3	1	2	34	999	layer	55	1	1	18	2	2
         """
         .trim(),
       (TileSizeStats.headerRow() + String.join("", formatted)).trim());
@@ -89,9 +89,9 @@ class TileSizeStatsTest {
     var formatted = TileSizeStats.formatOutputRows(TileCoord.ofXYZ(1, 2, 3), 999, stats);
     assertEquals(
       """
-        z	x	y	hilbert	archived_tile_bytes	layer	layer_bytes	layer_features	layer_attr_bytes	layer_attr_keys	layer_attr_values
-        3	1	2	34	999	a	72	2	20	2	3
-        3	1	2	34	999	b	19	1	0	0	0
+        z	x	y	hilbert	archived_tile_bytes	layer	layer_bytes	layer_features	layer_geometries	layer_attr_bytes	layer_attr_keys	layer_attr_values
+        3	1	2	34	999	a	72	2	2	20	2	3
+        3	1	2	34	999	b	19	1	1	0	0	0
         """
         .trim(),
       (TileSizeStats.headerRow() + String.join("", formatted)).trim());

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/util/TilesetSummaryStatisticsTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/util/TilesetSummaryStatisticsTest.java
@@ -15,12 +15,12 @@ class TilesetSummaryStatisticsTest {
     var updater1 = tileStats.threadLocalUpdater();
     var updater2 = tileStats.threadLocalUpdater();
     updater1.recordTile(TileCoord.ofXYZ(0, 0, 1), 123, List.of(
-      new TileSizeStats.LayerStats("a", 1, 2, 3, 4, 5),
-      new TileSizeStats.LayerStats("b", 6, 7, 8, 9, 10)
+      new TileSizeStats.LayerStats("a", 1, 2, 2, 3, 4, 5),
+      new TileSizeStats.LayerStats("b", 6, 7, 7, 8, 9, 10)
     ));
     updater2.recordTile(TileCoord.ofXYZ(0, 1, 1), 345, List.of(
-      new TileSizeStats.LayerStats("b", 1, 2, 3, 4, 5),
-      new TileSizeStats.LayerStats("c", 6, 7, 8, 9, 10)
+      new TileSizeStats.LayerStats("b", 1, 2, 2, 3, 4, 5),
+      new TileSizeStats.LayerStats("c", 6, 7, 7, 8, 9, 10)
     ));
     var summary = tileStats.summary();
     assertEquals(Set.of("a", "b", "c"), Set.copyOf(summary.layers()));
@@ -51,7 +51,7 @@ class TilesetSummaryStatisticsTest {
     assertEquals(2, summary.get().numTiles());
 
     updater1.recordTile(TileCoord.ofXYZ(0, 0, 2), 0, List.of(
-      new TileSizeStats.LayerStats("c", 10, 7, 8, 9, 10)
+      new TileSizeStats.LayerStats("c", 10, 7, 7, 8, 9, 10)
     ));
     assertEquals("""
                   z1    z2   all
@@ -101,8 +101,8 @@ class TilesetSummaryStatisticsTest {
     List<TilesetSummaryStatistics.TileSummary> summaries = new ArrayList<>();
     for (int i = 0; i < 20; i++) {
       var summary = new TilesetSummaryStatistics.TileSummary(TileCoord.decode(i), i, List.of(
-        new TileSizeStats.LayerStats("a", i * 2, i, 0, 0, 0),
-        new TileSizeStats.LayerStats("b", i * 3, i, 0, 0, 0)
+        new TileSizeStats.LayerStats("a", i * 2, i, i * 2, 0, 0, 0),
+        new TileSizeStats.LayerStats("b", i * 3, i, i * 2, 0, 0, 0)
       ));
       summaries.add(0, summary);
       (i % 2 == 0 ? updater1 : updater2).recordTile(summary.coord(), summary.archivedSize(), summary.layers());
@@ -140,21 +140,21 @@ class TilesetSummaryStatisticsTest {
     updater1.recordTile(
       TileCoord.ofXYZ(0, 0, 0),
       100,
-      List.of(new TileSizeStats.LayerStats("a", 10, 0, 0, 0, 0))
+      List.of(new TileSizeStats.LayerStats("a", 10, 0, 0, 0, 0, 0))
     );
     updater2.recordTile(
       TileCoord.ofXYZ(0, 0, 1),
       200,
       List.of(
-        new TileSizeStats.LayerStats("a", 20, 0, 0, 0, 0),
-        new TileSizeStats.LayerStats("b", 30, 0, 0, 0, 0)
+        new TileSizeStats.LayerStats("a", 20, 0, 0, 0, 0, 0),
+        new TileSizeStats.LayerStats("b", 30, 0, 0, 0, 0, 0)
       )
     );
     updater2.recordTile(
       TileCoord.ofXYZ(0, 0, 2), // no stats
       400,
       List.of(
-        new TileSizeStats.LayerStats("c", 40, 0, 0, 0, 0)
+        new TileSizeStats.LayerStats("c", 40, 0, 0, 0, 0, 0)
       )
     );
 
@@ -189,14 +189,14 @@ class TilesetSummaryStatisticsTest {
     updater1.recordTile(
       TileCoord.ofXYZ(0, 0, 0),
       100,
-      List.of(new TileSizeStats.LayerStats("a", 10, 0, 0, 0, 0))
+      List.of(new TileSizeStats.LayerStats("a", 10, 0, 0, 0, 0, 0))
     );
     updater2.recordTile(
       TileCoord.ofXYZ(0, 0, 1),
       200,
       List.of(
-        new TileSizeStats.LayerStats("a", 20, 0, 0, 0, 0),
-        new TileSizeStats.LayerStats("b", 30, 0, 0, 0, 0)
+        new TileSizeStats.LayerStats("a", 20, 0, 0, 0, 0, 0),
+        new TileSizeStats.LayerStats("b", 30, 0, 0, 0, 0, 0)
       )
     );
 


### PR DESCRIPTION
Slight improvement to utilities from #669 to sort geometries with the same attributes by hilbert index before merging them into a multigeometry.   This helps because every x/y command in a multigeometry is specified as a zig-zag-encoded offset from the previous x/y coordinate in an int array ([see spec](https://github.com/mapbox/vector-tile-spec/tree/master/2.1#431-command-integers)). That int array gets varint encoded to bytes by the protobuf encoder so sorting by hilbert order minimizes the x/y distance between subsequent geometries.

Also added a `layer_geometries` column to layerstats so it becomes more clear how many geometries are contained inside multigeometry features inside a tile.

This has no impact on weighted average tile size, but it does reduce the largest housenumber, building, and transportation layers by an additional 10-20% and the overall largest gzipped tile by 17% (680->566kb).

The impact on tile generation time appears to be minimal, but if it causes issues in the future we can limit so that we only sort features when more than a certain number (50-1000?) get merged into a multigeometry.

Before:
<img width="926" alt="image" src="https://github.com/onthegomap/planetiler/assets/1480504/3ba62041-adea-4d6a-8c2e-14081b0c6bc8">


After:
<img width="926" alt="image" src="https://github.com/onthegomap/planetiler/assets/1480504/75be40ae-9aec-4ac7-865e-9cd3bf943833">


