### PR TITLE
Add omit() feature collector api and `--refresh-sources` arg

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureCollector.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureCollector.java
@@ -797,6 +797,12 @@ public class FeatureCollector implements Iterable<FeatureCollector.Feature> {
       return this;
     }
 
+    /** Omit this feature from the output */
+    public Feature omit() {
+      output.remove(this);
+      return this;
+    }
+
     @Override
     public String toString() {
       return "Feature{" +

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/FeatureCollectorTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/FeatureCollectorTest.java
@@ -86,6 +86,17 @@ class FeatureCollectorTest {
   }
 
   @Test
+  void testOmit() {
+    var collector = factory.get(newReaderFeature(newPoint(0, 0), Map.of(
+      "key", "val"
+    )));
+    var point = collector.point("layername");
+    assertFeatures(14, List.of(Map.of("_layer", "layername")), collector);
+    point.omit();
+    assertFeatures(14, List.of(), collector);
+  }
+
+  @Test
   void testAttrWithMinzoom() {
     var collector = factory.get(newReaderFeature(newPoint(0, 0), Map.of(
       "key", "val"


### PR DESCRIPTION
Add 2 usability improvements:

- `feature.omit()` to exclude a feature from the output if already created
- `--refresh-sources`  cli arg to download new versions of source files if they have changed (can override for specific sources with `--refresh-osm=true/false`)