### PR TITLE
Fix log4j log format

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/util/LogUtil.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/util/LogUtil.java
@@ -14,7 +14,7 @@ public class LogUtil {
 
   /** Prepends {@code [stage]} to all subsequent logs from this thread. */
   public static void setStage(String stage) {
-    MDC.put(STAGE_KEY, stage);
+    MDC.put(STAGE_KEY, "[%s] ".formatted(stage));
   }
 
   /** Removes {@code [stage]} from subsequent logs from this thread. */

--- a/planetiler-core/src/main/resources/log4j2.properties
+++ b/planetiler-core/src/main/resources/log4j2.properties
@@ -2,7 +2,7 @@ appenders=console
 appender.console.type=Console
 appender.console.name=STDOUT
 appender.console.layout.type=PatternLayout
-appender.console.layout.pattern=%highlight{$${uptime:now} %level{length=3} %notEmpty{[%X{stage}] }- %msg%n%throwable}{FATAL=red, ERROR=red, WARN=YELLOW, INFO=normal, DEBUG=normal, TRACE=normal}
+appender.console.layout.pattern=%highlight{$${uptime:now} %level{length=3} %X{stage}- %msg%n%throwable}{FATAL=red, ERROR=red, WARN=YELLOW, INFO=normal, DEBUG=normal, TRACE=normal}
 packages=com.onthegomap.planetiler.util.log4j
 rootLogger.level=debug
 rootLogger.appenderRefs=stdout

--- a/planetiler-core/src/test/resources/log4j2-test.properties
+++ b/planetiler-core/src/test/resources/log4j2-test.properties
@@ -2,7 +2,7 @@ appenders=console
 appender.console.type=Console
 appender.console.name=STDOUT
 appender.console.layout.type=PatternLayout
-appender.console.layout.pattern=$${uptime:now} %level{length=3} %notEmpty{[%X{stage}] }- %msg%n%throwable
+appender.console.layout.pattern=$${uptime:now} %level{length=3} %X{stage}- %msg%n%throwable
 packages=com.onthegomap.planetiler.util.log4j
 rootLogger.level=warn
 rootLogger.appenderRefs=stdout


### PR DESCRIPTION
`%{notEmpty}` doesn't seem to work anymore with variables from MDC