### PR TITLE
Filter out null MultiExpression entries

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/expression/MultiExpression.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/expression/MultiExpression.java
@@ -148,6 +148,7 @@ public record MultiExpression<T> (List<Entry<T>> expressions) implements Simplif
     return new MultiExpression<>(
       expressions.stream()
         .map(entry -> entry(fn.apply(entry.result), entry.expression))
+        .filter(entry -> entry.result != null)
         .toList()
     );
   }


### PR DESCRIPTION
… allowing skipping of OSM read when no profile needs OSM data. See https://github.com/openmaptiles/planetiler-openmaptiles/pull/156 for how to handle that in a custom profile (but that PR was closed without merging since OpenMapTiles profile actually uses OSM in all layers hence the change there is not effective).

E.g. if we run for example `java ... --only-layers=water ...` Planetiler skips OSM processing since such data is not needed for `water` layer, thus speeding up work when one is troubleshooting only that one particular layer.

Fixes https://github.com/onthegomap/planetiler/issues/823 .