### PR TITLE
Add API for maximum inscribed circle/pole of inaccessibility centerpoint of a polygon

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureCollector.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureCollector.java
@@ -15,6 +15,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import org.locationtech.jts.algorithm.construct.MaximumInscribedCircle;
 import org.locationtech.jts.geom.Geometry;
 
 /**
@@ -170,6 +171,30 @@ public class FeatureCollector implements Iterable<FeatureCollector.Feature> {
       e.log(stats, "feature_point_on_surface", "Error constructing point on surface for " + source.id());
       return new Feature(layer, EMPTY_GEOM, source.id());
     }
+  }
+
+  /**
+   * Starts building a new point map feature at the furthest interior point of a polygon from its edge using
+   * {@link MaximumInscribedCircle} (aka "pole of inaccessibility") of the source feature.
+   *
+   * @param layer     the output vector tile layer this feature will be written to
+   * @param tolerance precision for calculating maximum inscribed circle. 0.01 means 1% of the square root of the area.
+   *                  Smaller values for a more precise tolerance become very expensive to compute. Values between 5%
+   *                  and 10% are a good compromise of performance vs. precision.
+   * @return a feature that can be configured further.
+   */
+  public Feature innermostPoint(String layer, double tolerance) {
+    try {
+      return geometry(layer, source.innermostPoint(tolerance));
+    } catch (GeometryException e) {
+      e.log(stats, "feature_innermost_point", "Error constructing innermost point for " + source.id());
+      return new Feature(layer, EMPTY_GEOM, source.id());
+    }
+  }
+
+  /** Alias for {@link #innermostPoint(String, double)} with a default tolerance of 5%. */
+  public Feature innermostPoint(String layer) {
+    return innermostPoint(layer, 0.05);
   }
 
   /**

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureCollector.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureCollector.java
@@ -176,6 +176,9 @@ public class FeatureCollector implements Iterable<FeatureCollector.Feature> {
   /**
    * Starts building a new point map feature at the furthest interior point of a polygon from its edge using
    * {@link MaximumInscribedCircle} (aka "pole of inaccessibility") of the source feature.
+   * <p>
+   * NOTE: This is substantially more expensive to compute than {@link #centroid(String)} or
+   * {@link #pointOnSurface(String)}.
    *
    * @param layer     the output vector tile layer this feature will be written to
    * @param tolerance precision for calculating maximum inscribed circle. 0.01 means 1% of the square root of the area.
@@ -288,8 +291,8 @@ public class FeatureCollector implements Iterable<FeatureCollector.Feature> {
 
     /**
      * Sets the value by which features are sorted within a layer in the output vector tile. Sort key gets packed into
-     * {@link FeatureGroup#SORT_KEY_BITS} bits so the range of this is limited to {@code -(2^(bits-1))} to {@code
-     * (2^(bits-1))-1}.
+     * {@link FeatureGroup#SORT_KEY_BITS} bits so the range of this is limited to {@code -(2^(bits-1))} to
+     * {@code (2^(bits-1))-1}.
      * <p>
      * Circles, lines, and polygons are rendered in the order they appear in each layer, so features that appear later
      * (higher sort key) show up on top of features with a lower sort key.

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureCollector.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureCollector.java
@@ -195,9 +195,9 @@ public class FeatureCollector implements Iterable<FeatureCollector.Feature> {
     }
   }
 
-  /** Alias for {@link #innermostPoint(String, double)} with a default tolerance of 5%. */
+  /** Alias for {@link #innermostPoint(String, double)} with a default tolerance of 10%. */
   public Feature innermostPoint(String layer) {
-    return innermostPoint(layer, 0.05);
+    return innermostPoint(layer, 0.1);
   }
 
   /**

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureCollector.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureCollector.java
@@ -178,7 +178,7 @@ public class FeatureCollector implements Iterable<FeatureCollector.Feature> {
    * {@link MaximumInscribedCircle} (aka "pole of inaccessibility") of the source feature.
    * <p>
    * NOTE: This is substantially more expensive to compute than {@link #centroid(String)} or
-   * {@link #pointOnSurface(String)}.
+   * {@link #pointOnSurface(String)}, especially for small {@code tolerance} values.
    *
    * @param layer     the output vector tile layer this feature will be written to
    * @param tolerance precision for calculating maximum inscribed circle. 0.01 means 1% of the square root of the area.

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureCollector.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureCollector.java
@@ -230,6 +230,10 @@ public class FeatureCollector implements Iterable<FeatureCollector.Feature> {
       this.geom = geom;
       this.geometryType = GeometryType.typeOf(geom);
       this.id = id;
+      if (geometryType == GeometryType.POINT) {
+        minPixelSizeAtMaxZoom = 0;
+        defaultMinPixelSize = 0;
+      }
     }
 
     /** Returns the original ID of the source feature that this feature came from (i.e. OSM node/way ID). */
