### PR TITLE
Avoid deserializing entire parquet geometry just to determine type

### DIFF
--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/GeometryTypeTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/GeometryTypeTest.java
@@ -1,12 +1,20 @@
 package com.onthegomap.planetiler.geo;
 
 import static java.util.Collections.emptyList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.onthegomap.planetiler.TestUtils;
 import com.onthegomap.planetiler.reader.SimpleFeature;
 import java.util.Map;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKBWriter;
+import org.locationtech.jts.io.WKTReader;
 
 class GeometryTypeTest {
 
@@ -22,20 +30,38 @@ class GeometryTypeTest {
       SimpleFeature.createFakeOsmFeature(TestUtils.newPolygon(0, 0, 1, 0, 1, 1, 0, 0), tags, "osm", null, 1,
         emptyList());
 
-    Assertions.assertTrue(GeometryType.LINE.featureTest().evaluate(line));
-    Assertions.assertFalse(GeometryType.LINE.featureTest().evaluate(point));
-    Assertions.assertFalse(GeometryType.LINE.featureTest().evaluate(poly));
+    assertTrue(GeometryType.LINE.featureTest().evaluate(line));
+    assertFalse(GeometryType.LINE.featureTest().evaluate(point));
+    assertFalse(GeometryType.LINE.featureTest().evaluate(poly));
 
-    Assertions.assertFalse(GeometryType.POINT.featureTest().evaluate(line));
-    Assertions.assertTrue(GeometryType.POINT.featureTest().evaluate(point));
-    Assertions.assertFalse(GeometryType.POINT.featureTest().evaluate(poly));
+    assertFalse(GeometryType.POINT.featureTest().evaluate(line));
+    assertTrue(GeometryType.POINT.featureTest().evaluate(point));
+    assertFalse(GeometryType.POINT.featureTest().evaluate(poly));
 
-    Assertions.assertFalse(GeometryType.POLYGON.featureTest().evaluate(line));
-    Assertions.assertFalse(GeometryType.POLYGON.featureTest().evaluate(point));
-    Assertions.assertTrue(GeometryType.POLYGON.featureTest().evaluate(poly));
+    assertFalse(GeometryType.POLYGON.featureTest().evaluate(line));
+    assertFalse(GeometryType.POLYGON.featureTest().evaluate(point));
+    assertTrue(GeometryType.POLYGON.featureTest().evaluate(poly));
 
-    Assertions.assertThrows(Exception.class, () -> GeometryType.UNKNOWN.featureTest().evaluate(point));
-    Assertions.assertThrows(Exception.class, () -> GeometryType.UNKNOWN.featureTest().evaluate(line));
-    Assertions.assertThrows(Exception.class, () -> GeometryType.UNKNOWN.featureTest().evaluate(poly));
+    assertThrows(Exception.class, () -> GeometryType.UNKNOWN.featureTest().evaluate(point));
+    assertThrows(Exception.class, () -> GeometryType.UNKNOWN.featureTest().evaluate(line));
+    assertThrows(Exception.class, () -> GeometryType.UNKNOWN.featureTest().evaluate(poly));
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "POINT; POINT EMPTY",
+    "POINT; POINT(1 1)",
+    "POINT; MULTIPOINT(1 1, 2 2)",
+    "LINE; lineString(1 1, 2 2)",
+    "LINE; LINESTRING ZM(1 1 2 3, 2 2 4 5)",
+    "LINE; multiLineString((1 1, 2 2))",
+    "POLYGON; POLYGON((0 0, 0 1, 1 0, 0 0))",
+    "POLYGON; MULTIPOLYGON(((0 0, 0 1, 1 0, 0 0)))",
+    "UNKNOWN; GEOMETRYCOLLECTION EMPTY",
+  }, delimiter = ';')
+  void testSniffTypes(GeometryType expected, String wkt) throws ParseException {
+    assertEquals(expected, GeometryType.fromWKT(wkt));
+    var wkb = new WKBWriter().write(new WKTReader().read(wkt));
+    assertEquals(expected, GeometryType.fromWKB(wkb));
   }
 }


### PR DESCRIPTION
Slight optimization to attempt to parse the geometry type from the beginning of a WKB or WKT-encoded geometry without deserializing the whole thing. If that fails, it falls back to the old behavior of deserializing and checking the type.