### PR TITLE
Structured tag api

### DIFF
--- a/planetiler-core/pom.xml
+++ b/planetiler-core/pom.xml
@@ -120,6 +120,11 @@
       <version>${jackson.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient</artifactId>
       <version>${prometheus.version}</version>

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/JsonConversion.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/JsonConversion.java
@@ -7,12 +7,18 @@ import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.io.UncheckedIOException;
 
-public class JsonConversion {
+/**
+ * Utilities for converting between JSON strings and java objects using Jackson utilities.
+ * <p>
+ * {@link ObjectMapper} are expensive to construct, but not thread safe, so this class reuses the same object mapper
+ * within each thread but does not share between threads.
+ */
+class JsonConversion {
+  private JsonConversion() {}
 
   private static final ThreadLocal<ObjectMapper> MAPPERS = ThreadLocal.withInitial(() -> JsonMapper.builder()
     .addModule(
-      new JavaTimeModule()
-        .addSerializer(Struct.class, new StructSerializer())
+      new JavaTimeModule().addSerializer(Struct.class, new StructSerializer())
     )
     .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
     .build());

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/JsonConversion.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/JsonConversion.java
@@ -1,0 +1,39 @@
+package com.onthegomap.planetiler.reader;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.io.UncheckedIOException;
+
+public class JsonConversion {
+
+  private static final ThreadLocal<ObjectMapper> MAPPERS = ThreadLocal.withInitial(() -> JsonMapper.builder()
+    .addModule(
+      new JavaTimeModule()
+        .addSerializer(Struct.class, new StructSerializer())
+    )
+    .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+    .build());
+
+  public static String writeValueAsString(Object o) {
+    try {
+      return o == null ? null : MAPPERS.get().writeValueAsString(o);
+    } catch (JsonProcessingException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  public static <T> T convertValue(Object o, Class<T> clazz) {
+    return o == null ? null : MAPPERS.get().convertValue(o, clazz);
+  }
+
+  public static <T> T readValue(String string, Class<T> clazz) {
+    try {
+      return string == null ? null : MAPPERS.get().readValue(string, clazz);
+    } catch (JsonProcessingException e) {
+      return null;
+    }
+  }
+}

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/JsonConversion.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/JsonConversion.java
@@ -16,6 +16,7 @@ import java.io.UncheckedIOException;
 class JsonConversion {
   private JsonConversion() {}
 
+  @SuppressWarnings("java:S5164") // ignore not calling remove() on mappers since number of threads is limited
   private static final ThreadLocal<ObjectMapper> MAPPERS = ThreadLocal.withInitial(() -> JsonMapper.builder()
     .addModule(
       new JavaTimeModule().addSerializer(Struct.class, new StructSerializer())

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/SourceFeature.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/SourceFeature.java
@@ -78,15 +78,6 @@ public abstract class SourceFeature implements WithTags, WithGeometryType {
 
 
   @Override
-  public Object getTag(String key, Object defaultValue) {
-    Object val = tags.get(key);
-    if (val == null) {
-      return defaultValue;
-    }
-    return val;
-  }
-
-  @Override
   public Map<String, Object> tags() {
     return tags;
   }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/Struct.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/Struct.java
@@ -1,0 +1,452 @@
+package com.onthegomap.planetiler.reader;
+
+import com.onthegomap.planetiler.util.Parse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+public interface Struct {
+  static Struct of(Object o) {
+    return switch (o) {
+      case null -> NULL;
+      case Struct struct -> struct;
+      case Number n -> new Numeric(n);
+      case Boolean b -> new BooleanStruct(b);
+      case String s -> new StringStruct(s);
+      case byte[] b -> new BinaryStruct(b);
+      case Instant i -> new InstantStruct(i);
+      case LocalTime i -> new LocalTimeStruct(i);
+      case LocalDate i -> new LocalDateStruct(i);
+      case UUID uuid -> new PrimitiveStruct<>(uuid);
+      case Map<?, ?> map -> {
+        Map<Object, Struct> result = LinkedHashMap.newLinkedHashMap(map.size());
+        for (var e : map.entrySet()) {
+          var v = of(e.getValue());
+          if (!v.isNull()) {
+            result.put(e.getKey(), v);
+          }
+        }
+        yield new MapStruct(result);
+      }
+      case Collection<?> collection -> {
+        List<Struct> result = new ArrayList<>(collection.size());
+        for (var d : collection) {
+          result.add(of(d));
+        }
+        yield new ListStruct(result);
+      }
+      default -> throw new IllegalArgumentException("Unable to convert " + o + " (" + o.getClass() + ")");
+    };
+  }
+
+  Struct NULL = new Struct() {
+    @Override
+    public Object rawValue() {
+      return null;
+    }
+
+    @Override
+    public List<Struct> asList() {
+      return List.of();
+    }
+
+    @Override
+    public String asString() {
+      return null;
+    }
+
+    @Override
+    public Struct orElse(Object fallback) {
+      return of(fallback);
+    }
+
+    @Override
+    public String toString() {
+      return "null";
+    }
+
+    @Override
+    public String asJson() {
+      return "null";
+    }
+
+    @Override
+    public boolean isNull() {
+      return true;
+    }
+  };
+
+  default Struct orElse(Object fallback) {
+    return this;
+  }
+
+  default Struct get(String key) {
+    return NULL;
+  }
+
+  default Struct get(Object first, Object... others) {
+    Struct struct = first instanceof Number n ? get(n.intValue()) : get(first.toString());
+    for (Object other : others) {
+      struct = other instanceof Number n ? struct.get(n.intValue()) : struct.get(other.toString());
+      if (struct.isNull()) {
+        return NULL;
+      }
+    }
+    return struct;
+  }
+
+  default Map<Object, Struct> asMap() {
+    return Map.of();
+  }
+
+  default Struct get(int index) {
+    return NULL;
+  }
+
+  default List<Struct> asList() {
+    return List.of(this);
+  }
+
+  default Integer asInt() {
+    return null;
+  }
+
+  default Long asLong() {
+    return null;
+  }
+
+  default Boolean asBoolean() {
+    return null;
+  }
+
+  default String asString() {
+    return rawValue() == null ? null : rawValue().toString();
+  }
+
+  default Double asDouble() {
+    return null;
+  }
+
+  default Instant asTimestamp() {
+    return null;
+  }
+
+  default byte[] asBytes() {
+    return null;
+  }
+
+  default boolean isNull() {
+    return false;
+  }
+
+  default boolean isStruct() {
+    return false;
+  }
+
+  Object rawValue();
+
+  default <T> T as(Class<T> clazz) {
+    return JsonConversion.convertValue(rawValue(), clazz);
+  }
+
+  default String asJson() {
+    return JsonConversion.writeValueAsString(rawValue());
+  }
+
+  class PrimitiveStruct<T> implements Struct {
+
+    final T value;
+    private String asJson;
+
+    PrimitiveStruct(T value) {
+      this.value = value;
+    }
+
+
+    @Override
+    public final Object rawValue() {
+      return value;
+    }
+
+    @Override
+    public String asJson() {
+      if (this.asJson == null) {
+        this.asJson = Struct.super.asJson();
+      }
+      return asJson;
+    }
+
+    @Override
+    public String asString() {
+      return value.toString();
+    }
+
+    @Override
+    public String toString() {
+      return asString();
+    }
+  }
+
+  class Numeric extends PrimitiveStruct<Number> {
+
+    Numeric(Number value) {
+      super(value);
+    }
+
+    @Override
+    public Integer asInt() {
+      return value.intValue();
+    }
+
+    @Override
+    public Long asLong() {
+      return value.longValue();
+    }
+
+    @Override
+    public Double asDouble() {
+      return value.doubleValue();
+    }
+
+    @Override
+    public Instant asTimestamp() {
+      var raw = Instant.ofEpochMilli(value.longValue());
+      if (value instanceof Float || value instanceof Double) {
+        double doubleValue = value.doubleValue();
+        raw = raw.plusNanos((long) ((doubleValue - Math.floor(doubleValue)) * Duration.ofMillis(1).toNanos()));
+      }
+      return raw;
+    }
+  }
+  class BooleanStruct extends PrimitiveStruct<Boolean> {
+
+    BooleanStruct(boolean value) {
+      super(value);
+    }
+
+    @Override
+    public Boolean asBoolean() {
+      return value == Boolean.TRUE;
+    }
+  }
+  class StringStruct extends PrimitiveStruct<String> {
+    private Struct struct = null;
+
+
+    StringStruct(String value) {
+      super(value);
+    }
+
+    @Override
+    public String asString() {
+      return value;
+    }
+
+    @Override
+    public Integer asInt() {
+      return Parse.parseIntOrNull(value);
+    }
+
+    @Override
+    public Long asLong() {
+      return Parse.parseLongOrNull(value);
+    }
+
+    @Override
+    public Double asDouble() {
+      return Parse.parseDoubleOrNull(value);
+    }
+
+    @Override
+    public Boolean asBoolean() {
+      return Parse.bool(value);
+    }
+
+    @Override
+    public Instant asTimestamp() {
+      try {
+        return Instant.parse(value);
+      } catch (DateTimeParseException e) {
+        Long value = asLong();
+        if (value != null) {
+          return Instant.ofEpochMilli(value);
+        }
+        return null;
+      }
+    }
+
+    @Override
+    public Struct get(String key) {
+      return parseJson().get(key);
+    }
+
+    @Override
+    public Struct get(int index) {
+      return parseJson().get(index);
+    }
+
+    @Override
+    public Map<Object, Struct> asMap() {
+      return parseJson().asMap();
+    }
+
+    private Struct parseJson() {
+      return struct != null ? struct : (struct = of(JsonConversion.readValue(value, Object.class)));
+    }
+
+    @Override
+    public byte[] asBytes() {
+      return value.getBytes(StandardCharsets.UTF_8);
+    }
+  }
+  class BinaryStruct extends PrimitiveStruct<byte[]> {
+
+    BinaryStruct(byte[] value) {
+      super(value);
+    }
+
+    @Override
+    public String asString() {
+      return new String(value, StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public byte[] asBytes() {
+      return value;
+    }
+  }
+  class InstantStruct extends PrimitiveStruct<Instant> {
+
+    InstantStruct(Instant value) {
+      super(value);
+    }
+
+    @Override
+    public Instant asTimestamp() {
+      return value;
+    }
+
+    @Override
+    public Integer asInt() {
+      return Math.toIntExact(value.toEpochMilli());
+    }
+
+    @Override
+    public Long asLong() {
+      return value.toEpochMilli();
+    }
+
+    @Override
+    public Double asDouble() {
+      return (double) value.toEpochMilli();
+    }
+  }
+  class LocalTimeStruct extends PrimitiveStruct<LocalTime> {
+
+    LocalTimeStruct(LocalTime value) {
+      super(value);
+    }
+
+    @Override
+    public Integer asInt() {
+      return Math.toIntExact(Duration.ofNanos(value.toNanoOfDay()).toMillis());
+    }
+
+    @Override
+    public Long asLong() {
+      return Duration.ofNanos(value.toNanoOfDay()).toMillis();
+    }
+
+    @Override
+    public Double asDouble() {
+      return value.toNanoOfDay() * 1d / Duration.ofMillis(1).toNanos();
+    }
+
+    @Override
+    public String asString() {
+      return DateTimeFormatter.ISO_LOCAL_TIME.format(value);
+    }
+  }
+  class LocalDateStruct extends PrimitiveStruct<LocalDate> {
+
+    LocalDateStruct(LocalDate value) {
+      super(value);
+    }
+
+    @Override
+    public Integer asInt() {
+      return Math.toIntExact(value.toEpochDay());
+    }
+
+    @Override
+    public Long asLong() {
+      return value.toEpochDay();
+    }
+
+    @Override
+    public Double asDouble() {
+      return (double) value.toEpochDay();
+    }
+
+    @Override
+    public String asString() {
+      return DateTimeFormatter.ISO_LOCAL_DATE.format(value);
+    }
+  }
+
+  class MapStruct extends PrimitiveStruct<Map<Object, Struct>> {
+
+    MapStruct(Map<Object, Struct> value) {
+      super(value);
+    }
+
+    @Override
+    public Struct get(String key) {
+      return value.getOrDefault(key, NULL);
+    }
+
+    @Override
+    public boolean isStruct() {
+      return true;
+    }
+
+    @Override
+    public String asString() {
+      return super.asJson();
+    }
+
+    @Override
+    public Map<Object, Struct> asMap() {
+      return value.entrySet().stream()
+        .map(e -> Map.entry(e.getKey(), e.getValue()))
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+  }
+
+  class ListStruct extends PrimitiveStruct<List<Struct>> {
+    ListStruct(List<Struct> value) {
+      super(value);
+    }
+
+    @Override
+    public List<Struct> asList() {
+      return value;
+    }
+
+    @Override
+    public Struct get(int index) {
+      return index < value.size() && index >= 0 ? value.get(index) : NULL;
+    }
+  }
+}

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/Struct.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/Struct.java
@@ -188,7 +188,7 @@ public interface Struct {
    * Returns boolean value of this element, or true for "1", "true", "yes" and false for "0", "false", "no".
    */
   default Boolean asBoolean() {
-    return null;
+    return false;
   }
 
   /** Returns a string representation of this value (use {@link #asJson()} for json string). */
@@ -205,6 +205,7 @@ public interface Struct {
   }
 
   /** Returns a byte array value or bytes from a UTF8-encoded string. */
+  @SuppressWarnings("java:S1168")
   default byte[] asBytes() {
     return null;
   }
@@ -343,6 +344,7 @@ public interface Struct {
     }
   }
 
+  @SuppressWarnings("java:S2160") // don't need to override equals() for struct since it is derived from value
   class StringStruct extends PrimitiveStruct<String> {
     private Struct struct = null;
 
@@ -528,17 +530,16 @@ public interface Struct {
       var result = value.get(key);
       if (result != null) {
         return result;
-      } else if (key instanceof String s) {
-        if (s.contains(".")) {
-          String[] parts = s.split("\\.", 2);
-          if (parts.length == 2) {
-            String firstPart = parts[0];
-            return firstPart.endsWith("[]") ?
-              get(firstPart.substring(0, firstPart.length() - 2)).flatMap(child -> child.get(parts[1])) :
-              get(firstPart, parts[1]);
-          }
+      } else if (key instanceof String s && s.contains(".")) {
+        String[] parts = s.split("\\.", 2);
+        if (parts.length == 2) {
+          String firstPart = parts[0];
+          return firstPart.endsWith("[]") ?
+            get(firstPart.substring(0, firstPart.length() - 2)).flatMap(child -> child.get(parts[1])) :
+            get(firstPart, parts[1]);
         }
       }
+
       return NULL;
     }
 

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/Struct.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/Struct.java
@@ -225,12 +225,9 @@ public interface Struct {
    * <a href="https://github.com/FasterXML/jackson-databind">jackson-databind</a>.
    * <p>
    * For example:
-   * {@snippet : java
+   * {@snippet :
    * record Point(double x, double y) {}
-   * var point = Struct.of(Map.of(
-   *   "x", 1.5,
-   *   "y", 2
-   * )).as(Point.class);
+   * var point = Struct.of(Map.of("x", 1.5, "y", 2)).as(Point.class);
    * System.out.println(point); // "Point[x=1.5, y=2.0]"
    * }
    */

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/Struct.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/Struct.java
@@ -510,7 +510,16 @@ public interface Struct {
 
     @Override
     public Struct get(Object key) {
-      return value.getOrDefault(key, NULL);
+      var result = value.get(key);
+      if (result != null) {
+        return result;
+      } else if (key instanceof String s && s.contains(".")) {
+        String[] parts = s.split("\\.", 2);
+        if (parts.length == 2) {
+          return get(parts[0], parts[1]);
+        }
+      }
+      return NULL;
     }
 
     @Override

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/StructSerializer.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/StructSerializer.java
@@ -1,0 +1,24 @@
+package com.onthegomap.planetiler.reader;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import java.io.IOException;
+
+class StructSerializer extends StdSerializer<Struct> {
+
+  public StructSerializer() {
+    this(null);
+  }
+
+  public StructSerializer(Class<Struct> t) {
+    super(t);
+  }
+
+  @Override
+  public void serialize(
+    Struct value, JsonGenerator jgen, SerializerProvider provider)
+    throws IOException {
+    jgen.writePOJO(value.rawValue());
+  }
+}

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/WithTags.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/WithTags.java
@@ -8,7 +8,6 @@ import java.util.Objects;
 
 /** An input element with a set of string key/object value pairs. */
 public interface WithTags {
-
   static WithTags from(Map<String, Object> tags) {
     return new OfMap(tags);
   }
@@ -17,7 +16,21 @@ public interface WithTags {
   Map<String, Object> tags();
 
   default Object getTag(String key) {
-    return tags().get(key);
+    var result = tags().get(key);
+    if (result != null) {
+      return result;
+    } else if (key.contains(".")) {
+      return getDotted(key).rawValue();
+    }
+    return null;
+  }
+
+  private Struct getDotted(String key) {
+    String[] parts = key.split("\\.", 2);
+    if (parts.length == 2) {
+      return getStruct(parts[0]).get(parts[1]);
+    }
+    return getStruct(parts[0]);
   }
 
   default Object getTag(String key, Object defaultValue) {
@@ -29,7 +42,8 @@ public interface WithTags {
   }
 
   default boolean hasTag(String key) {
-    return tags().containsKey(key);
+    var contains = tags().containsKey(key);
+    return contains || (key.contains(".") && !getDotted(key).isNull());
   }
 
   default boolean hasTag(String key, Object value) {

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/WithTags.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/WithTags.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 /** An input element with a set of string key/object value pairs. */
 public interface WithTags {
+
   static WithTags from(Map<String, Object> tags) {
     return new OfMap(tags);
   }
@@ -77,8 +78,8 @@ public interface WithTags {
   }
 
   /**
-   * Returns {@code false} if {@code tag}'s {@link Object#toString()} value is empty, "0", "false", or "no" and {@code
-   * true} otherwise.
+   * Returns {@code false} if {@code tag}'s {@link Object#toString()} value is empty, "0", "false", or "no" and
+   * {@code true} otherwise.
    */
   default boolean getBoolean(String key) {
     return Parse.bool(getTag(key));
@@ -110,6 +111,30 @@ public interface WithTags {
 
   default void setTag(String key, Object value) {
     tags().put(key, value);
+  }
+
+
+  default Struct getStruct(String key) {
+    return Struct.of(getTag(key));
+  }
+
+  default Struct getStruct(String key, String... others) {
+    Struct struct = getStruct(key);
+    for (String other : others) {
+      struct = struct.get(other);
+      if (struct.isNull()) {
+        return Struct.NULL;
+      }
+    }
+    return struct;
+  }
+
+  default <T> T as(Class<T> clazz) {
+    return JsonConversion.convertValue(tags(), clazz);
+  }
+
+  default String asJson() {
+    return JsonConversion.writeValueAsString(tags());
   }
 
   record OfMap(@Override Map<String, Object> tags) implements WithTags {}

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/parquet/ParquetFeature.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/parquet/ParquetFeature.java
@@ -4,7 +4,6 @@ import com.onthegomap.planetiler.geo.GeoUtils;
 import com.onthegomap.planetiler.geo.GeometryException;
 import com.onthegomap.planetiler.reader.SourceFeature;
 import com.onthegomap.planetiler.reader.Struct;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.locationtech.jts.geom.Geometry;
@@ -86,11 +85,11 @@ public class ParquetFeature extends SourceFeature {
   public Object getTag(String key) {
     var value = tags().get(key);
     if (value == null) {
-      String[] parts = key.split("\\.");
-      if (parts.length > 1) {
-        Object[] rest = Arrays.copyOfRange(parts, 1, parts.length);
-        value = getStruct(parts[0], rest).rawValue();
+      String[] parts = key.split("\\.", 2);
+      if (parts.length == 2) {
+        return getStruct(parts[0]).get(parts[1]).rawValue();
       }
+      return getStruct(parts[0]).rawValue();
     }
     return value;
   }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/parquet/ParquetRecordConverter.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/parquet/ParquetRecordConverter.java
@@ -64,7 +64,8 @@ public class ParquetRecordConverter extends RecordMaterializer<Map<String, Objec
 
     @Override
     protected Converter makeConverter(Context child) {
-      if ((child.named("list") || child.named("array")) && child.onlyField("element")) {
+      if ((child.named("list") || child.named("array")) &&
+        (child.onlyField("element") || child.onlyField("array_element"))) {
         return new ListElementConverter(child.hoist());
       }
       return super.makeConverter(child);

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/reader/StructTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/reader/StructTest.java
@@ -69,6 +69,16 @@ class StructTest {
     )).hasTag("a.b"));
   }
 
+
+  @Test
+  void testListQuery() {
+    var struct = Struct.of(Map.of(
+      "a", List.of(Map.of("b", "c"), Map.of("b", "d"))
+    ));
+    assertEquals("d", struct.get("a").flatMap(elem -> elem.get("b")).get(1).asString());
+    assertEquals(Struct.of(List.of("c", "d")), struct.get("a[].b"));
+  }
+
   @Test
   void testListGet() {
     var struct = Struct.of(List.of(1, 2, 3));

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/reader/StructTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/reader/StructTest.java
@@ -1,0 +1,308 @@
+package com.onthegomap.planetiler.reader;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class StructTest {
+  @Test
+  void testGet() {
+    var struct = WithTags.from(Map.of(
+      "a", Map.of("b", "c")
+    ));
+    var nested = struct.getStruct("a").get("b");
+    assertEquals("c", nested.asString());
+    assertEquals("c", nested.rawValue());
+    assertFalse(nested.isNull());
+
+    assertTrue(struct.getStruct("a").get("b").get("c").get("d").isNull());
+  }
+
+  @Test
+  void testGetMultilevel() {
+    var struct = WithTags.from(Map.of(
+      "a", Map.of("b", "c")
+    ));
+    var nested = struct.getStruct("a", "b");
+    assertEquals("c", nested.asString());
+    assertEquals("c", nested.rawValue());
+    assertFalse(nested.isNull());
+
+    assertTrue(struct.getStruct("a", "b", "c", "d").isNull());
+  }
+
+  @Test
+  void testListGet() {
+    var struct = Struct.of(List.of(1, 2, 3));
+    assertEquals(1, struct.get(0).asInt());
+    assertEquals(3, struct.get(2).asInt());
+    assertTrue(struct.get(4).isNull());
+    assertTrue(struct.get(-1).isNull());
+  }
+
+  @Test
+  void testNullInput() {
+    var struct = Struct.of(null);
+    assertNull(struct.rawValue());
+    assertTrue(struct.isNull());
+    assertTrue(struct.get(0).isNull());
+    assertTrue(struct.get("nested").isNull());
+    assertTrue(struct.get("nested", "level2").isNull());
+    assertEquals(Map.of(), struct.asMap());
+    assertEquals(List.of(), struct.asList());
+    assertEquals("null", struct.toString());
+    assertEquals("null", struct.asJson());
+    record Type() {}
+    assertNull(struct.as(Type.class));
+
+    assertEquals(1, struct.orElse(Struct.of(1)).rawValue());
+  }
+
+  private static void assertNotListOrMap(Struct struct) {
+    assertTrue(struct.get(0).isNull());
+    assertTrue(struct.get("nested").isNull());
+    assertTrue(struct.get("nested", "level2").isNull());
+    assertEquals(Map.of(), struct.asMap());
+    assertEquals(List.of(struct), struct.asList());
+  }
+
+  @Test
+  void testBooleanInput() {
+    var struct = Struct.of(true);
+    assertEquals(true, struct.rawValue());
+    assertEquals(true, struct.asBoolean());
+    assertFalse(struct.isNull());
+    assertNotListOrMap(struct);
+    assertEquals(true, struct.asList().get(0).asBoolean());
+    assertEquals("true", struct.toString());
+    assertEquals("true", struct.asJson());
+
+    assertEquals(true, struct.orElse(Struct.of(1)).rawValue());
+  }
+
+  @Test
+  void testIntInput() {
+    var struct = Struct.of(1);
+    assertEquals(1, struct.rawValue());
+    assertEquals(1, struct.asInt());
+    assertEquals(1L, struct.asLong());
+    assertEquals(1d, struct.asDouble());
+    assertFalse(struct.isNull());
+    assertNotListOrMap(struct);
+    assertEquals(1, struct.asList().get(0).asInt());
+    assertEquals("1", struct.toString());
+    assertEquals("1", struct.asJson());
+
+    assertEquals(1, struct.orElse(Struct.of(2)).rawValue());
+  }
+
+  @Test
+  void testLongInput() {
+    var struct = Struct.of(1L);
+    assertEquals(1L, struct.rawValue());
+    assertEquals(1, struct.asInt());
+    assertEquals(1L, struct.asLong());
+    assertEquals(1d, struct.asDouble());
+    assertEquals(Instant.ofEpochMilli(1), struct.asTimestamp());
+    assertFalse(struct.isNull());
+    assertNotListOrMap(struct);
+    assertEquals(1, struct.asList().get(0).asInt());
+    assertEquals("1", struct.toString());
+    assertEquals("1", struct.asJson());
+
+    assertEquals(1L, struct.orElse(Struct.of(2)).rawValue());
+  }
+
+  @Test
+  void testFloatInput() {
+    var struct = Struct.of(1.3f);
+    assertEquals(1.3f, struct.rawValue());
+    assertEquals(1, struct.asInt());
+    assertEquals(1L, struct.asLong());
+    assertEquals(1.3d, struct.asDouble(), 1e-2);
+    assertFalse(struct.isNull());
+    assertNotListOrMap(struct);
+    assertEquals(1.3, struct.asList().get(0).asDouble(), 1e-2);
+    assertEquals("1.3", struct.toString());
+    assertEquals("1.3", struct.asJson());
+
+    assertEquals(1.3f, struct.orElse(Struct.of(2)).rawValue());
+  }
+
+  @Test
+  void testDoubleInput() {
+    var struct = Struct.of(1.3d);
+    assertEquals(1.3d, struct.rawValue());
+    assertEquals(1, struct.asInt());
+    assertEquals(1L, struct.asLong());
+    assertEquals(1.3d, struct.asDouble());
+    assertFalse(struct.isNull());
+    assertNotListOrMap(struct);
+    assertEquals(1.3, struct.asList().get(0).asDouble());
+    assertEquals("1.3", struct.toString());
+    assertEquals("1.3", struct.asJson());
+    assertEquals(1.3d, struct.orElse(Struct.of(2)).rawValue());
+  }
+
+  @Test
+  void testNumbersConvertToTimestamps() {
+    assertEquals(Instant.ofEpochSecond(1, Duration.ofMillis(1).toNanos() / 2), Struct.of(1000.5).asTimestamp());
+    assertEquals(Instant.ofEpochMilli(1500), Struct.of(1500L).asTimestamp());
+  }
+
+  @Test
+  void testInstantInput() {
+    var struct = Struct.of(Instant.ofEpochSecond(60));
+    assertFalse(struct.isNull());
+    assertNotListOrMap(struct);
+
+    assertEquals(Instant.ofEpochSecond(60), struct.rawValue());
+    assertEquals(60_000, struct.asInt());
+    assertEquals(60_000L, struct.asLong());
+    assertEquals(60_000d, struct.asDouble());
+    assertEquals(Instant.ofEpochSecond(60), struct.asTimestamp());
+    assertEquals(60_000d, struct.asList().get(0).asDouble());
+    assertEquals("1970-01-01T00:01:00Z", struct.toString());
+    assertEquals("\"1970-01-01T00:01:00Z\"", struct.asJson());
+
+    assertEquals(Instant.ofEpochSecond(60), struct.orElse(Struct.of(2)).rawValue());
+  }
+
+  @Test
+  void testLocalTimeInput() {
+    var struct = Struct.of(LocalTime.of(1, 2));
+    assertFalse(struct.isNull());
+    assertNotListOrMap(struct);
+
+    assertEquals(LocalTime.of(1, 2), struct.rawValue());
+    assertEquals((int) Duration.ofHours(1).plusMinutes(2).toMillis(), struct.asInt());
+    assertEquals(Duration.ofHours(1).plusMinutes(2).toMillis(), struct.asLong());
+    assertEquals((double) Duration.ofHours(1).plusMinutes(2).toMillis(), struct.asDouble());
+    assertEquals("01:02:00", struct.toString());
+    assertEquals("\"01:02:00\"", struct.asJson());
+  }
+
+  @Test
+  void testLocalDateInput() {
+    var struct = Struct.of(LocalDate.of(1, 2, 3));
+    assertFalse(struct.isNull());
+    assertNotListOrMap(struct);
+
+    assertEquals(LocalDate.of(1, 2, 3), struct.rawValue());
+    assertEquals(-719129, struct.asInt());
+    assertEquals(-719129L, struct.asLong());
+    assertEquals(-719129d, struct.asDouble());
+    assertEquals("0001-02-03", struct.toString());
+    assertEquals("\"0001-02-03\"", struct.asJson());
+  }
+
+  @Test
+  void testUUIDInput() {
+    var struct = Struct.of(new UUID(1, 2));
+    assertFalse(struct.isNull());
+    assertNotListOrMap(struct);
+
+    assertEquals(new UUID(1, 2), struct.rawValue());
+    assertEquals("00000000-0000-0001-0000-000000000002", struct.asString());
+    assertEquals("00000000-0000-0001-0000-000000000002", struct.toString());
+    assertEquals("\"00000000-0000-0001-0000-000000000002\"", struct.asJson());
+  }
+
+  @Test
+  void testStringInput() {
+    var struct = Struct.of("abc");
+    assertFalse(struct.isNull());
+    assertNotListOrMap(struct);
+    assertEquals("abc", struct.asString());
+    assertEquals("\"abc\"", struct.asJson());
+    assertNull(struct.asInt());
+    assertNull(struct.asLong());
+    assertNull(struct.asDouble());
+    assertEquals(true, struct.asBoolean());
+    assertArrayEquals("abc".getBytes(StandardCharsets.UTF_8), struct.asBytes());
+  }
+
+  @Test
+  void testStringToNumber() {
+    var struct = Struct.of("1.5");
+    assertEquals(1, struct.asInt());
+    assertEquals(1L, struct.asLong());
+    assertEquals(1.5, struct.asDouble(), 1e-2);
+    assertEquals(true, struct.asBoolean());
+    assertEquals("\"1.5\"", struct.asJson());
+  }
+
+  @Test
+  void testStringToBoolean() {
+    assertFalse(Struct.of("false").asBoolean());
+    assertTrue(Struct.of("true").asBoolean());
+    assertTrue(Struct.of("yes").asBoolean());
+    assertFalse(Struct.of("0").asBoolean());
+    assertTrue(Struct.of("1").asBoolean());
+    assertFalse(Struct.of("no").asBoolean());
+  }
+
+  @Test
+  void testStringToInstant() {
+    assertEquals(Instant.ofEpochSecond(100), Struct.of(Instant.ofEpochSecond(100).toString()).asTimestamp());
+    assertEquals(Instant.ofEpochSecond(100), Struct.of("100000").asTimestamp());
+  }
+
+  @Test
+  void testJsonStringToStruct() {
+    var struct = Struct.of("""
+      {"a":[{"b":1}]}
+      """);
+    assertEquals(1, struct.get("a", 0, "b").asInt());
+  }
+
+  @Test
+  void testJsonListToStruct() {
+    var struct = Struct.of("""
+      [1,2,3]
+      """);
+    assertEquals(1, struct.get(0).asInt());
+    assertEquals(2, struct.get(1).asInt());
+  }
+
+  @Test
+  void testBinaryInput() {
+    var struct = Struct.of(new byte[]{1, 2});
+    assertArrayEquals(new byte[]{1, 2}, struct.asBytes());
+  }
+
+  @Test
+  void testAsMapper() {
+    var struct = WithTags.from(Map.of(
+      "a", Map.of("b", "c")
+    ));
+    record Inner(String b) {}
+    record Outer(Inner a) {}
+    assertEquals(new Outer(new Inner("c")), struct.as(Outer.class));
+    assertEquals(new Inner("c"), struct.getStruct("a").as(Inner.class));
+  }
+
+  @Test
+  void testAsJson() {
+    var struct = WithTags.from(Map.of(
+      "a", Map.of("b", "c")
+    ));
+    assertEquals("""
+      {"a":{"b":"c"}}
+      """.strip(), struct.asJson());
+    assertEquals("""
+      {"b":"c"}
+      """.strip(), struct.getStruct("a").asJson());
+    assertEquals("""
+      "c"
+      """.strip(), struct.getStruct("a").get("b").asJson());
+  }
+}

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/reader/StructTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/reader/StructTest.java
@@ -258,10 +258,13 @@ class StructTest {
 
   @Test
   void testJsonStringToStruct() {
+    record Inner(int b) {}
+    record Outer(List<Inner> a) {}
     var struct = Struct.of("""
       {"a":[{"b":1}]}
       """);
     assertEquals(1, struct.get("a", 0, "b").asInt());
+    assertEquals(new Outer(List.of(new Inner(1))), struct.as(Outer.class));
   }
 
   @Test

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/reader/StructTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/reader/StructTest.java
@@ -39,6 +39,36 @@ class StructTest {
     assertTrue(struct.getStruct("a", "b", "c", "d").isNull());
   }
 
+
+  @Test
+  void testGetDottedFromStruct() {
+    assertEquals("c", Struct.of(Map.of(
+      "a", Map.of("b", "c")
+    )).get("a.b").asString());
+    assertEquals("c", Struct.of(Map.of(
+      "a.b", "c"
+    )).get("a.b").asString());
+    assertEquals("d", Struct.of(Map.of(
+      "a", Map.of("b.c", "d")
+    )).get("a.b.c").asString());
+    assertNull(Struct.of(Map.of(
+      "a", Map.of("b.c", "d")
+    )).get("a.b.e").asString());
+  }
+
+  @Test
+  void testGetDottedFromWithTags() {
+    assertEquals("c", WithTags.from(Map.of(
+      "a", Map.of("b", "c")
+    )).getStruct("a.b").asString());
+    assertEquals("c", WithTags.from(Map.of(
+      "a", Map.of("b", "c")
+    )).getTag("a.b"));
+    assertTrue(WithTags.from(Map.of(
+      "a", Map.of("b", "c")
+    )).hasTag("a.b"));
+  }
+
   @Test
   void testListGet() {
     var struct = Struct.of(List.of(1, 2, 3));

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/reader/parquet/ParquetInputFileTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/reader/parquet/ParquetInputFileTest.java
@@ -199,7 +199,7 @@ class ParquetInputFileTest {
         updateTime.add(item.getStruct("update_time").asTimestamp().toEpochMilli());
       }
     }
-    assertEquals(Set.of(-71.0743637084961, -71.07460021972656, -71.07461547851562), xmins);
+    assertEquals(Set.of(-71.0743637084961, -71.07461547851562, -71.07460021972656), xmins);
     assertEquals(Set.of(1596647976000L, 1624238059000L, 1625971545000L), updateTime);
   }
 }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/reader/parquet/ParquetInputFileTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/reader/parquet/ParquetInputFileTest.java
@@ -20,6 +20,7 @@ import java.util.UUID;
 import java.util.function.Consumer;
 import org.apache.parquet.filter2.predicate.FilterApi;
 import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -184,5 +185,21 @@ class ParquetInputFileTest {
 
   private static DynamicTest test(Map<String, Object> map, String key, Consumer<Object> test) {
     return dynamicTest(key, () -> test.accept(map.get(key)));
+  }
+
+  @Test
+  void testReadNested() {
+    Set<Object> xmins = new HashSet<>();
+    Set<Long> updateTime = new HashSet<>();
+    for (var block : new ParquetInputFile("parquet", "layer",
+      TestUtils.pathToResource("parquet").resolve("boston.parquet"))
+      .get()) {
+      for (var item : block) {
+        xmins.add(item.getTag("bbox.xmin"));
+        updateTime.add(item.getStruct("update_time").asTimestamp().toEpochMilli());
+      }
+    }
+    assertEquals(Set.of(-71.0743637084961, -71.07460021972656, -71.07461547851562), xmins);
+    assertEquals(Set.of(1596647976000L, 1624238059000L, 1625971545000L), updateTime);
   }
 }

--- a/planetiler-examples/src/main/java/com/onthegomap/planetiler/examples/overture/OvertureBasemap.java
+++ b/planetiler-examples/src/main/java/com/onthegomap/planetiler/examples/overture/OvertureBasemap.java
@@ -1,16 +1,12 @@
 package com.onthegomap.planetiler.examples.overture;
 
 import com.onthegomap.planetiler.FeatureCollector;
-import com.onthegomap.planetiler.FeatureMerge;
 import com.onthegomap.planetiler.Planetiler;
 import com.onthegomap.planetiler.Profile;
-import com.onthegomap.planetiler.VectorTile;
 import com.onthegomap.planetiler.config.Arguments;
-import com.onthegomap.planetiler.geo.GeometryException;
 import com.onthegomap.planetiler.reader.SourceFeature;
 import com.onthegomap.planetiler.util.Glob;
 import java.nio.file.Path;
-import java.util.List;
 
 /**
  * Example basemap using <a href="https://overturemaps.org/">Overture Maps</a> data.
@@ -25,15 +21,6 @@ public class OvertureBasemap implements Profile {
         .setMinZoom(13)
         .inheritAttrFromSource("height")
         .inheritAttrFromSource("roof_color");
-      case "land_cover" -> {
-        if (source.getLong("cartography.max_zoom") < 8) {
-          features.polygon("land_cover")
-            .setMinZoom(source.getStruct("cartography", "min_zoom").asInt())
-            .setMaxZoom(source.getStruct("cartography", "max_zoom").asInt())
-            .inheritAttrFromSource("subtype")
-            .setMinPixelSize(0);
-        }
-      }
       case null, default -> {
         // ignore for now
       }
@@ -64,12 +51,6 @@ public class OvertureBasemap implements Profile {
     run(Arguments.fromArgsOrConfigFile(args));
   }
 
-  @Override
-  public List<VectorTile.Feature> postProcessLayerFeatures(String layer, int zoom, List<VectorTile.Feature> items)
-    throws GeometryException {
-    return FeatureMerge.mergeOverlappingPolygons(items, 0.1);
-  }
-
   static void run(Arguments args) throws Exception {
     Path base = args.inputFile("base", "overture base directory", Path.of("data", "overture"));
     Planetiler.create(args)
@@ -79,9 +60,6 @@ public class OvertureBasemap implements Profile {
         true, // hive-partitioning
         fields -> fields.get("id"), // hash the ID field to generate unique long IDs
         fields -> fields.get("type")) // extract "type={}" from the filename to get layer
-      .addParquetSource("overture-landcover",
-        Glob.of(base).resolve("theme=base", "type=land_cover", "*.parquet").find(),
-        true, fields -> fields.get("id"), fields -> fields.get("type"))
       .overwriteOutput(Path.of("data", "overture.pmtiles"))
       .run();
   }

--- a/planetiler-examples/src/main/java/com/onthegomap/planetiler/examples/overture/OvertureBasemap.java
+++ b/planetiler-examples/src/main/java/com/onthegomap/planetiler/examples/overture/OvertureBasemap.java
@@ -1,12 +1,16 @@
 package com.onthegomap.planetiler.examples.overture;
 
 import com.onthegomap.planetiler.FeatureCollector;
+import com.onthegomap.planetiler.FeatureMerge;
 import com.onthegomap.planetiler.Planetiler;
 import com.onthegomap.planetiler.Profile;
+import com.onthegomap.planetiler.VectorTile;
 import com.onthegomap.planetiler.config.Arguments;
+import com.onthegomap.planetiler.geo.GeometryException;
 import com.onthegomap.planetiler.reader.SourceFeature;
 import com.onthegomap.planetiler.util.Glob;
 import java.nio.file.Path;
+import java.util.List;
 
 /**
  * Example basemap using <a href="https://overturemaps.org/">Overture Maps</a> data.
@@ -21,6 +25,15 @@ public class OvertureBasemap implements Profile {
         .setMinZoom(13)
         .inheritAttrFromSource("height")
         .inheritAttrFromSource("roof_color");
+      case "land_cover" -> {
+        if (source.getLong("cartography.max_zoom") < 8) {
+          features.polygon("land_cover")
+            .setMinZoom(source.getStruct("cartography", "min_zoom").asInt())
+            .setMaxZoom(source.getStruct("cartography", "max_zoom").asInt())
+            .inheritAttrFromSource("subtype")
+            .setMinPixelSize(0);
+        }
+      }
       case null, default -> {
         // ignore for now
       }
@@ -51,6 +64,12 @@ public class OvertureBasemap implements Profile {
     run(Arguments.fromArgsOrConfigFile(args));
   }
 
+  @Override
+  public List<VectorTile.Feature> postProcessLayerFeatures(String layer, int zoom, List<VectorTile.Feature> items)
+    throws GeometryException {
+    return FeatureMerge.mergeOverlappingPolygons(items, 0.1);
+  }
+
   static void run(Arguments args) throws Exception {
     Path base = args.inputFile("base", "overture base directory", Path.of("data", "overture"));
     Planetiler.create(args)
@@ -60,6 +79,9 @@ public class OvertureBasemap implements Profile {
         true, // hive-partitioning
         fields -> fields.get("id"), // hash the ID field to generate unique long IDs
         fields -> fields.get("type")) // extract "type={}" from the filename to get layer
+      .addParquetSource("overture-landcover",
+        Glob.of(base).resolve("theme=base", "type=land_cover", "*.parquet").find(),
+        true, fields -> fields.get("id"), fields -> fields.get("type"))
       .overwriteOutput(Path.of("data", "overture.pmtiles"))
       .run();
   }


### PR DESCRIPTION
Add an API to features that makes it more convenient to work with feature properties that may be nested lists or maps.

For example:

```java
// for struct from {"a": {"b": {"c": 1}}}
// all return 1:
struct.getStruct("a").get("b").get("c").asInt();
struct.getStruct("a", "b", "c").asInt();
struct.getLong("a.b.c");
// returns null:
struct.getStruct("d", "e", "f").asInt();
```

You can also treat any string as json and attempt to parse structured attributes from it:

```java
Struct.of("[1,2,3]").get(1).asInt(); // returns 2
Struct.of("""
{"a":{"b":{"c":1}}}
""").get("a", "b", "c").asInt(); // returns 1
Struct.of("""
{"a":{"b":[{"c":1}, {"c":2}]}}
""").get("a.b[].c").get(1) // returns 2
```

And you can marshal structs into java wrappers 

```java
var struct = Struct.of("""
{
  "name": "place",
  "population": 100,
  "class": "town"
}
""");
record Place(String name, int population, String class) {}
// returns Place[name="place", population=100, class="town"]
struct.as(Place.class);
```

See `StructTest` for more examples.