@@ -727,6 +731,16 @@ public class FeatureCollector implements Iterable<FeatureCollector.Feature> {
         ", geom=" + geom.getGeometryType() +
         ", attrs=" + attrs +
         '}';
+    }
+
+    /** Returns the actual pixel size of the source feature at {@code zoom} (length if line, sqrt(area) if polygon). */
+    public double getSourceFeaturePixelSizeAtZoom(int zoom) {
+      try {
+        return source.size() * (256 << zoom);
+      } catch (GeometryException e) {
+        e.log(stats, "point_get_size_failure", "Error getting min size for point from geometry " + source.id());
+        return 0;
+      }
     }
   }
 }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/SourceFeature.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/SourceFeature.java
@@ -39,6 +39,7 @@ public abstract class SourceFeature implements WithTags, WithGeometryType {
   private Geometry validPolygon = null;
   private double area = Double.NaN;
   private double length = Double.NaN;
+  private double size = Double.NaN;
 
   /**
    * Constructs a new input feature.
@@ -245,6 +246,14 @@ public abstract class SourceFeature implements WithTags, WithGeometryType {
       (isPoint() || canBePolygon() || canBeLine()) ? worldGeometry().getLength() : 0) : length;
   }
 
+  /**
+   * Returns and caches sqrt of {@link #area()} if polygon or {@link #length()} if a line string.
+   */
+  public double size() throws GeometryException {
+    return Double.isNaN(size) ? (size = canBePolygon() ? Math.sqrt(Math.abs(area())) : canBeLine() ? length() : 0) :
+      size;
+  }
+
   /** Returns the ID of the source that this feature came from. */
   public String getSource() {
     return source;
@@ -292,4 +301,5 @@ public abstract class SourceFeature implements WithTags, WithGeometryType {
   public boolean hasRelationInfo() {
     return relationInfos != null && !relationInfos.isEmpty();
   }
+
 }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/SourceFeature.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/SourceFeature.java
@@ -35,6 +35,8 @@ public abstract class SourceFeature implements WithTags, WithGeometryType {
   private Geometry centroid = null;
   private Geometry pointOnSurface = null;
   private Geometry centroidIfConvex = null;
+  private double innermostPointTolerance = Double.NaN;
+  private Geometry innermostPoint = null;
   private Geometry linearGeometry = null;
   private Geometry polygonGeometry = null;
   private Geometry validPolygon = null;
@@ -136,7 +138,12 @@ public abstract class SourceFeature implements WithTags, WithGeometryType {
    */
   public final Geometry innermostPoint(double tolerance) throws GeometryException {
     if (canBePolygon()) {
-      return MaximumInscribedCircle.getCenter(polygon(), Math.sqrt(area()) * tolerance);
+      // cache as long as the tolerance hasn't changed
+      if (tolerance != innermostPointTolerance || innermostPoint == null) {
+        innermostPoint = MaximumInscribedCircle.getCenter(polygon(), Math.sqrt(area()) * tolerance);
+        innermostPointTolerance = tolerance;
+      }
+      return innermostPoint;
     } else {
       return pointOnSurface();
     }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/SourceFeature.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/SourceFeature.java
@@ -7,6 +7,7 @@ import com.onthegomap.planetiler.reader.osm.OsmRelationInfo;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import org.locationtech.jts.algorithm.construct.MaximumInscribedCircle;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.Lineal;
@@ -124,6 +125,21 @@ public abstract class SourceFeature implements WithTags, WithGeometryType {
       canBePolygon() ? polygon().getInteriorPoint() :
         canBeLine() ? line().getInteriorPoint() :
         worldGeometry().getInteriorPoint());
+  }
+
+  /**
+   * Returns {@link MaximumInscribedCircle#getCenter()} of this geometry in world web mercator coordinates.
+   *
+   * @param tolerance precision for calculating maximum inscribed circle. 0.01 means 1% of the square root of the area.
+   *                  Smaller values for a more precise tolerance become very expensive to compute. Values between
+   *                  0.05-0.1 are a good compromise of performance vs. precision.
+   */
+  public final Geometry innermostPoint(double tolerance) throws GeometryException {
+    if (canBePolygon()) {
+      return MaximumInscribedCircle.getCenter(polygon(), Math.sqrt(area()) * tolerance);
+    } else {
+      return pointOnSurface();
+    }
   }
 
   private Geometry computeCentroidIfConvex() throws GeometryException {
@@ -301,5 +317,4 @@ public abstract class SourceFeature implements WithTags, WithGeometryType {
   public boolean hasRelationInfo() {
     return relationInfos != null && !relationInfos.isEmpty();
   }
-
 }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/render/FeatureRenderer.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/render/FeatureRenderer.java
@@ -97,6 +97,10 @@ public class FeatureRenderer implements Consumer<FeatureCollector.Feature>, Clos
       coords[i] = origCoords[i].copy();
     }
     for (int zoom = feature.getMaxZoom(); zoom >= feature.getMinZoom(); zoom--) {
+      double minSize = feature.getMinPixelSizeAtZoom(zoom);
+      if (minSize > 0 && feature.getSourceFeaturePixelSizeAtZoom(zoom) < minSize) {
+        continue;
+      }
       Map<String, Object> attrs = feature.getAttrsAtZoom(zoom);
       double buffer = feature.getBufferPixelsAtZoom(zoom) / 256;
       int tilesAtZoom = 1 << zoom;
@@ -207,7 +211,7 @@ public class FeatureRenderer implements Consumer<FeatureCollector.Feature>, Clos
       }
       Map<String, Object> attrs = feature.getAttrsAtZoom(sliced.zoomLevel());
       if (numPointsAttr != null) {
-        // if profile wants the original number of points that the simplified but untiled geometry started with
+        // if profile wants the original number off points that the simplified but untiled geometry started with
         attrs = new HashMap<>(attrs);
         attrs.put(numPointsAttr, geom.getNumPoints());
       }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/FeatureCollectorTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/FeatureCollectorTest.java
@@ -503,9 +503,9 @@ class FeatureCollectorTest {
     var sourceLine = newReaderFeature(newPolygon(worldToLatLon(
       0, 0,
       1, 0,
-      1, 0.25,
-      0.25, 0.25,
-      0.25, 1,
+      1, 0.5,
+      0.5, 0.5,
+      0.5, 1,
       0, 1,
       0, 0
     )), Map.of());
@@ -516,7 +516,7 @@ class FeatureCollectorTest {
 
     var item = iter.next();
     assertEquals(GeometryType.POINT, item.getGeometryType());
-    assertEquals(round(newPoint(0.14, 0.14)), round(item.getGeometry(), 1e2));
+    assertEquals(round(newPoint(0.28, 0.28)), round(item.getGeometry(), 1e2));
 
     assertFalse(iter.hasNext());
   }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/FeatureCollectorTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/FeatureCollectorTest.java
@@ -494,6 +494,34 @@ class FeatureCollectorTest {
   }
 
   @Test
+  void testInnermostPoint() {
+    /*
+      _____
+     | · __|
+     |__|
+     */
+    var sourceLine = newReaderFeature(newPolygon(worldToLatLon(
+      0, 0,
+      1, 0,
+      1, 0.25,
+      0.25, 0.25,
+      0.25, 1,
+      0, 1,
+      0, 0
+    )), Map.of());
+
+    var fc = factory.get(sourceLine);
+    fc.innermostPoint("layer").setZoomRange(0, 10);
+    var iter = fc.iterator();
+
+    var item = iter.next();
+    assertEquals(GeometryType.POINT, item.getGeometryType());
+    assertEquals(round(newPoint(0.14, 0.14)), round(item.getGeometry(), 1e2));
+
+    assertFalse(iter.hasNext());
+  }
+
+  @Test
   void testMultiPolygonCoercion() throws GeometryException {
     var sourceLine = newReaderFeature(newMultiPolygon(
       newPolygon(worldToLatLon(

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/FeatureCollectorTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/FeatureCollectorTest.java
@@ -614,5 +614,4 @@ class FeatureCollectorTest {
       )
     ), collector);
   }
-
 }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
@@ -2435,35 +2435,6 @@ class PlanetilerTests {
   }
 
   @Test
-  void testAttributeMinSize() throws Exception {
-    List<Coordinate> points = z14PixelRectangle(0, 40);
-
-    var results = runWithReaderFeatures(
-      Map.of("threads", "1"),
-      List.of(
-        newReaderFeature(newLineString(points), Map.of())
-      ),
-      (in, features) -> features.centroid("layer")
-        .setZoomRange(0, 14)
-        .setAttrWithMinPixelSizeBelowZoom("")
-        .setBufferPixels(0)
-        .setMinPixelSize(10) // should only show up z14 (40) z13 (20) and z12 (10)
-    );
-
-    assertEquals(Map.ofEntries(
-      newTileEntry(Z12_TILES / 2, Z12_TILES / 2, 12, List.of(
-        feature(newPoint(5, 1), Map.of())
-      )),
-      newTileEntry(Z13_TILES / 2, Z13_TILES / 2, 13, List.of(
-        feature(newPoint(10, 2), Map.of())
-      )),
-      newTileEntry(Z14_TILES / 2, Z14_TILES / 2, 14, List.of(
-        feature(newPoint(20, 4), Map.of())
-      ))
-    ), results.tiles);
-  }
-
-  @Test
   void testBoundFiltersFill() throws Exception {
     var polyResultz8 = runForBoundsTest(8, 8, "polygon", TestUtils.pathToResource("bottomrightearth.poly").toString());
 

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
@@ -2435,6 +2435,35 @@ class PlanetilerTests {
   }
 
   @Test
+  void testAttributeMinSize() throws Exception {
+    List<Coordinate> points = z14PixelRectangle(0, 40);
+
+    var results = runWithReaderFeatures(
+      Map.of("threads", "1"),
+      List.of(
+        newReaderFeature(newLineString(points), Map.of())
+      ),
+      (in, features) -> features.centroid("layer")
+        .setZoomRange(0, 14)
+        .setAttrWithMinPixelSizeBelowZoom("")
+        .setBufferPixels(0)
+        .setMinPixelSize(10) // should only show up z14 (40) z13 (20) and z12 (10)
+    );
+
+    assertEquals(Map.ofEntries(
+      newTileEntry(Z12_TILES / 2, Z12_TILES / 2, 12, List.of(
+        feature(newPoint(5, 1), Map.of())
+      )),
+      newTileEntry(Z13_TILES / 2, Z13_TILES / 2, 13, List.of(
+        feature(newPoint(10, 2), Map.of())
+      )),
+      newTileEntry(Z14_TILES / 2, Z14_TILES / 2, 14, List.of(
+        feature(newPoint(20, 4), Map.of())
+      ))
+    ), results.tiles);
+  }
+
+  @Test
   void testBoundFiltersFill() throws Exception {
     var polyResultz8 = runForBoundsTest(8, 8, "polygon", TestUtils.pathToResource("bottomrightearth.poly").toString());
 


### PR DESCRIPTION
Add a new feature API `feature.innermostPoint("layer")` that emits an interior point that is the furthest distance away from the edge of a polygon using the JTS `MaximumInscribedCircle` utility. 

JTS uses a variant of the [polylabel](https://github.com/mapbox/polylabel) algorithm that uses an iterative approach to find that point and stops when it's within a certain tolerance of that point. So this API also lets you set the tolerance., but it is still an expensive operation (~10-100x slower than centroid).  It gets more expensive the tighter the `tolerance` threshold is so we use 10% of square root of the area by default. This larger tolerance also keeps the center from straying too far from the center of the bounding box of a polygon as it searches for the "perfect" point, which makes it look a bit better for long thin rectangular shapes like pennsylvania.

So use it judiciously, and be careful about lowering the tolerance value.

<img width="1200" alt="image" src="https://github.com/onthegomap/planetiler/assets/1480504/6735d030-5ba4-48a8-aae4-496204d65367">