### PR TITLE
Deterministic IDs on SimpleFeatures

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/VectorTile.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/VectorTile.java
@@ -75,6 +75,7 @@ import vector_tile.VectorTileProto;
  */
 @NotThreadSafe
 public class VectorTile {
+  public static final long NO_FEATURE_ID = 0;
 
   private static final Logger LOGGER = LoggerFactory.getLogger(VectorTile.class);
 
@@ -534,7 +535,7 @@ public class VectorTile {
           .setType(feature.geometry().geomType().asProtobufType())
           .addAllGeometry(Ints.asList(feature.geometry().commands()));
 
-        if (feature.id >= 0) {
+        if (feature.id != NO_FEATURE_ID) {
           featureBuilder.setId(feature.id);
         }
 

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/util/CompareArchives.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/util/CompareArchives.java
@@ -223,8 +223,10 @@ public class CompareArchives {
           }
         }
       });
+    Format format = Format.defaultInstance();
     ProgressLoggers loggers = ProgressLoggers.create()
       .addRateCounter("tiles", total)
+      .add(() -> " diffs: [ " + format.numeric(diffs, true) + " ]")
       .newLine()
       .addPipelineStats(pipeline)
       .newLine()


### PR DESCRIPTION
I ran openmaptiles profile over the planet after #785 #788 and #789 and the only remaining diffs were in boundary and POI layers due to the fact that they create `SimpleFeature` instances in a finish handler method, which use an ID generator that results in different IDs each time it runs.  This PR adds the ability for profiles to set the ID explicitly on these simple feature, and defaults to no ID.  With this change I was able to get the same md5 hash on pmtiles generated by 2 consecutive planet runs of the openmaptiles profile.