### PR TITLE
Add `setAttrWithMinSize` to feature API

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureCollector.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureCollector.java
@@ -738,7 +738,9 @@ public class FeatureCollector implements Iterable<FeatureCollector.Feature> {
      * shows when {@code minZoomIfBigEnough <= zoom_level < minZoomToShowAlways} when it is at least
      * {@code minPixelSize} pixels in size.
      * <p>
-     * If you need more flexibility, use {@link #getMinZoomForPixelSize(double)} directly.
+     * If you need more flexibility, use {@link #getMinZoomForPixelSize(double)} directly, or create a
+     * {@link ZoomFunction} that calculates {@link #getPixelSizeAtZoom(int)} and applies a custom threshold based on the
+     * zoom level.
      */
     public Feature setAttrWithMinSize(String key, Object value, double minPixelSize, int minZoomIfBigEnough,
       int minZoomToShowAlways) {

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/GeoUtils.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/GeoUtils.java
@@ -1,6 +1,7 @@
 package com.onthegomap.planetiler.geo;
 
 import com.onthegomap.planetiler.collection.LongLongMap;
+import com.onthegomap.planetiler.config.PlanetilerConfig;
 import com.onthegomap.planetiler.stats.Stats;
 import java.util.ArrayList;
 import java.util.List;
@@ -51,6 +52,7 @@ public class GeoUtils {
   public static final double WORLD_CIRCUMFERENCE_METERS = Math.PI * 2 * WORLD_RADIUS_METERS;
   private static final double RADIANS_PER_DEGREE = Math.PI / 180;
   private static final double DEGREES_PER_RADIAN = 180 / Math.PI;
+  private static final double LOG2 = Math.log(2);
   /**
    * Transform web mercator coordinates where top-left corner of the planet is (0,0) and bottom-right is (1,1) to
    * latitude/longitude coordinates.
@@ -532,6 +534,18 @@ public class GeoUtils {
     }
     return innerGeometries.size() == 1 ? innerGeometries.getFirst() :
       JTS_FACTORY.createGeometryCollection(innerGeometries.toArray(Geometry[]::new));
+  }
+
+  /**
+   * For a feature of size {@code worldGeometrySize} (where 1=full planet), determine the minimum zoom level at which
+   * the feature appears at least {@code minPixelSize} pixels large.
+   * <p>
+   * The result will be clamped to the range [0, {@link PlanetilerConfig#MAX_MAXZOOM}].
+   */
+  public static int minZoomForPixelSize(double worldGeometrySize, double minPixelSize) {
+    double worldPixels = worldGeometrySize * 256;
+    return Math.clamp((int) Math.ceil(Math.log(minPixelSize / worldPixels) / LOG2), 0,
+      PlanetilerConfig.MAX_MAXZOOM);
   }
 
   /** Helper class to sort polygons by area of their outer shell. */

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
@@ -87,6 +87,8 @@ class PlanetilerTests {
   private static final double Z13_WIDTH = 1d / Z13_TILES;
   private static final int Z12_TILES = 1 << 12;
   private static final double Z12_WIDTH = 1d / Z12_TILES;
+  private static final int Z11_TILES = 1 << 11;
+  private static final double Z11_WIDTH = 1d / Z11_TILES;
   private static final int Z4_TILES = 1 << 4;
   private static final Polygon WORLD_POLYGON = newPolygon(
     worldCoordinateList(
@@ -2430,6 +2432,74 @@ class PlanetilerTests {
       )),
       newTileEntry(Z14_TILES / 2, Z14_TILES / 2, 14, List.of(
         feature(newPoint(20, 4), Map.of())
+      ))
+    ), results.tiles);
+  }
+
+  @Test
+  void testAttributeMinSizeLine() throws Exception {
+    List<Coordinate> points = z14CoordinatePixelList(0, 4, 40, 4);
+
+    var results = runWithReaderFeatures(
+      Map.of("threads", "1"),
+      List.of(
+        newReaderFeature(newLineString(points), Map.of())
+      ),
+      (in, features) -> features.line("layer")
+        .setZoomRange(11, 14)
+        .setBufferPixels(0)
+        .setAttrWithMinSize("a", "1", 10)
+        .setAttrWithMinSize("b", "2", 20)
+        .setAttrWithMinSize("c", "3", 40)
+        .setAttrWithMinSize("d", "4", 40, 0, 13) // should show up at z13 and above
+    );
+
+    assertEquals(Map.ofEntries(
+      newTileEntry(Z11_TILES / 2, Z11_TILES / 2, 11, List.of(
+        feature(newLineString(0, 0.5, 5, 0.5), Map.of())
+      )),
+      newTileEntry(Z12_TILES / 2, Z12_TILES / 2, 12, List.of(
+        feature(newLineString(0, 1, 10, 1), Map.of("a", "1"))
+      )),
+      newTileEntry(Z13_TILES / 2, Z13_TILES / 2, 13, List.of(
+        feature(newLineString(0, 2, 20, 2), Map.of("a", "1", "b", "2", "d", "4"))
+      )),
+      newTileEntry(Z14_TILES / 2, Z14_TILES / 2, 14, List.of(
+        feature(newLineString(0, 4, 40, 4), Map.of("a", "1", "b", "2", "c", "3", "d", "4"))
+      ))
+    ), results.tiles);
+  }
+
+  @Test
+  void testAttributeMinSizePoint() throws Exception {
+    List<Coordinate> points = z14CoordinatePixelList(0, 4, 40, 4);
+
+    var results = runWithReaderFeatures(
+      Map.of("threads", "1"),
+      List.of(
+        newReaderFeature(newLineString(points), Map.of())
+      ),
+      (in, features) -> features.centroid("layer")
+        .setZoomRange(11, 14)
+        .setBufferPixels(0)
+        .setAttrWithMinSize("a", "1", 10)
+        .setAttrWithMinSize("b", "2", 20)
+        .setAttrWithMinSize("c", "3", 40)
+        .setAttrWithMinSize("d", "4", 40, 0, 13) // should show up at z13 and above
+    );
+
+    assertEquals(Map.ofEntries(
+      newTileEntry(Z11_TILES / 2, Z11_TILES / 2, 11, List.of(
+        feature(newPoint(2.5, 0.5), Map.of())
+      )),
+      newTileEntry(Z12_TILES / 2, Z12_TILES / 2, 12, List.of(
+        feature(newPoint(5, 1), Map.of("a", "1"))
+      )),
+      newTileEntry(Z13_TILES / 2, Z13_TILES / 2, 13, List.of(
+        feature(newPoint(10, 2), Map.of("a", "1", "b", "2", "d", "4"))
+      )),
+      newTileEntry(Z14_TILES / 2, Z14_TILES / 2, 14, List.of(
+        feature(newPoint(20, 4), Map.of("a", "1", "b", "2", "c", "3", "d", "4"))
       ))
     ), results.tiles);
   }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/GeoUtilsTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/GeoUtilsTest.java
@@ -447,4 +447,30 @@ class GeoUtilsTest {
     assertTrue(result.isValid());
     assertFalse(result.contains(point));
   }
+
+  @ParameterizedTest
+  @CsvSource({
+    "1,0,0",
+    "1,10,0",
+    "1,255,0",
+
+    "0.5,0,0",
+    "0.5,128,0",
+    "0.5,129,1",
+    "0.5,256,1",
+
+    "0.25,0,0",
+    "0.25,128,1",
+    "0.25,129,2",
+    "0.25,256,2",
+  })
+  void minZoomForPixelSize(double worldGeometrySize, double minPixelSize, int expectedMinZoom) {
+    assertEquals(expectedMinZoom, GeoUtils.minZoomForPixelSize(worldGeometrySize, minPixelSize));
+  }
+
+  @Test
+  void minZoomForPixelSizesAtZ9_10() {
+    assertEquals(10, GeoUtils.minZoomForPixelSize(3.1 / (256 << 10), 3));
+    assertEquals(9, GeoUtils.minZoomForPixelSize(6.1 / (256 << 10), 3));
+  }
 }


### PR DESCRIPTION
Add a new `features.getMinZoomForPixelSize(zoom)` method to feature API that returns the minimum zoom level at which a feature is a certain size in pixels, and a convenience `feature.setAttrWithMinSize(key, value, minPixelSize)` method that uses it to set the min zoom based on feature size.

For more flexibility you can do math on the result of `features.getMinZoomForPixelSize(zoom)` or create a `ZoomFunction` that calculates `feature.getPixelSizeAtZoom(zoom)` and applies a custom threshold based on the zoom level.