### PR TITLE
Use snappy compression for `--compress-temp` flag

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/config/PlanetilerConfig.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/config/PlanetilerConfig.java
@@ -29,7 +29,7 @@ public record PlanetilerConfig(
   int maxzoomForRendering,
   boolean force,
   boolean append,
-  boolean gzipTempStorage,
+  boolean compressTempStorage,
   boolean mmapTempStorage,
   int sortMaxReaders,
   int sortMaxWriters,
@@ -146,7 +146,8 @@ public record PlanetilerConfig(
         "append to the output file - only supported by " + Stream.of(TileArchiveConfig.Format.values())
           .filter(TileArchiveConfig.Format::supportsAppend).map(TileArchiveConfig.Format::id).toList(),
         false),
-      arguments.getBoolean("gzip_temp", "gzip temporary feature storage (uses more CPU, but less disk space)", false),
+      arguments.getBoolean("compress_temp|gzip_temp",
+        "compress temporary feature storage (uses more CPU, but less disk space)", false),
       arguments.getBoolean("mmap_temp", "use memory-mapped IO for temp feature files", true),
       arguments.getInteger("sort_max_readers", "maximum number of concurrent read threads to use when sorting chunks",
         6),

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
@@ -2082,6 +2082,7 @@ class PlanetilerTests {
     "",
     "--write-threads=2 --process-threads=2 --feature-read-threads=2 --threads=4",
     "--free-osm-after-read",
+    "--compress-temp",
     "--osm-parse-node-bounds",
     "--output-format=pmtiles",
     "--output-format=csv",

--- a/planetiler-custommap/README.md
+++ b/planetiler-custommap/README.md
@@ -144,6 +144,7 @@ to regenerate:
 
 cat planetiler-custommap/planetiler.schema.json | jq -r '.properties.args.properties | to_entries[] | "- `" + .key + "` - " + .value.description' | pbcopy
 -->
+
 - `threads` - Default number of threads to use.
 - `write_threads` - Default number of threads to use when writing temp features
 - `process_threads` - Default number of threads to use when processing input features
@@ -152,7 +153,7 @@ cat planetiler-custommap/planetiler.schema.json | jq -r '.properties.args.proper
 - `maxzoom` - Maximum tile zoom level to emit
 - `render_maxzoom` - Maximum rendering zoom level up to
 - `force` - Overwriting output file and ignore warnings
-- `gzip_temp` - Gzip temporary feature storage (uses more CPU, but less disk space)
+- `compress_temp` - Gzip temporary feature storage (uses more CPU, but less disk space)
 - `mmap_temp` - Use memory-mapped IO for temp feature files
 - `sort_max_readers` - Maximum number of concurrent read threads to use when sorting chunks
 - `sort_max_writers` - Maximum number of concurrent write threads to use when sorting chunks

--- a/planetiler-custommap/README.md
+++ b/planetiler-custommap/README.md
@@ -144,7 +144,6 @@ to regenerate:
 
 cat planetiler-custommap/planetiler.schema.json | jq -r '.properties.args.properties | to_entries[] | "- `" + .key + "` - " + .value.description' | pbcopy
 -->
-
 - `threads` - Default number of threads to use.
 - `write_threads` - Default number of threads to use when writing temp features
 - `process_threads` - Default number of threads to use when processing input features

--- a/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/Contexts.java
+++ b/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/Contexts.java
@@ -190,7 +190,7 @@ public class Contexts {
       argumentValues.put("maxzoom", config.maxzoom());
       argumentValues.put("render_maxzoom", config.maxzoomForRendering());
       argumentValues.put("force", config.force());
-      argumentValues.put("gzip_temp", config.gzipTempStorage());
+      argumentValues.put("compress_temp", config.compressTempStorage());
       argumentValues.put("mmap_temp", config.mmapTempStorage());
       argumentValues.put("sort_max_readers", config.sortMaxReaders());
       argumentValues.put("sort_max_writers", config.sortMaxWriters());


### PR DESCRIPTION
Rename `--gzip-temp` command-line argument to `--compress-temp` and make it use snappy compression instead of gzip. Snappy didn't product the smallest size, but adds almost a negligible amount to the overall runtime. Zstd produced the smallest feature sizes but nearly doubles the overall runtime.

Here were the temp feature sizes vs. runtimes when running over massachusetts:

compression | MA time | tmp feature size
-- | -- | --
none | 0:48 | 638mb
gzip level 1 | 1:30 | 265mb
[aircompressor zstd](https://github.com/airlift/aircompressor) | 0:55 | 365mb
[snappy-java](https://github.com/xerial/snappy-java) | 0:50 (winner) | 326mb
[zstd-jni](https://github.com/luben/zstd-jni) level 3 | 1:18 | 219mb (winner)
[zstd-jni](https://github.com/luben/zstd-jni) level 2 | 1:16 | 236mb
[zstd-jni](https://github.com/luben/zstd-jni) level 1 | 1:17 | 248mb

