### PR TITLE
Fix dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,36 +3,36 @@
 
 version: 2
 updates:
-  - package-ecosystem: maven
-    directory: "/"
-    open-pull-requests-limit: 1
-    schedule:
-      interval: daily
-      time: "04:30"
-      timezone: America/New_York
-    labels:
-      - dependencies
-    ignore:
-      - dependency-name: "com.google.protobuf:protobuf-java"
-        versions: [ "3.23.3" ]
-  - package-ecosystem: maven
-    # workaround for non-standard pom.xml filename (https://github.com/dependabot/dependabot-core/issues/4425)
-    directory: "/.github/planetiler-examples-dependabot"
-    open-pull-requests-limit: 1
-    schedule:
-      interval: daily
-      time: "04:30"
-      timezone: America/New_York
-    labels:
-      - dependencies
-    ignore:
-      - dependency-name: "com.onthegomap.planetiler:*"
-  - package-ecosystem: github-actions
-    directory: "/"
-    open-pull-requests-limit: 1
-    schedule:
-      interval: daily
-      time: "04:30"
-      timezone: America/New_York
-    labels:
-      - dependencies
+- package-ecosystem: maven
+  directory: "/"
+  open-pull-requests-limit: 1
+  schedule:
+    interval: daily
+    time: "04:25"
+    timezone: America/New_York
+  labels:
+  - dependencies
+  ignore:
+  - dependency-name: "com.google.protobuf:protobuf-java"
+    versions: [ "3.23.3" ]
+- package-ecosystem: maven
+  # workaround for non-standard pom.xml filename (https://github.com/dependabot/dependabot-core/issues/4425)
+  directory: "/.github/planetiler-examples-dependabot"
+  open-pull-requests-limit: 1
+  schedule:
+    interval: daily
+    time: "04:30"
+    timezone: America/New_York
+  labels:
+  - dependencies
+  ignore:
+  - dependency-name: "com.onthegomap.planetiler:*"
+- package-ecosystem: github-actions
+  directory: "/"
+  open-pull-requests-limit: 1
+  schedule:
+    interval: daily
+    time: "04:30"
+    timezone: America/New_York
+  labels:
+  - dependencies

--- a/planetiler-openmaptiles.pom.xml
+++ b/planetiler-openmaptiles.pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- This pom.xml gets used when this repo loaded as a submodule within https://github.com/onthegomap/planetiler -->
+<!-- TODO it should be in planetiler-openmaptiles/submodule.pom.xml when this is fixed: https://github.com/dependabot/dependabot-core/issues/9193 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
   <modules>
     <module>planetiler-core</module>
     <!-- TODO replace with planetiler-openmaptiles/submodule.pom.xml when this is fixed: https://github.com/dependabot/dependabot-core/issues/9193 -->
-    <module>submodule.pom.xml</module>
+    <module>planetiler-openmaptiles.pom.xml</module>
     <module>planetiler-custommap</module>
     <module>planetiler-benchmarks</module>
     <module>planetiler-examples</module>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,8 @@
 
   <modules>
     <module>planetiler-core</module>
-    <module>planetiler-openmaptiles/submodule.pom.xml</module>
+    <!-- TODO replace with planetiler-openmaptiles/submodule.pom.xml when this is fixed: https://github.com/dependabot/dependabot-core/issues/9193 -->
+    <module>submodule.pom.xml</module>
     <module>planetiler-custommap</module>
     <module>planetiler-benchmarks</module>
     <module>planetiler-examples</module>

--- a/submodule.pom.xml
+++ b/submodule.pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This pom.xml gets used when this repo loaded as a submodule within https://github.com/onthegomap/planetiler -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.openmaptiles</groupId>
+  <artifactId>planetiler-openmaptiles</artifactId>
+
+  <parent>
+    <groupId>com.onthegomap.planetiler</groupId>
+    <artifactId>planetiler-parent</artifactId>
+    <version>${revision}</version>
+    <relativePath>./</relativePath>
+  </parent>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.onthegomap.planetiler</groupId>
+      <artifactId>planetiler-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+      <version>1.33</version>
+    </dependency>
+    <dependency>
+      <groupId>org.commonmark</groupId>
+      <artifactId>commonmark</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.onthegomap.planetiler</groupId>
+      <artifactId>planetiler-core</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <sourceDirectory>planetiler-openmaptiles/src/main/java</sourceDirectory>
+    <testSourceDirectory>planetiler-openmaptiles/src/test/java</testSourceDirectory>
+    <plugins>
+      <plugin>
+        <groupId>io.github.zlika</groupId>
+        <artifactId>reproducible-build-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <!-- we don't want to deploy this module -->
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
Temporary workaround for https://github.com/dependabot/dependabot-core/issues/9193 to get dependabot updates by moving planetiler-openmaptiles/submodule.pom.xml into planetiler repo so that dependabot can check for dependency updates without needing to pull submodules.