### PR TITLE
Encode 3x node/way/relation in vector tile feature id

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureCollector.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureCollector.java
@@ -284,10 +284,10 @@ public class FeatureCollector implements Iterable<FeatureCollector.Feature> {
       if (source instanceof OsmSourceFeature osmSourceFeature) {
         long osmId = osmSourceFeature.originalElement().id();
         this.id = switch (osmSourceFeature.originalElement()) {
-          case OsmElement.Node node -> node.id() * 10 + 1;
-          case OsmElement.Way way -> way.id() * 10 + 2;
-          case OsmElement.Relation relation -> relation.id() * 10 + 3;
-          default -> osmId * 10;
+          case OsmElement.Node node -> node.id() * 3;
+          case OsmElement.Way way -> way.id() * 3 + 1;
+          case OsmElement.Relation relation -> relation.id() * 3 + 2;
+          default -> osmId;
         };
       } else {
         this.id = source.id();

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/FeatureCollectorTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/FeatureCollectorTest.java
@@ -653,4 +653,28 @@ class FeatureCollectorTest {
       )
     ), collector);
   }
+
+  @Test
+  void testOsmFeat() throws GeometryException {
+    var pointSourceFeature = newReaderFeature(newPoint(0, 0), Map.of());
+    assertEquals(0, pointSourceFeature.area());
+    assertEquals(0, pointSourceFeature.length());
+
+    var fc = factory.get(pointSourceFeature);
+    fc.line("layer").setZoomRange(0, 10);
+    fc.polygon("layer").setZoomRange(0, 10);
+    assertFalse(fc.iterator().hasNext(), "silently fail coercing to line/polygon");
+    fc.point("layer").setZoomRange(0, 10);
+    fc.centroid("layer").setZoomRange(0, 10);
+    fc.pointOnSurface("layer").setZoomRange(0, 10);
+    var iter = fc.iterator();
+    for (int i = 0; i < 3; i++) {
+      assertTrue(iter.hasNext(), "item " + i);
+      var item = iter.next();
+      assertEquals(GeometryType.POINT, item.getGeometryType());
+      assertEquals(newPoint(0.5, 0.5), item.getGeometry());
+    }
+
+    assertFalse(iter.hasNext());
+  }
 }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/FeatureCollectorTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/FeatureCollectorTest.java
@@ -653,28 +653,4 @@ class FeatureCollectorTest {
       )
     ), collector);
   }
-
-  @Test
-  void testOsmFeat() throws GeometryException {
-    var pointSourceFeature = newReaderFeature(newPoint(0, 0), Map.of());
-    assertEquals(0, pointSourceFeature.area());
-    assertEquals(0, pointSourceFeature.length());
-
-    var fc = factory.get(pointSourceFeature);
-    fc.line("layer").setZoomRange(0, 10);
-    fc.polygon("layer").setZoomRange(0, 10);
-    assertFalse(fc.iterator().hasNext(), "silently fail coercing to line/polygon");
-    fc.point("layer").setZoomRange(0, 10);
-    fc.centroid("layer").setZoomRange(0, 10);
-    fc.pointOnSurface("layer").setZoomRange(0, 10);
-    var iter = fc.iterator();
-    for (int i = 0; i < 3; i++) {
-      assertTrue(iter.hasNext(), "item " + i);
-      var item = iter.next();
-      assertEquals(GeometryType.POINT, item.getGeometryType());
-      assertEquals(newPoint(0.5, 0.5), item.getGeometry());
-    }
-
-    assertFalse(iter.hasNext());
-  }
 }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
@@ -875,7 +875,7 @@ class PlanetilerTests {
         feature(newPoint(128, 128), Map.of(
           "attr", "value",
           "name", "name value"
-        ))
+        )).withId(11)
       )
     ), results.tiles);
   }
@@ -964,7 +964,7 @@ class PlanetilerTests {
         feature(newLineString(128, 128, 192, 192), Map.of(
           "attr", "value",
           "name", "name value"
-        ))
+        )).withId(32)
       )
     ), results.tiles);
   }
@@ -1089,7 +1089,7 @@ class PlanetilerTests {
           "attr", "value",
           "name", "name value",
           "relname", "rel name"
-        ))
+        )).withId(173)
       )
     ), results.tiles);
   }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
@@ -875,7 +875,7 @@ class PlanetilerTests {
         feature(newPoint(128, 128), Map.of(
           "attr", "value",
           "name", "name value"
-        )).withId(11)
+        )).withId(3)
       )
     ), results.tiles);
   }
@@ -964,7 +964,7 @@ class PlanetilerTests {
         feature(newLineString(128, 128, 192, 192), Map.of(
           "attr", "value",
           "name", "name value"
-        )).withId(32)
+        )).withId(3 * 3 + 1)
       )
     ), results.tiles);
   }
@@ -1089,7 +1089,7 @@ class PlanetilerTests {
           "attr", "value",
           "name", "name value",
           "relname", "rel name"
-        )).withId(173)
+        )).withId(17 * 3 + 2)
       )
     ), results.tiles);
   }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/TestUtils.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/TestUtils.java
@@ -279,7 +279,9 @@ public class TestUtils {
         case UNKNOWN -> throw new IllegalArgumentException("cannot decompress \"UNKNOWN\"");
       };
       var decoded = VectorTile.decode(bytes).stream()
-        .map(feature -> feature(decodeSilently(feature.geometry()), feature.layer(), feature.attrs())).toList();
+        .map(
+          feature -> feature(decodeSilently(feature.geometry()), feature.layer(), feature.attrs()).withId(feature.id()))
+        .toList();
       tiles.put(tile.coord(), decoded);
     }
     return tiles;
@@ -467,12 +469,21 @@ public class TestUtils {
   public record ComparableFeature(
     GeometryComparision geometry,
     String layer,
-    Map<String, Object> attrs
+    Map<String, Object> attrs,
+    Long id
   ) {
+    ComparableFeature(
+      GeometryComparision geometry,
+      String layer,
+      Map<String, Object> attrs
+    ) {
+      this(geometry, layer, attrs, null);
+    }
 
     @Override
     public boolean equals(Object o) {
       return o == this || (o instanceof ComparableFeature other &&
+        (id == null || other.id == null || id.equals(other.id)) &&
         geometry.equals(other.geometry) &&
         attrs.equals(other.attrs) &&
         (layer == null || other.layer == null || Objects.equals(layer, other.layer)));
@@ -483,6 +494,10 @@ public class TestUtils {
       int result = geometry.hashCode();
       result = 31 * result + attrs.hashCode();
       return result;
+    }
+
+    ComparableFeature withId(long id) {
+      return new ComparableFeature(geometry, layer, attrs, id);
     }
   }
 


### PR DESCRIPTION
Encode whether a vector tile feature comes from an OSM node, way, or relation in the feature ID according to the formula {vector tile feature id} = {osm id} * 3 + {0 for node, 1 for way, 2 for relation}. See https://github.com/onthegomap/planetiler/discussions/824 and compare to #826 which resulted in slightly larger tile sizes