### PR TITLE
Make VectorTile.Feature implement WithTags

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureMerge.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureMerge.java
@@ -161,7 +161,7 @@ public class FeatureMerge {
     var groupedByAttrs = groupByAttrs(features, result, GeometryType.LINE);
     for (List<VectorTile.Feature> groupedFeatures : groupedByAttrs) {
       VectorTile.Feature feature1 = groupedFeatures.getFirst();
-      double lengthLimit = lengthLimitCalculator.apply(feature1.attrs());
+      double lengthLimit = lengthLimitCalculator.apply(feature1.tags());
 
       // as a shortcut, can skip line merging only if:
       // - only 1 element in the group
@@ -401,7 +401,7 @@ public class FeatureMerge {
         others.add(feature);
       } else {
         groupedByAttrs
-          .computeIfAbsent(feature.attrs(), k -> new ArrayList<>())
+          .computeIfAbsent(feature.tags(), k -> new ArrayList<>())
           .add(feature);
       }
     }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/VectorTile.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/VectorTile.java
@@ -26,6 +26,7 @@ import com.onthegomap.planetiler.geo.GeoUtils;
 import com.onthegomap.planetiler.geo.GeometryException;
 import com.onthegomap.planetiler.geo.GeometryType;
 import com.onthegomap.planetiler.geo.MutableCoordinateSequence;
+import com.onthegomap.planetiler.reader.WithTags;
 import com.onthegomap.planetiler.util.Hilbert;
 import com.onthegomap.planetiler.util.LayerAttrStats;
 import java.util.ArrayList;
@@ -484,7 +485,7 @@ public class VectorTile {
       if (inFeature != null && inFeature.geometry().commands().length > 0) {
         EncodedFeature outFeature = new EncodedFeature(inFeature);
 
-        for (Map.Entry<String, ?> e : inFeature.attrs().entrySet()) {
+        for (Map.Entry<String, ?> e : inFeature.tags().entrySet()) {
           // skip attribute without value
           if (e.getValue() != null) {
             String key = e.getKey();
@@ -1010,7 +1011,7 @@ public class VectorTile {
    * @param layer    the layer the feature was in
    * @param id       the feature ID
    * @param geometry the encoded feature geometry (decode using {@link VectorGeometry#decode()})
-   * @param attrs    tags for the feature to output
+   * @param tags     tags for the feature to output
    * @param group    grouping key used to limit point density or {@link #NO_GROUP} if not in a group. NOTE: this is only
    *                 populated when this feature was deserialized from {@link FeatureGroup}, not when parsed from a tile
    *                 since vector tile schema does not encode group.
@@ -1019,9 +1020,9 @@ public class VectorTile {
     String layer,
     long id,
     VectorGeometry geometry,
-    Map<String, Object> attrs,
+    Map<String, Object> tags,
     long group
-  ) {
+  ) implements WithTags {
 
     public static final long NO_GROUP = Long.MIN_VALUE;
 
@@ -1054,7 +1055,7 @@ public class VectorTile {
         layer,
         id,
         newGeometry,
-        attrs,
+        tags,
         group
       );
     }
@@ -1065,10 +1066,16 @@ public class VectorTile {
         layer,
         id,
         geometry,
-        Stream.concat(attrs.entrySet().stream(), extraAttrs.entrySet().stream())
+        Stream.concat(tags.entrySet().stream(), extraAttrs.entrySet().stream())
           .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)),
         group
       );
+    }
+
+    /** @deprecated use {@link #tags()} instead. */
+    @Deprecated(forRemoval = true)
+    public Map<String, Object> attrs() {
+      return tags;
     }
   }
 

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/collection/FeatureGroup.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/collection/FeatureGroup.java
@@ -202,7 +202,7 @@ public final class FeatureGroup implements Iterable<FeatureGroup.TileFeatures>, 
       }
       packer.packLong(vectorTileFeature.id());
       packer.packByte(encodeGeomTypeAndScale(vectorTileFeature.geometry()));
-      var attrs = vectorTileFeature.attrs();
+      var attrs = vectorTileFeature.tags();
       packer.packMapHeader((int) attrs.values().stream().filter(Objects::nonNull).count());
       for (Map.Entry<String, Object> entry : attrs.entrySet()) {
         Object value = entry.getValue();

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/mbtiles/Compare.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/mbtiles/Compare.java
@@ -116,7 +116,7 @@ public class Compare {
    * <li>{@link VectorTile.Feature#id()} won't be compared
    * <li>{@link VectorTile.Feature#layer()} will be compared
    * <li>{@link VectorTile.Feature#geometry()} gets normalized for comparing
-   * <li>{@link VectorTile.Feature#attrs()} will be compared except for the rank attribute since the value produced by
+   * <li>{@link VectorTile.Feature#tags()} will be compared except for the rank attribute since the value produced by
    * planetiler is not stable and differs on every run (at least for parks)
    * <li>{@link VectorTile.Feature#group()} will be compared
    * </ul>
@@ -129,7 +129,7 @@ public class Compare {
   ) {
     static VectorTileFeatureForCmp fromActualFeature(VectorTile.Feature f) {
       try {
-        var attrs = new HashMap<>(f.attrs());
+        var attrs = new HashMap<>(f.tags());
         attrs.remove("rank");
         return new VectorTileFeatureForCmp(f.layer(), f.geometry().decode().norm(), attrs, f.group());
       } catch (GeometryException e) {

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/mbtiles/Verify.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/mbtiles/Verify.java
@@ -68,7 +68,7 @@ public class Verify {
         if (tileCoord.z() == zoom) {
           byte[] data = db.getTile(tileCoord);
           for (var feature : decode(data)) {
-            if (layer.equals(feature.layer()) && feature.attrs().entrySet().containsAll(attrs.entrySet())) {
+            if (layer.equals(feature.layer()) && feature.tags().entrySet().containsAll(attrs.entrySet())) {
               Geometry geometry = feature.geometry().decode();
               num += getGeometryCounts(geometry, clazz);
             }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/TestUtils.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/TestUtils.java
@@ -279,7 +279,7 @@ public class TestUtils {
         case UNKNOWN -> throw new IllegalArgumentException("cannot decompress \"UNKNOWN\"");
       };
       var decoded = VectorTile.decode(bytes).stream()
-        .map(feature -> feature(decodeSilently(feature.geometry()), feature.layer(), feature.attrs())).toList();
+        .map(feature -> feature(decodeSilently(feature.geometry()), feature.layer(), feature.tags())).toList();
       tiles.put(tile.coord(), decoded);
     }
     return tiles;
@@ -738,7 +738,7 @@ public class TestUtils {
           if (feature.geometry().decode().isWithinDistance(tilePoint, 2)) {
             containedInLayers.add(feature.layer());
             if (layer.equals(feature.layer())) {
-              Map<String, Object> tags = feature.attrs();
+              Map<String, Object> tags = feature.tags();
               containedInLayerFeatures.add(tags.toString());
               if (tags.entrySet().containsAll(attrs.entrySet())) {
                 // found a match

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/VectorTileTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/VectorTileTest.java
@@ -160,7 +160,7 @@ class VectorTileTest {
 
     List<VectorTile.Feature> decoded = VectorTile.decode(encoded);
     assertEquals(1, decoded.size());
-    Map<String, Object> decodedAttributes = decoded.getFirst().attrs();
+    Map<String, Object> decodedAttributes = decoded.getFirst().tags();
     assertEquals("value1", decodedAttributes.get("key1"));
     assertEquals(123L, decodedAttributes.get("key2"));
     assertEquals(234.1f, decodedAttributes.get("key3"));
@@ -330,13 +330,13 @@ class VectorTileTest {
     )).encode();
 
     List<VectorTile.Feature> decoded = VectorTile.decode(encoded);
-    assertEquals(attrs1, decoded.get(0).attrs());
+    assertEquals(attrs1, decoded.get(0).tags());
     assertEquals("layer1", decoded.get(0).layer());
 
-    assertEquals(attrs2, decoded.get(1).attrs());
+    assertEquals(attrs2, decoded.get(1).tags());
     assertEquals("layer1", decoded.get(1).layer());
 
-    assertEquals(attrs1, decoded.get(2).attrs());
+    assertEquals(attrs1, decoded.get(2).tags());
     assertEquals("layer2", decoded.get(2).layer());
   }
 

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/collection/FeatureGroupTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/collection/FeatureGroupTest.java
@@ -95,7 +95,7 @@ class FeatureGroupTest {
       for (var feature : VectorTile.decode(tile.getVectorTile().encode())) {
         map.computeIfAbsent(tile.tileCoord().encoded(), (i) -> new TreeMap<>())
           .computeIfAbsent(feature.layer(), l -> new ArrayList<>())
-          .add(new Feature(feature.attrs(), decodeSilently(feature.geometry())));
+          .add(new Feature(feature.tags(), decodeSilently(feature.geometry())));
       }
     }
     return map;
@@ -109,7 +109,7 @@ class FeatureGroupTest {
       for (var feature : VectorTile.decode(tile.getVectorTile().encode())) {
         map.computeIfAbsent(tile.tileCoord().encoded(), (i) -> new TreeMap<>())
           .computeIfAbsent(feature.layer(), l -> new ArrayList<>())
-          .add(new Feature(feature.attrs(), decodeSilently(feature.geometry())));
+          .add(new Feature(feature.tags(), decodeSilently(feature.geometry())));
       }
     }
     return map;


### PR DESCRIPTION
So you can use convenience methods for accessing tag values.

This also renames `VectorTile.Feature#attrs` to `tags` and marks the old `attrs` method deprecated for removal.