### PR TITLE
Expose osm element type to yaml configs

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/SimpleFeature.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/SimpleFeature.java
@@ -136,6 +136,11 @@ public class SimpleFeature extends SourceFeature {
         }
 
         @Override
+        public Type type() {
+          return isPoint() ? Type.NODE : Type.WAY;
+        }
+
+        @Override
         public Map<String, Object> tags() {
           return tags();
         }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/osm/OsmElement.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/osm/OsmElement.java
@@ -24,6 +24,8 @@ public interface OsmElement extends WithTags {
 
   int cost();
 
+  Type type();
+
   enum Type {
     NODE,
     WAY,
@@ -40,6 +42,11 @@ public interface OsmElement extends WithTags {
     @Override
     public int cost() {
       return 1 + tags.size() + (info == null ? 0 : Info.COST);
+    }
+
+    @Override
+    public Type type() {
+      return null;
     }
   }
 
@@ -118,6 +125,11 @@ public interface OsmElement extends WithTags {
     }
 
     @Override
+    public Type type() {
+      return Type.NODE;
+    }
+
+    @Override
     public boolean equals(Object obj) {
       if (obj == this) {
         return true;
@@ -170,6 +182,11 @@ public interface OsmElement extends WithTags {
     public int cost() {
       return 1 + tags.size() + nodes.size() + (info == null ? 0 : Info.COST);
     }
+
+    @Override
+    public Type type() {
+      return Type.WAY;
+    }
   }
 
   /** An ordered list of nodes, ways, and other relations. */
@@ -197,6 +214,11 @@ public interface OsmElement extends WithTags {
     @Override
     public int cost() {
       return 1 + tags.size() + members.size() * 3 + (info == null ? 0 : Info.COST);
+    }
+
+    @Override
+    public Type type() {
+      return Type.RELATION;
     }
 
     /**

--- a/planetiler-custommap/README.md
+++ b/planetiler-custommap/README.md
@@ -473,13 +473,16 @@ Scripts are parsed and evaluated inside a "context" that defines the variables a
 ##### 1. Root Context
 
 Available variables:
-- `args` - a map from [argument](#arguments) name to value, see also [built-in arguments](#built-in-arguments) that are always available.
+
+- `args` - a map from [argument](#arguments) name to value, see also [built-in arguments](#built-in-arguments) that are
+  always available.
 
 ##### 2. Process Feature Context
 
 Context available when processing an input feature, for example testing whether to include it from `include_when`.
 
 Additional variables, on top of the root context:
+
 - `feature.tags` - map with key/value tags from the input feature
 - `feature.id` - numeric ID of the input feature
 - `feature.source` - string source ID this feature came from
@@ -489,12 +492,14 @@ Additional variables, on top of the root context:
 - `feature.osm_timestamp` - optional OSM last modified timestamp for this feature
 - `feature.osm_user_id` - optional ID of the OSM user that last modified this feature
 - `feature.osm_user_name` - optional name of the OSM user that last modified this feature
+- `feature.osm_type` - type of the OSM element as a string: `"node"`, `"way"`, or `"relation"`
 
 ##### 3. Post-Match Context
 
 Context available after a feature has matched, for example computing an attribute value.
 
 Additional variables, on top of the process feature context:
+
 - `match_key` - string tag that triggered a match to include the feature in this layer
 - `match_value` - the tag value associated with that key
 
@@ -504,6 +509,7 @@ Context available after the value of an attribute has been computed, for example
 attribute.
 
 Additional variable, on top of the post-match context:
+
 - `value` the value that was computed for this key
 
 For example:

--- a/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/Contexts.java
+++ b/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/Contexts.java
@@ -347,6 +347,7 @@ public class Contexts {
     private static final String FEATURE_OSM_TIMESTAMP = "feature.osm_timestamp";
     private static final String FEATURE_OSM_USER_ID = "feature.osm_user_id";
     private static final String FEATURE_OSM_USER_NAME = "feature.osm_user_name";
+    private static final String FEATURE_OSM_TYPE = "feature.osm_type";
 
     public static ScriptEnvironment<ProcessFeature> description(Root root) {
       return root.description()
@@ -360,7 +361,8 @@ public class Contexts {
           Decls.newVar(FEATURE_OSM_VERSION, Decls.Int),
           Decls.newVar(FEATURE_OSM_TIMESTAMP, Decls.Int),
           Decls.newVar(FEATURE_OSM_USER_ID, Decls.Int),
-          Decls.newVar(FEATURE_OSM_USER_NAME, Decls.String)
+          Decls.newVar(FEATURE_OSM_USER_NAME, Decls.String),
+          Decls.newVar(FEATURE_OSM_TYPE, Decls.String)
         );
     }
 
@@ -373,7 +375,11 @@ public class Contexts {
           case FEATURE_SOURCE -> feature.getSource();
           case FEATURE_SOURCE_LAYER -> wrapNullable(feature.getSourceLayer());
           default -> {
-            OsmElement.Info info = feature instanceof OsmSourceFeature osm ? osm.originalElement().info() : null;
+            OsmElement elem = feature instanceof OsmSourceFeature osm ? osm.originalElement() : null;
+            if (FEATURE_OSM_TYPE.equals(key)) {
+              yield elem == null ? null : elem.type().name().toLowerCase();
+            }
+            OsmElement.Info info = elem != null ? elem.info() : null;
             yield info == null ? null : switch (key) {
               case FEATURE_OSM_CHANGESET -> info.changeset();
               case FEATURE_OSM_VERSION -> info.version();

--- a/planetiler-custommap/src/test/java/com/onthegomap/planetiler/custommap/ConfiguredFeatureTest.java
+++ b/planetiler-custommap/src/test/java/com/onthegomap/planetiler/custommap/ConfiguredFeatureTest.java
@@ -556,6 +556,8 @@ class ConfiguredFeatureTest {
     "${feature.osm_user_id}|4",
     "${feature.osm_version}|5",
     "${feature.osm_user_name}|user",
+    "${feature.osm_type}|node",
+    "${feature.osm_type.charAt(0)}|n",
     "${coalesce(feature.source_layer, 'missing')}|missing",
     "{match: {test: {natural: water}}}|test",
     "{match: {test: {natural: not_water}}}|null",


### PR DESCRIPTION
Fix #878 by exposing `${feature.osm_type}` to yaml configs.