### PR TITLE
Add polygon index intersection utility

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/PolygonIndex.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/PolygonIndex.java
@@ -57,10 +57,28 @@ public class PolygonIndex<T> {
     return postFilterContaining(point, items);
   }
 
+  /** Returns the data associated with all polygons containing {@code point}. */
+  public List<T> getIntersecting(Geometry geom) {
+    build();
+    List<?> items = index.query(geom.getEnvelopeInternal());
+    return postFilterIntersecting(geom, items);
+  }
+
   private List<T> postFilterContaining(Point point, List<?> items) {
     List<T> result = new ArrayList<>(items.size());
     for (Object item : items) {
       if (item instanceof GeomWithData<?> value && value.poly.contains(point)) {
+        @SuppressWarnings("unchecked") T t = (T) value.data;
+        result.add(t);
+      }
+    }
+    return result;
+  }
+
+  private List<T> postFilterIntersecting(Geometry geom, List<?> items) {
+    List<T> result = new ArrayList<>(items.size());
+    for (Object item : items) {
+      if (item instanceof GeomWithData<?> value && value.poly.intersects(geom)) {
         @SuppressWarnings("unchecked") T t = (T) value.data;
         result.add(t);
       }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/PolygonIndex.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/PolygonIndex.java
@@ -67,8 +67,8 @@ public class PolygonIndex<T> {
   private List<T> postFilterContaining(Point point, List<?> items) {
     List<T> result = new ArrayList<>(items.size());
     for (Object item : items) {
-      if (item instanceof GeomWithData<?> value && value.poly.contains(point)) {
-        @SuppressWarnings("unchecked") T t = (T) value.data;
+      if (item instanceof GeomWithData<?>(var poly,var data) && poly.contains(point)) {
+        @SuppressWarnings("unchecked") T t = (T) data;
         result.add(t);
       }
     }
@@ -78,8 +78,8 @@ public class PolygonIndex<T> {
   private List<T> postFilterIntersecting(Geometry geom, List<?> items) {
     List<T> result = new ArrayList<>(items.size());
     for (Object item : items) {
-      if (item instanceof GeomWithData<?> value && value.poly.intersects(geom)) {
-        @SuppressWarnings("unchecked") T t = (T) value.data;
+      if (item instanceof GeomWithData<?>(var poly,var data) && poly.intersects(geom)) {
+        @SuppressWarnings("unchecked") T t = (T) data;
         result.add(t);
       }
     }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/PolygonIndexTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/PolygonIndexTest.java
@@ -21,10 +21,13 @@ class PolygonIndexTest {
   void testSingle() {
     index.put(rectangle(0, 1), 1);
     assertListsContainSameElements(List.of(1), index.getContaining(newPoint(0.5, 0.5)));
+    assertListsContainSameElements(List.of(1), index.getIntersecting(newPoint(0.5, 0.5)));
+    assertListsContainSameElements(List.of(1), index.getIntersecting(rectangle(1, 2)));
     assertListsContainSameElements(List.of(1), index.getContainingOrNearest(newPoint(0.5, 0.5)));
 
     assertListsContainSameElements(List.of(), index.getContaining(newPoint(1.5, 1.5)));
     assertListsContainSameElements(List.of(), index.getContainingOrNearest(newPoint(1.5, 1.5)));
+    assertListsContainSameElements(List.of(), index.getIntersecting(rectangle(2, 3)));
   }
 
   @Test
@@ -33,6 +36,9 @@ class PolygonIndexTest {
     index.put(rectangle(0, 1), 2);
     assertListsContainSameElements(List.of(1, 2), index.getContaining(newPoint(0.5, 0.5)));
     assertListsContainSameElements(List.of(1, 2), index.getContainingOrNearest(newPoint(0.5, 0.5)));
+    assertListsContainSameElements(List.of(1, 2), index.getIntersecting(rectangle(0.5, 1.5)));
+    assertListsContainSameElements(List.of(1, 2), index.getIntersecting(rectangle(1, 2)));
+    assertListsContainSameElements(List.of(), index.getIntersecting(rectangle(2, 3)));
   }
 
   @Test


### PR DESCRIPTION
In order to support the use-case in https://github.com/openmaptiles/planetiler-openmaptiles/pull/160, add a utility to check for polygon intersections instead of just containing a point.