### PR TITLE
Compute layer attr stats from actual vector tile features

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/VectorTile.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/VectorTile.java
@@ -81,7 +81,7 @@ public class VectorTile {
   private static final int EXTENT = 4096;
   private static final double SIZE = 256d;
   private final Map<String, Layer> layers = new LinkedHashMap<>();
-  private LayerAttrStats.Updater.ForZoom layerStatsTracker = LayerAttrStats.Updater.ForZoom.NO_OP;
+  private LayerAttrStats.Updater.ForZoom layerStatsTracker = LayerAttrStats.Updater.ForZoom.NOOP;
 
   private static int[] getCommands(Geometry input, int scale) {
     var encoder = new CommandEncoder(scale);
@@ -599,6 +599,11 @@ public class VectorTile {
     return layers.values().stream().allMatch(v -> v.encodedFeatures.isEmpty()) || containsOnlyFillsOrEdges();
   }
 
+  /**
+   * Call back to {@code layerStats} as vector tile features are being encoded in
+   * {@link #addLayerFeatures(String, List)} to track attribute types present on features in each layer, for example to
+   * emit in tilejson metadata stats.
+   */
   public void trackLayerStats(LayerAttrStats.Updater.ForZoom layerStats) {
     this.layerStatsTracker = layerStats;
   }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/VectorTile.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/VectorTile.java
@@ -27,6 +27,7 @@ import com.onthegomap.planetiler.geo.GeometryException;
 import com.onthegomap.planetiler.geo.GeometryType;
 import com.onthegomap.planetiler.geo.MutableCoordinateSequence;
 import com.onthegomap.planetiler.util.Hilbert;
+import com.onthegomap.planetiler.util.LayerAttrStats;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -80,6 +81,7 @@ public class VectorTile {
   private static final int EXTENT = 4096;
   private static final double SIZE = 256d;
   private final Map<String, Layer> layers = new LinkedHashMap<>();
+  private LayerAttrStats.Updater.ForZoom layerStatsTracker = LayerAttrStats.Updater.ForZoom.NO_OP;
 
   private static int[] getCommands(Geometry input, int scale) {
     var encoder = new CommandEncoder(scale);
@@ -467,12 +469,12 @@ public class VectorTile {
     if (features.isEmpty()) {
       return this;
     }
-
     Layer layer = layers.get(layerName);
     if (layer == null) {
       layer = new Layer();
       layers.put(layerName, layer);
     }
+    var statsTracker = layerStatsTracker.forLayer(layerName);
 
     for (Feature inFeature : features) {
       if (inFeature != null && inFeature.geometry().commands().length > 0) {
@@ -481,8 +483,11 @@ public class VectorTile {
         for (Map.Entry<String, ?> e : inFeature.attrs().entrySet()) {
           // skip attribute without value
           if (e.getValue() != null) {
-            outFeature.tags.add(layer.key(e.getKey()));
-            outFeature.tags.add(layer.value(e.getValue()));
+            String key = e.getKey();
+            Object value = e.getValue();
+            outFeature.tags.add(layer.key(key));
+            outFeature.tags.add(layer.value(value));
+            statsTracker.accept(key, value);
           }
         }
 
@@ -592,6 +597,10 @@ public class VectorTile {
    */
   public boolean likelyToBeDuplicated() {
     return layers.values().stream().allMatch(v -> v.encodedFeatures.isEmpty()) || containsOnlyFillsOrEdges();
+  }
+
+  public void trackLayerStats(LayerAttrStats.Updater.ForZoom layerStats) {
+    this.layerStatsTracker = layerStats;
   }
 
   enum Command {

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/archive/WriteableTileArchive.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/archive/WriteableTileArchive.java
@@ -30,7 +30,7 @@ public interface WriteableTileArchive extends Closeable {
    * Called before any tiles are written into {@link TileWriter}. Implementations of TileArchive should set up any
    * required state here.
    */
-  default void initialize(TileArchiveMetadata metadata) {}
+  default void initialize() {}
 
   /**
    * Implementations should return a object that implements {@link TileWriter} The specific TileWriter returned might

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/collection/FeatureGroup.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/collection/FeatureGroup.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import javax.annotation.concurrent.NotThreadSafe;
 import org.msgpack.core.MessageBufferPacker;
@@ -59,7 +58,6 @@ public final class FeatureGroup implements Iterable<FeatureGroup.TileFeatures>, 
   private final CommonStringEncoder.AsByte commonLayerStrings = new CommonStringEncoder.AsByte();
   private final CommonStringEncoder commonValueStrings = new CommonStringEncoder(100_000);
   private final Stats stats;
-  private final LayerAttrStats layerStats = new LayerAttrStats();
   private final PlanetilerConfig config;
   private volatile boolean prepared = false;
   private final TileOrder tileOrder;
@@ -141,14 +139,6 @@ public final class FeatureGroup implements Iterable<FeatureGroup.TileFeatures>, 
     return (byte) ((geometry.geomType().asByte() & 0xff) | (geometry.scale() << 3));
   }
 
-  /**
-   * Returns statistics about each layer written through {@link #newRenderedFeatureEncoder()} including min/max zoom,
-   * features on elements in that layer, and their types.
-   */
-  public LayerAttrStats layerStats() {
-    return layerStats;
-  }
-
   public long numFeaturesWritten() {
     return sorter.numFeaturesWritten();
   }
@@ -159,16 +149,13 @@ public final class FeatureGroup implements Iterable<FeatureGroup.TileFeatures>, 
       // This method gets called billions of times when generating the planet, so these optimizations make a big difference:
       // 1) Re-use the same buffer packer to avoid allocating and resizing new byte arrays for every feature.
       private final MessageBufferPacker packer = MessagePack.newDefaultBufferPacker();
-      // 2) Avoid a ThreadLocal lookup on every layer stats call by getting the handler for this thread once
-      private final Consumer<RenderedFeature> threadLocalLayerStats = layerStats.handlerForThread();
-      // 3) Avoid re-encoding values for identical filled geometries (i.e. ocean) by memoizing the encoded values
+      // 2) Avoid re-encoding values for identical filled geometries (i.e. ocean) by memoizing the encoded values
       // FeatureRenderer ensures that a separate VectorTileEncoder.Feature is used for each zoom level
       private VectorTile.Feature lastFeature = null;
       private byte[] lastEncodedValue = null;
 
       @Override
       public SortableFeature apply(RenderedFeature feature) {
-        threadLocalLayerStats.accept(feature);
         var group = feature.group().orElse(null);
         var thisFeature = feature.vectorTileFeature();
         byte[] encodedValue;
@@ -450,7 +437,14 @@ public final class FeatureGroup implements Iterable<FeatureGroup.TileFeatures>, 
     }
 
     public VectorTile getVectorTile() {
+      return getVectorTile(null);
+    }
+
+    public VectorTile getVectorTile(LayerAttrStats.Updater layerStats) {
       VectorTile tile = new VectorTile();
+      if (layerStats != null) {
+        tile.trackLayerStats(layerStats.forZoom(tileCoord.z()));
+      }
       List<VectorTile.Feature> items = new ArrayList<>(entries.size());
       String currentLayer = null;
       for (SortableFeature entry : entries) {

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/mbtiles/Mbtiles.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/mbtiles/Mbtiles.java
@@ -220,7 +220,7 @@ public final class Mbtiles implements WriteableTileArchive, ReadableTileArchive 
   }
 
   @Override
-  public void initialize(TileArchiveMetadata tileArchiveMetadata) {
+  public void initialize() {
     if (skipIndexCreation) {
       createTablesWithoutIndexes();
       if (LOGGER.isInfoEnabled()) {
@@ -230,12 +230,11 @@ public final class Mbtiles implements WriteableTileArchive, ReadableTileArchive 
     } else {
       createTablesWithIndexes();
     }
-
-    metadataTable().set(tileArchiveMetadata);
   }
 
   @Override
   public void finish(TileArchiveMetadata tileArchiveMetadata) {
+    metadataTable().set(tileArchiveMetadata);
     if (vacuumAnalyze) {
       vacuumAnalyze();
     }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/stream/WriteableJsonStreamArchive.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/stream/WriteableJsonStreamArchive.java
@@ -76,11 +76,11 @@ public final class WriteableJsonStreamArchive extends WriteableStreamArchive {
   }
 
   @Override
-  public void initialize(TileArchiveMetadata metadata) {
+  public void initialize() {
     if (writeTilesOnly) {
       return;
     }
-    writeEntryFlush(new InitializationEntry(metadata));
+    writeEntryFlush(new InitializationEntry());
   }
 
   @Override
@@ -204,7 +204,7 @@ public final class WriteableJsonStreamArchive extends WriteableStreamArchive {
     }
   }
 
-  record InitializationEntry(TileArchiveMetadata metadata) implements Entry {}
+  record InitializationEntry() implements Entry {}
 
 
   record FinishEntry(TileArchiveMetadata metadata) implements Entry {}

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/stream/WriteableProtoStreamArchive.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/stream/WriteableProtoStreamArchive.java
@@ -50,14 +50,8 @@ public final class WriteableProtoStreamArchive extends WriteableStreamArchive {
   }
 
   @Override
-  public void initialize(TileArchiveMetadata metadata) {
-    writeEntry(
-      StreamArchiveProto.Entry.newBuilder()
-        .setInitialization(
-          StreamArchiveProto.InitializationEntry.newBuilder().setMetadata(toExportData(metadata)).build()
-        )
-        .build()
-    );
+  public void initialize() {
+    writeEntry(StreamArchiveProto.Entry.newBuilder().build());
   }
 
   @Override

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/util/LayerAttrStats.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/util/LayerAttrStats.java
@@ -61,6 +61,7 @@ public class LayerAttrStats {
       .toList();
   }
 
+  /** Shortcut for tests */
   void accept(String layer, int zoom, String key, Object value) {
     handlerForThread().forZoom(zoom).forLayer(layer).accept(key, value);
   }
@@ -160,7 +161,7 @@ public class LayerAttrStats {
 
     interface ForZoom {
 
-      ForZoom NO_OP = layer -> (key, value) -> {
+      ForZoom NOOP = layer -> (key, value) -> {
       };
 
       ForLayer forLayer(String layer);
@@ -171,7 +172,7 @@ public class LayerAttrStats {
     }
   }
 
-  public static class StatsForLayer {
+  private static class StatsForLayer {
 
     private final String layer;
     private final Map<String, FieldType> fields = new HashMap<>();

--- a/planetiler-core/src/main/proto/stream_archive_proto.proto
+++ b/planetiler-core/src/main/proto/stream_archive_proto.proto
@@ -1,4 +1,3 @@
-
 syntax = "proto3";
 
 package com.onthegomap.planetiler.proto;
@@ -19,7 +18,6 @@ message TileEntry {
 }
 
 message InitializationEntry {
-  Metadata metadata = 1;
 }
 
 message FinishEntry {

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/pmtiles/PmtilesTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/pmtiles/PmtilesTest.java
@@ -188,7 +188,7 @@ class PmtilesTest {
 
     var config = PlanetilerConfig.defaults();
     var metadata = new TileArchiveMetadata(new Profile.NullProfile(), config);
-    in.initialize(metadata);
+    in.initialize();
     var writer = in.newTileWriter();
     writer.write(new TileEncodingResult(TileCoord.ofXYZ(0, 0, 1), new byte[]{0xa, 0x2}, OptionalLong.empty()));
 
@@ -259,7 +259,7 @@ class PmtilesTest {
       var channel = new SeekableInMemoryByteChannel(0);
       var in = WriteablePmtiles.newWriteToMemory(channel)
     ) {
-      in.initialize(input);
+      in.initialize();
       var writer = in.newTileWriter();
       writer.write(new TileEncodingResult(TileCoord.ofXYZ(0, 0, 0), new byte[]{0xa, 0x2}, OptionalLong.empty()));
 
@@ -299,7 +299,7 @@ class PmtilesTest {
 
     var config = PlanetilerConfig.defaults();
     var metadata = new TileArchiveMetadata(new Profile.NullProfile(), config);
-    in.initialize(metadata);
+    in.initialize();
     var writer = in.newTileWriter();
     writer.write(new TileEncodingResult(TileCoord.ofXYZ(0, 0, 0), new byte[]{0xa, 0x2}, OptionalLong.of(42)));
     writer.write(new TileEncodingResult(TileCoord.ofXYZ(0, 0, 1), new byte[]{0xa, 0x2}, OptionalLong.of(42)));
@@ -337,7 +337,7 @@ class PmtilesTest {
 
     var config = PlanetilerConfig.defaults();
     var metadata = new TileArchiveMetadata(new Profile.NullProfile(), config);
-    in.initialize(metadata);
+    in.initialize();
     var writer = in.newTileWriter();
     writer.write(new TileEncodingResult(TileCoord.ofXYZ(0, 0, 1), new byte[]{0xa, 0x2}, OptionalLong.of(42)));
     writer.write(new TileEncodingResult(TileCoord.ofXYZ(0, 0, 0), new byte[]{0xa, 0x2}, OptionalLong.of(42)));
@@ -372,7 +372,7 @@ class PmtilesTest {
 
     var config = PlanetilerConfig.defaults();
     var metadata = new TileArchiveMetadata(new Profile.NullProfile(), config);
-    in.initialize(metadata);
+    in.initialize();
     var writer = in.newTileWriter();
 
     int ENTRIES = 20000;

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/stream/WriteableCsvArchiveTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/stream/WriteableCsvArchiveTest.java
@@ -32,7 +32,7 @@ class WriteableCsvArchiveTest {
     final Path csvFile = tempDir.resolve("out.csv");
 
     try (var archive = WriteableCsvArchive.newWriteToFile(format, csvFile, defaultConfig)) {
-      archive.initialize(defaultMetadata); // ignored
+      archive.initialize();
       try (var tileWriter = archive.newTileWriter()) {
         tileWriter.write(new TileEncodingResult(TileCoord.ofXYZ(0, 0, 0), new byte[]{0}, OptionalLong.empty()));
         tileWriter.write(new TileEncodingResult(TileCoord.ofXYZ(1, 2, 3), new byte[]{1}, OptionalLong.of(1)));
@@ -67,7 +67,7 @@ class WriteableCsvArchiveTest {
     try (
       var archive = WriteableCsvArchive.newWriteToFile(TileArchiveConfig.Format.CSV, csvFilePrimary, defaultConfig)
     ) {
-      archive.initialize(defaultMetadata); // ignored
+      archive.initialize();
       try (var tileWriter = archive.newTileWriter()) {
         tileWriter.write(new TileEncodingResult(TileCoord.ofXYZ(11, 12, 1), new byte[]{0}, OptionalLong.empty()));
         tileWriter.write(new TileEncodingResult(TileCoord.ofXYZ(21, 22, 2), new byte[]{1}, OptionalLong.empty()));
@@ -159,7 +159,7 @@ class WriteableCsvArchiveTest {
     final Path csvFile = tempDir.resolve("out.csv");
 
     try (var archive = WriteableCsvArchive.newWriteToFile(TileArchiveConfig.Format.CSV, csvFile, config)) {
-      archive.initialize(defaultMetadata);
+      archive.initialize();
       try (var tileWriter = archive.newTileWriter()) {
         tileWriter.write(new TileEncodingResult(TileCoord.ofXYZ(0, 0, 0), new byte[]{0, 1}, OptionalLong.empty()));
         tileWriter.write(new TileEncodingResult(TileCoord.ofXYZ(1, 1, 1), new byte[]{2, 3}, OptionalLong.empty()));

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/stream/WriteableProtoStreamArchiveTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/stream/WriteableProtoStreamArchiveTest.java
@@ -76,7 +76,7 @@ class WriteableProtoStreamArchiveTest {
     final var tile0 = new TileEncodingResult(TileCoord.ofXYZ(0, 0, 0), new byte[]{0}, OptionalLong.empty());
     final var tile1 = new TileEncodingResult(TileCoord.ofXYZ(1, 2, 3), new byte[]{1}, OptionalLong.of(1));
     try (var archive = WriteableProtoStreamArchive.newWriteToFile(csvFile, defaultConfig)) {
-      archive.initialize(maxMetadataIn);
+      archive.initialize();
       try (var tileWriter = archive.newTileWriter()) {
         tileWriter.write(tile0);
         tileWriter.write(tile1);
@@ -86,7 +86,7 @@ class WriteableProtoStreamArchiveTest {
 
     try (InputStream in = Files.newInputStream(csvFile)) {
       assertEquals(
-        List.of(wrapInit(maxMetadataOut), toEntry(tile0), toEntry(tile1), wrapFinish(minMetadataOut)),
+        List.of(wrapInit(), toEntry(tile0), toEntry(tile1), wrapFinish(minMetadataOut)),
         readAllEntries(in)
       );
     }
@@ -105,7 +105,7 @@ class WriteableProtoStreamArchiveTest {
     final var tile3 = new TileEncodingResult(TileCoord.ofXYZ(41, 42, 4), new byte[]{3}, OptionalLong.empty());
     final var tile4 = new TileEncodingResult(TileCoord.ofXYZ(51, 52, 5), new byte[]{4}, OptionalLong.empty());
     try (var archive = WriteableProtoStreamArchive.newWriteToFile(csvFilePrimary, defaultConfig)) {
-      archive.initialize(minMetadataIn);
+      archive.initialize();
       try (var tileWriter = archive.newTileWriter()) {
         tileWriter.write(tile0);
         tileWriter.write(tile1);
@@ -122,7 +122,7 @@ class WriteableProtoStreamArchiveTest {
 
     try (InputStream in = Files.newInputStream(csvFilePrimary)) {
       assertEquals(
-        List.of(wrapInit(minMetadataOut), toEntry(tile0), toEntry(tile1), wrapFinish(maxMetadataOut)),
+        List.of(wrapInit(), toEntry(tile0), toEntry(tile1), wrapFinish(maxMetadataOut)),
         readAllEntries(in)
       );
     }
@@ -167,10 +167,8 @@ class WriteableProtoStreamArchiveTest {
       .build();
   }
 
-  private static StreamArchiveProto.Entry wrapInit(StreamArchiveProto.Metadata metadata) {
-    return StreamArchiveProto.Entry.newBuilder()
-      .setInitialization(StreamArchiveProto.InitializationEntry.newBuilder().setMetadata(metadata).build())
-      .build();
+  private static StreamArchiveProto.Entry wrapInit() {
+    return StreamArchiveProto.Entry.newBuilder().build();
   }
 
   private static StreamArchiveProto.Entry wrapFinish(StreamArchiveProto.Metadata metadata) {

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/util/LayerAttrStatsTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/util/LayerAttrStatsTest.java
@@ -2,13 +2,8 @@ package com.onthegomap.planetiler.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.onthegomap.planetiler.VectorTile;
-import com.onthegomap.planetiler.geo.GeoUtils;
-import com.onthegomap.planetiler.geo.TileCoord;
-import com.onthegomap.planetiler.render.RenderedFeature;
-import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 class LayerAttrStatsTest {
@@ -17,109 +12,50 @@ class LayerAttrStatsTest {
 
   @Test
   void testEmptyLayerStats() {
-    assertEquals(Arrays.asList(new LayerAttrStats.VectorLayer[]{}), layerStats.getTileStats());
+    assertEquals(List.of(), layerStats.getTileStats());
   }
 
   @Test
   void testEmptyLayerStatsOneLayer() {
-    layerStats.accept(new RenderedFeature(
-      TileCoord.ofXYZ(1, 2, 3),
-      new VectorTile.Feature(
-        "layer1",
-        1,
-        VectorTile.encodeGeometry(GeoUtils.point(1, 2)),
-        Map.of("a", 1, "b", "string", "c", true)
-      ),
-      1,
-      Optional.empty()
-    ));
-    assertEquals(Arrays.asList(new LayerAttrStats.VectorLayer[]{
-      new LayerAttrStats.VectorLayer("layer1", Map.of(
-        "a", LayerAttrStats.FieldType.NUMBER,
-        "b", LayerAttrStats.FieldType.STRING,
-        "c", LayerAttrStats.FieldType.BOOLEAN
-      ), 3, 3)
-    }), layerStats.getTileStats());
+    layerStats.accept("layer1", 3, "a", 1);
+    layerStats.accept("layer1", 3, "b", "string");
+    layerStats.accept("layer1", 3, "c", true);
+    assertEquals(List.of(new LayerAttrStats.VectorLayer("layer1", Map.of(
+      "a", LayerAttrStats.FieldType.NUMBER,
+      "b", LayerAttrStats.FieldType.STRING,
+      "c", LayerAttrStats.FieldType.BOOLEAN
+    ), 3, 3)), layerStats.getTileStats());
   }
 
   @Test
   void testEmptyLayerStatsTwoLayers() {
-    layerStats.accept(new RenderedFeature(
-      TileCoord.ofXYZ(1, 2, 3),
-      new VectorTile.Feature(
-        "layer1",
-        1,
-        VectorTile.encodeGeometry(GeoUtils.point(1, 2)),
-        Map.of()
-      ),
-      1,
-      Optional.empty()
-    ));
-    layerStats.accept(new RenderedFeature(
-      TileCoord.ofXYZ(1, 2, 4),
-      new VectorTile.Feature(
-        "layer2",
-        1,
-        VectorTile.encodeGeometry(GeoUtils.point(1, 2)),
-        Map.of("a", 1, "b", true, "c", true)
-      ),
-      1,
-      Optional.empty()
-    ));
-    layerStats.accept(new RenderedFeature(
-      TileCoord.ofXYZ(1, 2, 1),
-      new VectorTile.Feature(
-        "layer2",
-        1,
-        VectorTile.encodeGeometry(GeoUtils.point(1, 2)),
-        Map.of("a", 1, "b", true, "c", 1)
-      ),
-      1,
-      Optional.empty()
-    ));
-    assertEquals(Arrays.asList(new LayerAttrStats.VectorLayer[]{
-      new LayerAttrStats.VectorLayer("layer1", Map.of(
-      ), 3, 3),
+    layerStats.handlerForThread().forZoom(3).forLayer("layer1");
+    layerStats.accept("layer2", 4, "a", 1);
+    layerStats.accept("layer2", 4, "b", true);
+    layerStats.accept("layer2", 4, "c", true);
+    layerStats.accept("layer2", 1, "a", 1);
+    layerStats.accept("layer2", 1, "b", true);
+    layerStats.accept("layer2", 1, "c", 1);
+    assertEquals(List.of(new LayerAttrStats.VectorLayer("layer1", Map.of(
+    ), 3, 3),
       new LayerAttrStats.VectorLayer("layer2", Map.of(
         "a", LayerAttrStats.FieldType.NUMBER,
         "b", LayerAttrStats.FieldType.BOOLEAN,
         "c", LayerAttrStats.FieldType.STRING
-      ), 1, 4)
-    }), layerStats.getTileStats());
+      ), 1, 4)), layerStats.getTileStats());
   }
 
   @Test
   void testMergeFromMultipleThreads() throws InterruptedException {
-    Thread t1 = new Thread(() -> layerStats.accept(new RenderedFeature(
-      TileCoord.ofXYZ(1, 2, 3),
-      new VectorTile.Feature(
-        "layer1",
-        1,
-        VectorTile.encodeGeometry(GeoUtils.point(1, 2)),
-        Map.of("a", 1)
-      ),
-      1,
-      Optional.empty()
-    )));
+    layerStats.accept("layer1", 3, "a", true);
+    Thread t1 = new Thread(() -> layerStats.accept("layer1", 3, "a", 1));
     t1.start();
-    Thread t2 = new Thread(() -> layerStats.accept(new RenderedFeature(
-      TileCoord.ofXYZ(1, 2, 4),
-      new VectorTile.Feature(
-        "layer1",
-        1,
-        VectorTile.encodeGeometry(GeoUtils.point(1, 2)),
-        Map.of("a", true)
-      ),
-      1,
-      Optional.empty()
-    )));
+    Thread t2 = new Thread(() -> layerStats.accept("layer1", 4, "a", true));
     t2.start();
     t1.join();
     t2.join();
-    assertEquals(Arrays.asList(new LayerAttrStats.VectorLayer[]{
-      new LayerAttrStats.VectorLayer("layer1", Map.of(
-        "a", LayerAttrStats.FieldType.STRING
-      ), 3, 4)
-    }), layerStats.getTileStats());
+    assertEquals(List.of(new LayerAttrStats.VectorLayer("layer1", Map.of(
+      "a", LayerAttrStats.FieldType.STRING
+    ), 3, 4)), layerStats.getTileStats());
   }
 }


### PR DESCRIPTION
Tilejson stats in the archive metadata are currently computed while processing source features, but this misses vector tile attributes added and removed during post-processing. This PR moves computing the attr stats to tile-write time to capture the actual attributes written on features to the output archive.

A side effect of this is that tile archive `initialize` method can no longer accept metadata since the metadata isn't fully-known until the tiles are done being written so any archive implementation needs write metadata from the `finish` method.

Fixes #749, see #746 