### PR TITLE
Attach sources to fat jar to improve no-build IDE experience

### DIFF
--- a/planetiler-core/pom.xml
+++ b/planetiler-core/pom.xml
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>org.locationtech.jts</groupId>
       <artifactId>jts-core</artifactId>
-      <version>1.19.0</version>
+      <version>${jts.version}</version>
     </dependency>
     <dependency>
       <groupId>org.tukaani</groupId>

--- a/planetiler-dist/pom.xml
+++ b/planetiler-dist/pom.xml
@@ -48,6 +48,19 @@
       <artifactId>planetiler-examples</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
+    <!-- Add sources to the jar to improve IDE experience when using jar with deps -->
+    <dependency>
+      <groupId>com.onthegomap.planetiler</groupId>
+      <artifactId>planetiler-core</artifactId>
+      <version>${project.parent.version}</version>
+      <classifier>sources</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.locationtech.jts</groupId>
+      <artifactId>jts-core</artifactId>
+      <version>${jts.version}</version>
+      <classifier>sources</classifier>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
     <maven.source.excludeResources>true</maven.source.excludeResources>
     <jackson.version>2.17.1</jackson.version>
     <junit.version>5.10.2</junit.version>
+    <jts.version>1.19.0</jts.version>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     <sonar.organization>onthegomap</sonar.organization>
     <sonar.projectKey>onthegomap_planetiler</sonar.projectKey>


### PR DESCRIPTION
Add sources for select dependencies (planetiler core and JTS for now) to get API documentation, variable names, etc. when editing code in an IDE that uses just the fat jar as a dependency.

Example in vscode:

<img width="1058" alt="image" src="https://github.com/onthegomap/planetiler/assets/1480504/7ce5d1f3-f46c-49ed-80af-0017760cc953">
