### PR TITLE
Add note about java update process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,7 @@ To set up your local development environment:
   - [macOS installer](https://adoptium.net/installation.html#macos-pkg) (or `brew install --cask temurin`,
     or `port install openjdk21-temurin`)
   - [Linux installer](https://adoptium.net/installation/linux/) (or `apt-get install openjdk-21-jdk`)
+  - If you update from an older version of java on Ubuntu, run `sudo update-alternatives --config java` after installing the new jdk.
 - Build and run the tests ([mvnw](https://github.com/takari/maven-wrapper) automatically downloads maven the first time
   you run it):
   - on mac/linux: `./mvnw clean test`


### PR DESCRIPTION
I had java 17 installed and updated to the temurin jdk 21 but `java --version` was still at 17. So I asked ChatGPT how to update java and it told me that there is this `update-alternatives` command which I found worked well for me.