### PR TITLE
Fix tile size stats memory leak

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/archive/TileArchiveWriter.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/archive/TileArchiveWriter.java
@@ -266,6 +266,7 @@ public class TileArchiveWriter {
     boolean lastIsFill = false;
     List<TileSizeStats.LayerStats> lastLayerStats = null;
     boolean skipFilled = config.skipFilledTiles();
+    var layerStatsSerializer = TileSizeStats.newThreadLocalSerializer();
 
     var tileStatsUpdater = tileStats.threadLocalUpdater();
     var layerAttrStatsUpdater = layerAttrStats.handlerForThread();
@@ -320,7 +321,7 @@ public class TileArchiveWriter {
         if ((!skipFilled || !lastIsFill) && bytes != null) {
           tileStatsUpdater.recordTile(tileFeatures.tileCoord(), bytes.length, layerStats);
           List<String> layerStatsRows = config.outputLayerStats() ?
-            TileSizeStats.formatOutputRows(tileFeatures.tileCoord(), bytes.length, layerStats) :
+            layerStatsSerializer.formatOutputRows(tileFeatures.tileCoord(), bytes.length, layerStats) :
             List.of();
           result.add(
             new TileEncodingResult(

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/util/TileSizeStats.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/util/TileSizeStats.java
@@ -38,7 +38,7 @@ import vector_tile.VectorTileProto;
  * Utilities for extracting tile and layer size summaries from encoded vector tiles.
  * <p>
  * {@link #computeTileStats(VectorTileProto.Tile)} extracts statistics about each layer in a tile and
- * {@link TsvSerializer formats them as row of a TSV file to write.
+ * {@link TsvSerializer} formats them as row of a TSV file to write.
  * <p>
  * To generate a tsv.gz file with stats for each tile, you can add {@code --output-layerstats} option when generating an
  * archive, or run the following an existing archive:

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/util/TileSizeStatsTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/util/TileSizeStatsTest.java
@@ -37,7 +37,7 @@ class TileSizeStatsTest {
     assertEquals(2, entry1.layerAttrKeys());
     assertEquals(2, entry1.layerAttrValues());
 
-    var formatted = TileSizeStats.formatOutputRows(TileCoord.ofXYZ(1, 2, 3), 999, stats);
+    var formatted = TileSizeStats.newThreadLocalSerializer().formatOutputRows(TileCoord.ofXYZ(1, 2, 3), 999, stats);
     assertEquals(
       """
         z	x	y	hilbert	archived_tile_bytes	layer	layer_bytes	layer_features	layer_geometries	layer_attr_bytes	layer_attr_keys	layer_attr_values
@@ -86,7 +86,7 @@ class TileSizeStatsTest {
     assertEquals("b", entry2.layer());
     assertEquals(1, entry2.layerFeatures());
 
-    var formatted = TileSizeStats.formatOutputRows(TileCoord.ofXYZ(1, 2, 3), 999, stats);
+    var formatted = TileSizeStats.newThreadLocalSerializer().formatOutputRows(TileCoord.ofXYZ(1, 2, 3), 999, stats);
     assertEquals(
       """
         z	x	y	hilbert	archived_tile_bytes	layer	layer_bytes	layer_features	layer_geometries	layer_attr_bytes	layer_attr_keys	layer_attr_values


### PR DESCRIPTION
There was a memory leak when generating TileSizeStats TSV output during a planetiler run. The jackson `ObjectWriter#writeValueAsString` method `JsonFactory#_getBufferRecycler()` which uses `LockFreePool#acquireAndLinkPooled` to get a  `BufferRecycler`. This tried to share up to 4 recyclers between threads, but somewhere around z13-15 tile generation, it stops working and starts creating a new `BufferRecycler` per row written, which ends up making a lot of `char[]` instances, causing the JVM to run out of memory.  This change uses a new `CsvWriter` and `ObjectWriter` per thread so there's no race condition to cause out of control allocations.