### PR TITLE
Safer natural earth unzip

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/util/FileUtils.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/util/FileUtils.java
@@ -268,7 +268,7 @@ public class FileUtils {
    * @throws UncheckedIOException if an IO exception occurs
    */
   public static void safeCopy(InputStream inputStream, Path destPath) {
-    try (var outputStream = Files.newOutputStream(destPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE)) {
+    try (var outputStream = Files.newOutputStream(destPath, StandardOpenOption.CREATE, WRITE)) {
       int totalSize = 0;
 
       int nBytes;

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/util/FileUtils.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/util/FileUtils.java
@@ -268,7 +268,7 @@ public class FileUtils {
    * @throws UncheckedIOException if an IO exception occurs
    */
   public static void safeCopy(InputStream inputStream, Path destPath) {
-    try (var outputStream = Files.newOutputStream(destPath, StandardOpenOption.CREATE, WRITE)) {
+    try (var outputStream = Files.newOutputStream(destPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE)) {
       int totalSize = 0;
 
       int nBytes;


### PR DESCRIPTION
Prevent unzipping natural earth file from extracting the file outside of the target directory, and limit max unzip size.