### PR TITLE
Replaced log4j usage with commons-io

### DIFF
--- a/planetiler-core/pom.xml
+++ b/planetiler-core/pom.xml
@@ -154,6 +154,11 @@
       <artifactId>geopackage</artifactId>
       <version>${geopackage.version}</version>
     </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.11.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/stream/WriteableStreamArchive.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/stream/WriteableStreamArchive.java
@@ -12,7 +12,7 @@ import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.apache.logging.log4j.core.util.CloseShieldOutputStream;
+import org.apache.commons.io.output.CloseShieldOutputStream;
 
 /**
  * Base archive for all kinds of simple file streams. This is primarily useful when the file is a named pipe. In that
@@ -95,7 +95,7 @@ abstract class WriteableStreamArchive implements WriteableTileArchive {
      * the outputstream of the first writer must be closed by the archive and not the tile writer
      * since the primary stream can be used to send meta data, as well
      */
-    return new CloseShieldOutputStream(primaryOutputStream);
+    return CloseShieldOutputStream.wrap(primaryOutputStream);
   }
 
   @FunctionalInterface


### PR DESCRIPTION
See https://github.com/onthegomap/planetiler/discussions/773#discussioncomment-8037396

This is a separate PR since it's introducing a new dependency which is certainly more controversial then #776  - especially since it's only used for one method.

The same goal is probably also reachable by returning an anonymous inline extension of some sort OutputStream wich just overwrites the `close` method...