### PR TITLE
exclude slf4j-nop from geopackage to avoid SLF4J warning

### DIFF
--- a/planetiler-core/pom.xml
+++ b/planetiler-core/pom.xml
@@ -153,6 +153,12 @@
       <groupId>mil.nga.geopackage</groupId>
       <artifactId>geopackage</artifactId>
       <version>${geopackage.version}</version>
+      <exclusions>
+      <exclusion>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-nop</artifactId>
+      </exclusion>
+    </exclusions>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Planetiler from current `main` is complaining a little bit:

```
SLF4J(W): Class path contains multiple SLF4J providers.
SLF4J(W): Found provider [org.apache.logging.slf4j.SLF4JServiceProvider@49097b5d]
SLF4J(W): Found provider [org.slf4j.nop.NOPServiceProvider@6e2c634b]
SLF4J(W): See https://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J(I): Actual provider is of type [org.apache.logging.slf4j.SLF4JServiceProvider@49097b5d]
```

This PR fixes that by excluding `org.slf4j:slf4j-nop` from `mil.nga.geopackage:geopackage`.