### PR TITLE
Use maven build time for docker image

### DIFF
--- a/planetiler-dist/pom.xml
+++ b/planetiler-dist/pom.xml
@@ -79,6 +79,8 @@
               </org.opencontainers.image.source>
             </labels>
             <mainClass>${mainClass}</mainClass>
+            <creationTime>${maven.build.timestamp}</creationTime>
+            <filesModificationTime>${maven.build.timestamp}</filesModificationTime>
           </container>
         </configuration>
       </plugin>


### PR DESCRIPTION
Apply https://github.com/openmaptiles/planetiler-openmaptiles/pull/134 to planetiler's docker image as well so that the docker image shows the actual build timestamp instead of 1/1/1970.

Before change:

```
❯ docker image ls
REPOSITORY                      TAG            IMAGE ID       CREATED        SIZE
ghcr.io/onthegomap/planetiler   0.7-SNAPSHOT   7f320cc94a93   53 years ago   361MB
```

After change:

```
❯ docker image ls
REPOSITORY                      TAG            IMAGE ID       CREATED          SIZE
ghcr.io/onthegomap/planetiler   0.7-SNAPSHOT   b110ece1bf31   23 seconds ago   361MB
```

Jib was doing this to try to make the builds reproducible so if you build multiple times from the same code it doesn't generate new images - but planetiler includes a `buildinfo.properties` file that includes the current build time anyway so it would generate a new image no matter what so we might as well make the image info useful.