### PR TITLE
Parquet/no-build-tool java profile usability improvements

### DIFF
--- a/planetiler-core/pom.xml
+++ b/planetiler-core/pom.xml
@@ -125,6 +125,10 @@
       <version>${jackson.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.snakeyaml</groupId>
+      <artifactId>snakeyaml-engine</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient</artifactId>
       <version>${prometheus.version}</version>

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureCollector.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureCollector.java
@@ -353,7 +353,7 @@ public class FeatureCollector implements Iterable<FeatureCollector.Feature> {
      * size.
      */
     default T setAttrWithMinSize(String key, Object value, double minPixelSize) {
-      return setAttrWithMinzoom(key, value, collector().getMinZoomForPixelSize(minPixelSize));
+      return setAttrWithMinzoom(key, value, getMinZoomForPixelSize(minPixelSize));
     }
 
     /**
@@ -368,7 +368,11 @@ public class FeatureCollector implements Iterable<FeatureCollector.Feature> {
     default T setAttrWithMinSize(String key, Object value, double minPixelSize, int minZoomIfBigEnough,
       int minZoomToShowAlways) {
       return setAttrWithMinzoom(key, value,
-        Math.clamp(collector().getMinZoomForPixelSize(minPixelSize), minZoomIfBigEnough, minZoomToShowAlways));
+        Math.clamp(getMinZoomForPixelSize(minPixelSize), minZoomIfBigEnough, minZoomToShowAlways));
+    }
+
+    default int getMinZoomForPixelSize(double minPixelSize) {
+      return collector().getMinZoomForPixelSize(minPixelSize);
     }
 
     /**
@@ -1081,6 +1085,12 @@ public class FeatureCollector implements Iterable<FeatureCollector.Feature> {
        */
       public LinearRange linearRange(Range<Double> range) {
         return entireLine().linearRange(range);
+      }
+
+
+      @Override
+      public int getMinZoomForPixelSize(double minPixelSize) {
+        return WithAttrs.super.getMinZoomForPixelSize(minPixelSize / (range.upperEndpoint() - range.lowerEndpoint()));
       }
 
       @Override

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureProcessor.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureProcessor.java
@@ -1,0 +1,24 @@
+package com.onthegomap.planetiler;
+
+import com.onthegomap.planetiler.reader.SourceFeature;
+
+/**
+ * Subcomponent of {@link Profile} that handles processing layers from a feature, and optionally when that source is
+ * finished.
+ */
+@FunctionalInterface
+public interface FeatureProcessor<T extends SourceFeature> {
+
+  /**
+   * Generates output features for any input feature that should appear in the map.
+   * <p>
+   * Multiple threads may invoke this method concurrently for a single data source so implementations should ensure
+   * thread-safe access to any shared data structures. Separate data sources are processed sequentially.
+   * <p>
+   * All OSM nodes are processed first, then ways, then relations.
+   *
+   * @param sourceFeature the input feature from a source dataset (OSM element, shapefile element, etc.)
+   * @param features      a collector for generating output map features to emit
+   */
+  void processFeature(T sourceFeature, FeatureCollector features);
+}

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/ForwardingProfile.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/ForwardingProfile.java
@@ -201,10 +201,13 @@ public abstract class ForwardingProfile implements Profile {
 
   @Override
   public boolean caresAboutSource(String name) {
-    // if any match source
+    return caresAbout(Expression.PartialInput.ofSource(name));
+  }
+
+  @Override
+  public boolean caresAbout(Expression.PartialInput input) {
     return sourceElementProcessors.stream().anyMatch(e -> e.expression()
-      .replace(Expression.matchSource(name), Expression.TRUE)
-      .replace(exp -> exp instanceof Expression.MatchSource, Expression.FALSE)
+      .partialEvaluate(input)
       .simplify() != Expression.FALSE);
   }
 

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/ForwardingProfile.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/ForwardingProfile.java
@@ -1,5 +1,8 @@
 package com.onthegomap.planetiler;
 
+import com.onthegomap.planetiler.config.PlanetilerConfig;
+import com.onthegomap.planetiler.expression.Expression;
+import com.onthegomap.planetiler.expression.MultiExpression;
 import com.onthegomap.planetiler.geo.GeometryException;
 import com.onthegomap.planetiler.geo.TileCoord;
 import com.onthegomap.planetiler.reader.SourceFeature;
@@ -9,6 +12,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
 
 /**
@@ -41,8 +45,41 @@ public abstract class ForwardingProfile implements Profile {
   private final Map<String, List<LayerPostProcesser>> layerPostProcessors = new HashMap<>();
   /** List of handlers that implement {@link TilePostProcessor}. */
   private final List<TilePostProcessor> tilePostProcessors = new ArrayList<>();
-  /** Map from source ID to its handler if it implements {@link FeatureProcessor}. */
-  private final Map<String, List<FeatureProcessor>> sourceElementProcessors = new HashMap<>();
+  /** List of handlers that implements {@link FeatureProcessor} along with a filter expression. */
+  private final List<MultiExpression.Entry<FeatureProcessor>> sourceElementProcessors = new CopyOnWriteArrayList<>();
+  private final List<String> onlyLayers;
+  private final List<String> excludeLayers;
+  @SuppressWarnings("java:S3077")
+  private volatile MultiExpression.Index<FeatureProcessor> indexedSourceElementProcessors = null;
+
+  protected ForwardingProfile(PlanetilerConfig config, Handler... handlers) {
+    onlyLayers = config.arguments().getList("only_layers", "Include only certain layers", List.of());
+    excludeLayers = config.arguments().getList("exclude_layers", "Exclude certain layers", List.of());
+    for (var handler : handlers) {
+      registerHandler(handler);
+    }
+  }
+
+  protected ForwardingProfile() {
+    onlyLayers = List.of();
+    excludeLayers = List.of();
+  }
+
+  protected ForwardingProfile(Handler... handlers) {
+    onlyLayers = List.of();
+    excludeLayers = List.of();
+    for (var handler : handlers) {
+      registerHandler(handler);
+    }
+  }
+
+  private boolean caresAboutLayer(String layer) {
+    return (onlyLayers.isEmpty() || onlyLayers.contains(layer)) && !excludeLayers.contains(layer);
+  }
+
+  private boolean caresAboutLayer(Object obj) {
+    return !(obj instanceof HandlerForLayer l) || caresAboutLayer(l.name());
+  }
 
   /**
    * Call {@code processor} for every element in {@code source}.
@@ -51,8 +88,29 @@ public abstract class ForwardingProfile implements Profile {
    * @param processor handler that will process elements in that source
    */
   public void registerSourceHandler(String source, FeatureProcessor processor) {
-    sourceElementProcessors.computeIfAbsent(source, name -> new ArrayList<>())
-      .add(processor);
+    if (!caresAboutLayer(processor)) {
+      return;
+    }
+    sourceElementProcessors
+      .add(MultiExpression.entry(processor, Expression.and(Expression.matchSource(source), processor.filter())));
+    synchronized (sourceElementProcessors) {
+      indexedSourceElementProcessors = null;
+    }
+  }
+
+  /**
+   * Call {@code processor} for every element.
+   *
+   * @param processor handler that will process elements in that source
+   */
+  public void registerFeatureHandler(FeatureProcessor processor) {
+    if (!caresAboutLayer(processor)) {
+      return;
+    }
+    sourceElementProcessors.add(MultiExpression.entry(processor, processor.filter()));
+    synchronized (sourceElementProcessors) {
+      indexedSourceElementProcessors = null;
+    }
   }
 
   /**
@@ -60,6 +118,9 @@ public abstract class ForwardingProfile implements Profile {
    * {@link OsmRelationPreprocessor}, {@link FinishHandler}, {@link TilePostProcessor} or {@link LayerPostProcesser}.
    */
   public void registerHandler(Handler handler) {
+    if (!caresAboutLayer(handler)) {
+      return;
+    }
     this.handlers.add(handler);
     if (handler instanceof OsmNodePreprocessor osmNodePreprocessor) {
       osmNodePreprocessors.add(osmNodePreprocessor);
@@ -79,6 +140,9 @@ public abstract class ForwardingProfile implements Profile {
     }
     if (handler instanceof TilePostProcessor postProcessor) {
       tilePostProcessors.add(postProcessor);
+    }
+    if (handler instanceof FeatureProcessor processor) {
+      registerFeatureHandler(processor);
     }
   }
 
@@ -117,19 +181,31 @@ public abstract class ForwardingProfile implements Profile {
   @Override
   public void processFeature(SourceFeature sourceFeature, FeatureCollector features) {
     // delegate source feature processing to each handler for that source
-    var handlers = sourceElementProcessors.get(sourceFeature.getSource());
-    if (handlers != null) {
-      for (var handler : handlers) {
-        handler.processFeature(sourceFeature, features);
-        // TODO extract common handling for expression-based filtering from basemap to this
-        // common profile when we have another use-case for it.
+    for (var handler : getHandlerIndex().getMatches(sourceFeature)) {
+      handler.processFeature(sourceFeature, features);
+    }
+  }
+
+  private MultiExpression.Index<FeatureProcessor> getHandlerIndex() {
+    MultiExpression.Index<FeatureProcessor> result = indexedSourceElementProcessors;
+    if (result == null) {
+      synchronized (sourceElementProcessors) {
+        result = indexedSourceElementProcessors;
+        if (result == null) {
+          indexedSourceElementProcessors = result = MultiExpression.of(sourceElementProcessors).index();
+        }
       }
     }
+    return result;
   }
 
   @Override
   public boolean caresAboutSource(String name) {
-    return sourceElementProcessors.containsKey(name);
+    // if any match source
+    return sourceElementProcessors.stream().anyMatch(e -> e.expression()
+      .replace(Expression.matchSource(name), Expression.TRUE)
+      .replace(exp -> exp instanceof Expression.MatchSource, Expression.FALSE)
+      .simplify() != Expression.FALSE);
   }
 
   @Override
@@ -271,13 +347,12 @@ public abstract class ForwardingProfile implements Profile {
   }
 
   /** Handlers should implement this interface to process input features from a given source ID. */
-  public interface FeatureProcessor {
+  @FunctionalInterface
+  public interface FeatureProcessor extends com.onthegomap.planetiler.FeatureProcessor<SourceFeature>, Handler {
 
-    /**
-     * Process an input element from a source feature.
-     *
-     * @see Profile#processFeature(SourceFeature, FeatureCollector)
-     */
-    void processFeature(SourceFeature feature, FeatureCollector features);
+    /** Returns an {@link Expression} that limits the features that this processor gets called for. */
+    default Expression filter() {
+      return Expression.TRUE;
+    }
   }
 }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
@@ -34,6 +34,7 @@ import com.onthegomap.planetiler.util.TileSizeStats;
 import com.onthegomap.planetiler.util.TopOsmTiles;
 import com.onthegomap.planetiler.util.Translations;
 import com.onthegomap.planetiler.util.Wikidata;
+import com.onthegomap.planetiler.validator.JavaProfileValidator;
 import com.onthegomap.planetiler.worker.RunnableThatThrows;
 import java.io.IOException;
 import java.nio.file.FileSystem;
@@ -88,6 +89,7 @@ public class Planetiler {
   private final Path nodeDbPath;
   private final Path multipolygonPath;
   private final Path featureDbPath;
+  private final Path onlyRunTests;
   private boolean downloadSources;
   private final boolean refreshSources;
   private final boolean onlyDownloadSources;
@@ -124,6 +126,7 @@ public class Planetiler {
     }
     tmpDir = config.tmpDir();
     onlyDownloadSources = arguments.getBoolean("only_download", "download source data then exit", false);
+    onlyRunTests = arguments.file("tests", "run test cases in a yaml then quit", null);
     downloadSources = onlyDownloadSources || arguments.getBoolean("download", "download sources", false);
     refreshSources =
       arguments.getBoolean("refresh_sources", "download new version of source files if they have changed", false);
@@ -750,6 +753,9 @@ public class Planetiler {
 
     if (arguments.getBoolean("help", "show arguments then exit", false)) {
       System.exit(0);
+    } else if (onlyRunTests != null) {
+      boolean success = JavaProfileValidator.validate(profile(), onlyRunTests, config());
+      System.exit(success ? 0 : 1);
     } else if (onlyDownloadSources) {
       // don't check files if not generating map
     } else if (config.append()) {

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
@@ -684,42 +684,6 @@ public class Planetiler {
     return overwriteOutput(defaultOutput.toString());
   }
 
-  /** Adds an extra key/value pair to the output archive metadata. */
-  public Planetiler setOutputMetadata(String key, String value) {
-    archiveMetadataDefaults.put(key, value);
-    return this;
-  }
-
-  /** Sets the name attribute in the output archive metadata. */
-  public Planetiler setOutputName(String name) {
-    return setOutputMetadata(TileArchiveMetadata.NAME_KEY, name);
-  }
-
-  /** Sets the version attribute in the output archive metadata. */
-  public Planetiler setOutputVersion(String version) {
-    return setOutputMetadata(TileArchiveMetadata.VERSION_KEY, version);
-  }
-
-  /** Sets the version attribute in the output archive metadata. */
-  public Planetiler setOutputDescription(String description) {
-    return setOutputMetadata(TileArchiveMetadata.DESCRIPTION_KEY, description);
-  }
-
-  /** Sets the attribution attribute in the output archive metadata. */
-  public Planetiler setOutputAttribution(String attribution) {
-    return setOutputMetadata(TileArchiveMetadata.ATTRIBUTION_KEY, attribution);
-  }
-
-  /** Sets the type attribute in the output archive metadata to "overlay" meant to be shown over a basemap. */
-  public Planetiler setOutputIsOverlay() {
-    return setOutputMetadata(TileArchiveMetadata.TYPE_KEY, "overlay");
-  }
-
-  /** Sets the type attribute in the output archive metadata to "basemap". */
-  public Planetiler setOutputIsBasemap() {
-    return setOutputMetadata(TileArchiveMetadata.TYPE_KEY, "basemap");
-  }
-
   /**
    * Reads all elements from all sourced that have been added, generates map features according to the profile, and
    * writes the rendered tiles to the output archive.

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
@@ -41,7 +41,6 @@ import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -114,7 +113,6 @@ public class Planetiler {
   private boolean fetchWikidata = false;
   private final boolean fetchOsmTileStats;
   private TileArchiveMetadata tileArchiveMetadata;
-  private Map<String, String> archiveMetadataDefaults = new HashMap<>();
 
   private Planetiler(Arguments arguments) {
     this.arguments = arguments;

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/Profile.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/Profile.java
@@ -1,5 +1,6 @@
 package com.onthegomap.planetiler;
 
+import com.onthegomap.planetiler.expression.Expression;
 import com.onthegomap.planetiler.geo.GeometryException;
 import com.onthegomap.planetiler.geo.TileCoord;
 import com.onthegomap.planetiler.mbtiles.Mbtiles;
@@ -244,6 +245,14 @@ public interface Profile extends FeatureProcessor<SourceFeature> {
    */
   default long estimateRamRequired(long osmFileSize) {
     return 0L;
+  }
+
+  /**
+   * Returns false if this profile will ignore every feature in a set where {@linkplain Expression.PartialInput partial
+   * attributes} are known ahead of time.
+   */
+  default boolean caresAbout(Expression.PartialInput input) {
+    return true;
   }
 
   /**

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/Profile.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/Profile.java
@@ -32,8 +32,17 @@ import java.util.function.Consumer;
  * For complex profiles, {@link ForwardingProfile} provides a framework for splitting the logic up into several handlers
  * (i.e. one per layer) and forwarding each element/event to the handlers that care about it.
  */
-public interface Profile {
+public interface Profile extends FeatureProcessor<SourceFeature> {
   // TODO might want to break this apart into sub-interfaces that ForwardingProfile (and TileArchiveMetadata) can use too
+
+  /**
+   * Default attribution recommended for profiles using OpenStreetMap data
+   *
+   * @see <a href="https://www.openstreetmap.org/copyright">www.openstreetmap.org/copyright</a>
+   */
+  String OSM_ATTRIBUTION = """
+    <a href="https://www.openstreetmap.org/copyright" target="_blank">&copy; OpenStreetMap contributors</a>
+    """.trim();
 
   /**
    * Allows profile to extract any information it needs from a {@link OsmElement.Node} during the first pass through OSM
@@ -70,19 +79,6 @@ public interface Profile {
   default List<OsmRelationInfo> preprocessOsmRelation(OsmElement.Relation relation) {
     return null;
   }
-
-  /**
-   * Generates output features for any input feature that should appear in the map.
-   * <p>
-   * Multiple threads may invoke this method concurrently for a single data source so implementations should ensure
-   * thread-safe access to any shared data structures. Separate data sources are processed sequentially.
-   * <p>
-   * All OSM nodes are processed first, then ways, then relations.
-   *
-   * @param sourceFeature the input feature from a source dataset (OSM element, shapefile element, etc.)
-   * @param features      a collector for generating output map features to emit
-   */
-  void processFeature(SourceFeature sourceFeature, FeatureCollector features);
 
   /** Free any resources associated with this profile (i.e. shared data structures) */
   default void release() {}
@@ -143,7 +139,9 @@ public interface Profile {
    *
    * @see <a href="https://github.com/mapbox/mbtiles-spec/blob/master/1.3/spec.md#metadata">MBTiles specification</a>
    */
-  String name();
+  default String name() {
+    return getClass().getSimpleName();
+  }
 
   /**
    * Returns the description of the generated tileset to put into {@link Mbtiles} metadata

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/config/Arguments.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/config/Arguments.java
@@ -546,4 +546,9 @@ public class Arguments {
       () -> keys.get().stream().filter(key -> allowed.contains(normalize(key))).toList()
     );
   }
+
+  /** Returns a new arguments instance where the value for {@code key} defaults to {@code value}. */
+  public Arguments withDefault(Object key, Object value) {
+    return orElse(Arguments.of(key.toString().replaceFirst("^-*", ""), value));
+  }
 }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/expression/Expression.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/expression/Expression.java
@@ -685,5 +685,10 @@ public interface Expression extends Simplifiable<Expression> {
     public static PartialInput ofSource(String source) {
       return new PartialInput(Set.of(source), Set.of(), Map.of(), Set.of());
     }
+
+    @Override
+    public Map<String, Object> tags() {
+      return tags == null ? Map.of() : tags;
+    }
   }
 }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/expression/Expression.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/expression/Expression.java
@@ -187,6 +187,7 @@ public interface Expression extends Simplifiable<Expression> {
       case Or(var children) -> children.forEach(child -> child.visit(fn));
       case And(var children) -> children.forEach(child -> child.visit(fn));
       default -> {
+        // already called fn, and no nested children
       }
     }
   }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/expression/MultiExpression.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/expression/MultiExpression.java
@@ -4,6 +4,7 @@ import static com.onthegomap.planetiler.expression.Expression.FALSE;
 import static com.onthegomap.planetiler.expression.Expression.TRUE;
 import static com.onthegomap.planetiler.expression.Expression.matchType;
 
+import com.onthegomap.planetiler.reader.SourceFeature;
 import com.onthegomap.planetiler.reader.WithGeometryType;
 import com.onthegomap.planetiler.reader.WithTags;
 import java.util.ArrayList;
@@ -32,7 +33,7 @@ import org.slf4j.LoggerFactory;
  *
  * @param <T> type of data value associated with each expression
  */
-public record MultiExpression<T> (List<Entry<T>> expressions) implements Simplifiable<MultiExpression<T>> {
+public record MultiExpression<T>(List<Entry<T>> expressions) implements Simplifiable<MultiExpression<T>> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(MultiExpression.class);
   private static final Comparator<WithId> BY_ID = Comparator.comparingInt(WithId::id);
@@ -98,9 +99,18 @@ public record MultiExpression<T> (List<Entry<T>> expressions) implements Simplif
     if (expressions.isEmpty()) {
       return new EmptyIndex<>();
     }
-    boolean caresAboutGeometryType =
-      expressions.stream().anyMatch(entry -> entry.expression.contains(exp -> exp instanceof Expression.MatchType));
-    return caresAboutGeometryType ? new GeometryTypeIndex<>(this, warn) : new KeyIndex<>(simplify(), warn);
+    if (contains(Expression.MatchSource.class::isInstance)) {
+      return new SourceIndex<>(this, warn);
+    } else if (contains(Expression.MatchSourceLayer.class::isInstance)) {
+      return new SourceLayerIndex<>(this, warn);
+    } else if (contains(Expression.MatchType.class::isInstance)) {
+      return new GeometryTypeIndex<>(this, warn);
+    }
+    return new KeyIndex<>(simplify(), warn);
+  }
+
+  private boolean contains(Predicate<Expression> test) {
+    return expressions.stream().anyMatch(entry -> entry.expression.contains(test));
   }
 
   /** Returns a copy of this multi-expression that replaces every expression using {@code mapper}. */
@@ -203,7 +213,7 @@ public record MultiExpression<T> (List<Entry<T>> expressions) implements Simplif
 
     @Override
     public List<Match<T>> getMatchesWithTriggers(WithTags input) {
-      return List.of();
+      return new ArrayList<>();
     }
 
     @Override
@@ -238,7 +248,12 @@ public record MultiExpression<T> (List<Entry<T>> expressions) implements Simplif
           always.add(expressionValue);
         } else {
           getRelevantKeys(expression,
-            key -> keyToExpressions.computeIfAbsent(key, k -> new HashSet<>()).add(expressionValue));
+            key -> {
+              while (!key.isBlank()) {
+                keyToExpressions.computeIfAbsent(key, k -> new HashSet<>()).add(expressionValue);
+                key = key.replaceAll("(^|(\\[])?\\.)[^.]*$", "");
+              }
+            });
         }
       }
       // create immutable copies for fast iteration at matching time
@@ -302,10 +317,10 @@ public record MultiExpression<T> (List<Entry<T>> expressions) implements Simplif
   /** Index that limits the search space of expressions based on geometry type of an input element. */
   private static class GeometryTypeIndex<T> implements Index<T> {
 
-    private final KeyIndex<T> pointIndex;
-    private final KeyIndex<T> lineIndex;
-    private final KeyIndex<T> polygonIndex;
-    private final KeyIndex<T> otherIndex;
+    private final Index<T> pointIndex;
+    private final Index<T> lineIndex;
+    private final Index<T> polygonIndex;
+    private final Index<T> otherIndex;
 
     private GeometryTypeIndex(MultiExpression<T> expressions, boolean warn) {
       // build an index per type then search in each of those indexes based on the geometry type of each input element
@@ -316,14 +331,12 @@ public record MultiExpression<T> (List<Entry<T>> expressions) implements Simplif
       otherIndex = indexForType(expressions, Expression.UNKNOWN_GEOMETRY_TYPE, warn);
     }
 
-    private KeyIndex<T> indexForType(MultiExpression<T> expressions, String type, boolean warn) {
-      return new KeyIndex<>(
-        expressions
-          .replace(matchType(type), TRUE)
-          .replace(e -> e instanceof Expression.MatchType, FALSE)
-          .simplify(),
-        warn
-      );
+    private Index<T> indexForType(MultiExpression<T> expressions, String type, boolean warn) {
+      return expressions
+        .replace(matchType(type), TRUE)
+        .replace(e -> e instanceof Expression.MatchType, FALSE)
+        .simplify()
+        .index(warn);
     }
 
     /**
@@ -354,14 +367,97 @@ public record MultiExpression<T> (List<Entry<T>> expressions) implements Simplif
     }
   }
 
+  private abstract static class StringFieldIndex<T> implements Index<T> {
+
+    private final Map<String, Index<T>> sourceIndex;
+    private final Index<T> allSourcesIndex;
+
+    private StringFieldIndex(MultiExpression<T> expressions, boolean warn, Function<Expression, String> extract,
+      Function<String, Expression> make) {
+      Set<String> sources = new HashSet<>();
+      for (var expression : expressions.expressions) {
+        expression.expression.visit(e -> {
+          String key = extract.apply(e);
+          if (key != null) {
+            sources.add(key);
+          }
+        });
+      }
+      sourceIndex = HashMap.newHashMap(sources.size());
+      for (var source : sources) {
+        var forThisSource = expressions
+          .replace(make.apply(source), TRUE)
+          .replace(e -> extract.apply(e) != null, FALSE)
+          .simplify()
+          .index(warn);
+        if (!forThisSource.isEmpty()) {
+          sourceIndex.put(source, forThisSource);
+        }
+      }
+      allSourcesIndex = expressions.replace(e -> extract.apply(e) != null, FALSE).simplify().index(warn);
+    }
+
+    abstract String extract(WithTags input);
+
+    /**
+     * Returns all data values associated with expressions that match an input element, along with the tag keys that
+     * caused the match.
+     */
+    public List<Match<T>> getMatchesWithTriggers(WithTags input) {
+      List<Match<T>> result = null;
+      String key = extract(input);
+      if (key != null) {
+        var index = sourceIndex.get(key);
+        if (index != null) {
+          result = index.getMatchesWithTriggers(input);
+        }
+      }
+      if (result == null) {
+        result = allSourcesIndex.getMatchesWithTriggers(input);
+      }
+      result.sort(BY_ID);
+      return result;
+    }
+  }
+
+  /** Index that limits the search space of expressions based on geometry type of an input element. */
+  private static class SourceLayerIndex<T> extends StringFieldIndex<T> {
+
+    private SourceLayerIndex(MultiExpression<T> expressions, boolean warn) {
+      super(expressions, warn,
+        e -> e instanceof Expression.MatchSourceLayer(var layer) ? layer : null,
+        Expression::matchSourceLayer);
+    }
+
+    @Override
+    String extract(WithTags input) {
+      return input instanceof SourceFeature feature ? feature.getSourceLayer() : null;
+    }
+  }
+
+  /** Index that limits the search space of expressions based on geometry type of an input element. */
+  private static class SourceIndex<T> extends StringFieldIndex<T> {
+
+    private SourceIndex(MultiExpression<T> expressions, boolean warn) {
+      super(expressions, warn,
+        e -> e instanceof Expression.MatchSource(var source) ? source : null,
+        Expression::matchSource);
+    }
+
+    @Override
+    String extract(WithTags input) {
+      return input instanceof SourceFeature feature ? feature.getSource() : null;
+    }
+  }
+
   /** An expression/value pair with unique ID to store whether we evaluated it yet. */
-  private record EntryWithId<T> (T result, Expression expression, @Override int id) implements WithId {}
+  private record EntryWithId<T>(T result, Expression expression, @Override int id) implements WithId {}
 
   /**
    * An {@code expression} to evaluate on input elements and {@code result} value to return when the element matches.
    */
-  public record Entry<T> (T result, Expression expression) {}
+  public record Entry<T>(T result, Expression expression) {}
 
   /** The result when an expression matches, along with the input element tag {@code keys} that triggered the match. */
-  public record Match<T> (T match, List<String> keys, @Override int id) implements WithId {}
+  public record Match<T>(T match, List<String> keys, @Override int id) implements WithId {}
 }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/SourceFeature.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/SourceFeature.java
@@ -65,19 +65,6 @@ public abstract class SourceFeature implements WithTags, WithGeometryType {
     this.id = id;
   }
 
-  // slight optimization: replace default implementation with direct access to the tags
-  // map to get slightly improved performance when matching elements against expressions
-
-  @Override
-  public Object getTag(String key) {
-    return tags.get(key);
-  }
-
-  @Override
-  public boolean hasTag(String key) {
-    return tags.containsKey(key);
-  }
-
 
   @Override
   public Map<String, Object> tags() {

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/parquet/ParquetFeature.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/parquet/ParquetFeature.java
@@ -109,15 +109,7 @@ public class ParquetFeature extends SourceFeature {
 
   @Override
   public Object getTag(String key) {
-    var value = tags().get(key);
-    if (value == null) {
-      String[] parts = key.split("\\.", 2);
-      if (parts.length == 2) {
-        return getStruct(parts[0]).get(parts[1]).rawValue();
-      }
-      return getStruct(parts[0]).rawValue();
-    }
-    return value;
+    return cachedStruct().get(key).rawValue();
   }
 
   @Override
@@ -131,7 +123,7 @@ public class ParquetFeature extends SourceFeature {
 
   @Override
   public boolean hasTag(String key) {
-    return super.hasTag(key) || getTag(key) != null;
+    return !cachedStruct().get(key).isNull();
   }
 
   @Override

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/parquet/ParquetReader.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/parquet/ParquetReader.java
@@ -90,7 +90,7 @@ public class ParquetReader {
         String layer = getLayerName(path);
         return new ParquetInputFile(sourceName, layer, path, null, config.bounds(), hivePartitionFields, idGenerator);
       })
-      .filter(file -> !file.isOutOfBounds())
+      .filter(file -> !file.shouldSkip(profile))
       .toList();
     // don't show % complete on features when a filter is present because to determine total # elements would
     // take an expensive initial query, and % complete on blocks gives a good enough proxy

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/util/YAML.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/util/YAML.java
@@ -1,4 +1,4 @@
-package com.onthegomap.planetiler.custommap;
+package com.onthegomap.planetiler.util;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.ByteArrayInputStream;

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/validator/BaseSchemaValidator.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/validator/BaseSchemaValidator.java
@@ -1,0 +1,279 @@
+package com.onthegomap.planetiler.validator;
+
+import com.onthegomap.planetiler.FeatureCollector;
+import com.onthegomap.planetiler.Profile;
+import com.onthegomap.planetiler.config.Arguments;
+import com.onthegomap.planetiler.config.PlanetilerConfig;
+import com.onthegomap.planetiler.geo.GeometryType;
+import com.onthegomap.planetiler.reader.SimpleFeature;
+import com.onthegomap.planetiler.stats.Stats;
+import com.onthegomap.planetiler.util.AnsiColors;
+import com.onthegomap.planetiler.util.FileWatcher;
+import com.onthegomap.planetiler.util.Format;
+import com.onthegomap.planetiler.util.Try;
+import java.io.PrintStream;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
+
+/**
+ * Verifies that a profile maps input elements map to expected output vector tile features as defined by a
+ * {@link SchemaSpecification} instance.
+ */
+public abstract class BaseSchemaValidator {
+
+  private static final String PASS_BADGE = AnsiColors.greenBackground(" PASS ");
+  private static final String FAIL_BADGE = AnsiColors.redBackground(" FAIL ");
+  protected final PrintStream output;
+  private final boolean watch;
+
+  protected BaseSchemaValidator(Arguments args, PrintStream output) {
+    this(
+      args.getBoolean("watch", "Watch files for changes and re-run validation when schema or spec changes", false),
+      output
+    );
+  }
+
+  protected BaseSchemaValidator(boolean watch, PrintStream output) {
+    this.watch = watch;
+    this.output = output;
+  }
+
+  protected static boolean hasCause(Throwable t, Class<?> cause) {
+    return t != null && (cause.isInstance(t) || hasCause(t.getCause(), cause));
+  }
+
+  protected boolean runOrWatch() {
+    output.println("OK");
+    var response = validateFromCli();
+
+    if (watch) {
+      output.println();
+      output.println("Watching filesystem for changes...");
+      var watcher = FileWatcher.newWatcher(response.paths.toArray(Path[]::new));
+      watcher.pollForChanges(Duration.ofMillis(300), changed -> validateFromCli().paths);
+    }
+
+    return response.result.ok();
+  }
+
+  public record TestSummary(Result result, Set<Path> paths) {}
+
+  public TestSummary validateFromCli() {
+    Set<Path> pathsToWatch = ConcurrentHashMap.newKeySet();
+    output.println();
+    output.println("Validating...");
+    output.println();
+    BaseSchemaValidator.Result result;
+    result = validate(pathsToWatch);
+    int failed = 0;
+    if (result != null) {
+
+      int passed = 0;
+      List<ExampleResult> failures = new ArrayList<>();
+      for (var example : result.results) {
+        if (example.ok()) {
+          passed++;
+          output.printf("%s %s%n", PASS_BADGE, example.example().name());
+        } else {
+          failed++;
+          printFailure(example, output);
+          failures.add(example);
+        }
+      }
+      if (!failures.isEmpty()) {
+        output.println();
+        output.println("Summary of failures:");
+        for (var failure : failures) {
+          printFailure(failure, output);
+        }
+      }
+      List<String> summary = new ArrayList<>();
+      boolean none = (passed + failed) == 0;
+      if (none || failed > 0) {
+        summary.add(AnsiColors.redBold(failed + " failed"));
+      }
+      if (none || passed > 0) {
+        summary.add(AnsiColors.greenBold(passed + " passed"));
+      }
+      if (none || passed > 0 && failed > 0) {
+        summary.add((failed + passed) + " total");
+      }
+      output.println();
+      output.println(String.join(", ", summary));
+    }
+    return new TestSummary(result, pathsToWatch);
+  }
+
+  protected abstract Result validate(Set<Path> pathsToWatch);
+
+  private static void printFailure(ExampleResult example, PrintStream output) {
+    if (example.example() != null) {
+      output.printf("%s %s%n", FAIL_BADGE, example.example().name());
+    }
+    if (example.issues.isFailure()) {
+      output.println(ExceptionUtils.getStackTrace(example.issues.exception()).indent(4).stripTrailing());
+    } else {
+      for (var issue : example.issues().get()) {
+        output.println("  ● " + issue.indent(4).strip());
+      }
+    }
+  }
+
+  private static Geometry parseGeometry(String geometry) {
+    String wkt = switch (geometry.toLowerCase(Locale.ROOT).trim()) {
+      case "point" -> "POINT (0 0)";
+      case "line" -> "LINESTRING (0 0, 1 1)";
+      case "polygon" -> "POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))";
+      default -> geometry;
+    };
+    try {
+      return new WKTReader().read(wkt);
+    } catch (ParseException e) {
+      throw new IllegalArgumentException("""
+        Bad geometry: "%s", must be "point" "line" "polygon" or a valid WKT string.
+        """.formatted(geometry));
+    }
+  }
+
+  private record FeatureWithOverrides(FeatureCollector.Feature feature, FeatureCollector.RangeWithTags overrides) {}
+
+  /** Returns the result of validating {@code profile} against the examples in {@code specification}. */
+  public static Result validate(Profile profile, SchemaSpecification specification, PlanetilerConfig config) {
+    var featureCollectorFactory = new FeatureCollector.Factory(config, Stats.inMemory());
+    return new Result(specification.examples().stream().map(example -> new ExampleResult(example, Try.apply(() -> {
+      List<String> issues = new ArrayList<>();
+      var input = example.input();
+      var expectedFeatures = example.output();
+      var geometry = parseGeometry(input.geometry());
+      var feature = SimpleFeature.create(geometry, input.tags(), input.source(), null, 0);
+      var collector = featureCollectorFactory.get(feature);
+      profile.processFeature(feature, collector);
+      List<FeatureWithOverrides> result = new ArrayList<>();
+      Set<Integer> zooms = expectedFeatures.stream().map(f -> f.atZoom()).collect(Collectors.toSet());
+      for (var outputFeature : collector) {
+        if (outputFeature.hasLinearRanges()) {
+          for (var zoom : zooms) {
+            for (var range : outputFeature.getLinearRangesAtZoom(zoom)) {
+              result.add(new FeatureWithOverrides(outputFeature, range));
+            }
+          }
+        } else {
+          result.add(new FeatureWithOverrides(outputFeature, null));
+        }
+      }
+      if (result.size() != expectedFeatures.size()) {
+        issues.add(
+          "Different number of elements, expected=%s actual=%s".formatted(expectedFeatures.size(), result.size()));
+      } else {
+        // TODO print a diff of the input and output feature YAML representations
+        for (int i = 0; i < expectedFeatures.size(); i++) {
+          var expected = expectedFeatures.get(i);
+          var actual = result.stream().max(proximityTo(expected)).orElseThrow();
+          result.remove(actual);
+          var actualTags =
+            actual.overrides != null ? actual.overrides.attrs() : actual.feature.getAttrsAtZoom(expected.atZoom());
+          String prefix = "feature[%d]".formatted(i);
+          validate(prefix + ".layer", issues, expected.layer(), actual.feature.getLayer());
+          validate(prefix + ".minzoom", issues, expected.minZoom(), actual.feature.getMinZoom());
+          validate(prefix + ".maxzoom", issues, expected.maxZoom(), actual.feature.getMaxZoom());
+          validate(prefix + ".minsize", issues, expected.minSize(),
+            actual.feature.getMinPixelSizeAtZoom(expected.atZoom()));
+          validate(prefix + ".geometry", issues, expected.geometry(),
+            GeometryType.typeOf(actual.feature.getGeometry()));
+          Set<String> tags = new TreeSet<>(actualTags.keySet());
+          expected.tags().forEach((tag, value) -> {
+            validate(prefix + ".tags[\"%s\"]".formatted(tag), issues, value, actualTags.get(tag), false);
+            tags.remove(tag);
+          });
+          if (Boolean.FALSE.equals(expected.allowExtraTags())) {
+            for (var tag : tags) {
+              validate(prefix + ".tags[\"%s\"]".formatted(tag), issues, null, actualTags.get(tag), false);
+            }
+          }
+        }
+      }
+      return issues;
+    }))).toList());
+  }
+
+  private static Comparator<FeatureWithOverrides> proximityTo(SchemaSpecification.OutputFeature expected) {
+    return Comparator.comparingInt(item -> (Objects.equals(item.feature.getLayer(), expected.layer()) ? 2 : 0) +
+      (Objects.equals(GeometryType.typeOf(item.feature.getGeometry()), expected.geometry()) ? 1 : 0) +
+      mapProximity(expected, item, expected.allowExtraTags()));
+  }
+
+  private static int mapProximity(SchemaSpecification.OutputFeature expected, FeatureWithOverrides actualFeature,
+    Boolean allowExtra) {
+    int zoom = expected.atZoom();
+    var expectedMap = expected.tags();
+    var actualMap =
+      actualFeature.overrides != null ? actualFeature.overrides.attrs() : actualFeature.feature.getAttrsAtZoom(zoom);
+    int result = 0;
+    for (var entry : expectedMap.entrySet()) {
+      if (actualMap.containsKey(entry.getKey())) {
+        result++;
+        if (actualMap.get(entry.getKey()).equals(entry.getValue())) {
+          result++;
+        }
+      }
+    }
+
+    return result;
+  }
+
+  private static <T> void validate(String field, List<String> issues, T expected, T actual, boolean ignoreWhenNull) {
+    if ((!ignoreWhenNull || expected != null) && !Objects.equals(expected, actual)) {
+      // handle when expected and actual are int/long or long/int
+      if (expected instanceof Number && actual instanceof Number && expected.toString().equals(actual.toString())) {
+        return;
+      }
+      issues.add("%s: expected <%s> actual <%s>".formatted(field, format(expected), format(actual)));
+    }
+  }
+
+  private static String format(Object o) {
+    if (o == null) {
+      return "null";
+    } else if (o instanceof String s) {
+      return Format.quote(s);
+    } else {
+      return o.toString();
+    }
+  }
+
+  private static <T> void validate(String field, List<String> issues, T expected, T actual) {
+    validate(field, issues, expected, actual, true);
+  }
+
+  /** Result of comparing the output vector tile feature to what was expected. */
+  public record ExampleResult(
+    SchemaSpecification.Example example,
+    // TODO include a symmetric diff so we can pretty-print the expected/actual output diff
+    Try<List<String>> issues
+  ) {
+
+    public boolean ok() {
+      return issues.isSuccess() && issues.get().isEmpty();
+    }
+  }
+
+  public record Result(List<ExampleResult> results) {
+
+    public boolean ok() {
+      return results.stream().allMatch(ExampleResult::ok);
+    }
+  }
+}

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/validator/JavaProfileValidator.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/validator/JavaProfileValidator.java
@@ -1,0 +1,59 @@
+package com.onthegomap.planetiler.validator;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.onthegomap.planetiler.Profile;
+import com.onthegomap.planetiler.config.PlanetilerConfig;
+import com.onthegomap.planetiler.util.AnsiColors;
+import java.io.PrintStream;
+import java.nio.file.Path;
+import java.util.Set;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.snakeyaml.engine.v2.exceptions.YamlEngineException;
+
+/**
+ * Validates a java profile against a yaml set of example source features and the vector tile features they should map
+ * to.
+ */
+public class JavaProfileValidator extends BaseSchemaValidator {
+
+  private final Profile profile;
+  private final Path specPath;
+  private final PlanetilerConfig config;
+
+  JavaProfileValidator(PlanetilerConfig config, Path specPath, Profile profile, PrintStream output) {
+    super(config.arguments(), output);
+    this.config = config;
+    this.profile = profile;
+    this.specPath = specPath;
+  }
+
+  /**
+   * Validates that {@code profile} maps input features to expected output features as defined in {@code specPath} and
+   * returns true if successful, false if failed.
+   */
+  public static boolean validate(Profile profile, Path specPath, PlanetilerConfig config) {
+    return new JavaProfileValidator(config, specPath, profile, System.out).runOrWatch();
+  }
+
+  @Override
+  protected Result validate(Set<Path> pathsToWatch) {
+    Result result = null;
+    try {
+      SchemaSpecification spec;
+      pathsToWatch.add(specPath);
+      spec = SchemaSpecification.load(specPath);
+      result = validate(profile, spec, config);
+    } catch (Exception exception) {
+      Throwable rootCause = ExceptionUtils.getRootCause(exception);
+      if (hasCause(exception, YamlEngineException.class) || hasCause(exception, JacksonException.class)) {
+        output.println(AnsiColors.red("Malformed yaml input:\n\n" + rootCause.toString().indent(4)));
+      } else {
+        output.println(AnsiColors.red(
+          "Unexpected exception thrown:\n" + rootCause.toString().indent(4) + "\n" +
+            String.join("\n", ExceptionUtils.getStackTrace(rootCause)))
+          .indent(4));
+      }
+    }
+    return result;
+  }
+}

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/validator/SchemaSpecification.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/validator/SchemaSpecification.java
@@ -1,17 +1,21 @@
-package com.onthegomap.planetiler.custommap.validator;
+package com.onthegomap.planetiler.validator;
 
 import static com.onthegomap.planetiler.config.PlanetilerConfig.MAX_MAXZOOM;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.onthegomap.planetiler.custommap.YAML;
 import com.onthegomap.planetiler.geo.GeometryType;
+import com.onthegomap.planetiler.util.YAML;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
-/** A model of example input source features and expected output vector tile features that a schema should produce. */
+/**
+ * A model of example input source features and expected output vector tile features that a schema should produce.
+ * <p>
+ * Executed by a subclass of {@link BaseSchemaValidator}.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record SchemaSpecification(List<Example> examples) {
 

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/FeatureCollectorTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/FeatureCollectorTest.java
@@ -783,4 +783,14 @@ class FeatureCollectorTest {
       "d", true
     ), subFeature.attrs());
   }
+
+  @Test
+  void testSetAttrPartialWithMinSize() {
+    var collector = factory.get(newReaderFeature(newLineString(0, 0, 1, 1), Map.of()));
+    var line = collector.line("layername");
+
+    assertEquals(7, line.getMinZoomForPixelSize(100));
+    assertEquals(7, line.linearRange(0, 0.5).getMinZoomForPixelSize(50));
+    assertEquals(7, line.linearRange(0, 0.25).getMinZoomForPixelSize(25));
+  }
 }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/FeatureCollectorTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/FeatureCollectorTest.java
@@ -785,6 +785,65 @@ class FeatureCollectorTest {
   }
 
   @Test
+  void testSetAttrPartialWithMinzoom() {
+    var collector = factory.get(newReaderFeature(newLineString(0, 0, 1, 1), Map.of()));
+    collector.line("layername")
+      .setAttrWithMinzoom("full", 1, 2)
+      .setAttrWithMinzoom("fullstruct", Struct.of(2), 2)
+      .linearRange(0, 0.5)
+      .setAttr("a", Struct.of(1))
+      .setAttrWithMinzoom("b", Struct.of(2d), 9)
+      .putAttrs(Map.of("c", Struct.of("3"), "d", ZoomFunction.minZoom(9, Struct.of(true))));
+    var feature = collector.iterator().next();
+    var subFeature = feature.getLinearRangesAtZoom(14).getFirst();
+    assertEquals(Map.of(
+      "a", 1,
+      "b", 2d,
+      "c", "3",
+      "d", true,
+      "full", 1,
+      "fullstruct", 2
+    ), subFeature.attrs());
+  }
+
+  @Test
+  void testUnwrapStruct() {
+    var collector = factory.get(newReaderFeature(newLineString(0, 0, 1, 1), Map.of()));
+    collector.line("layername")
+      .setAttr("full", Struct.of(1))
+      .linearRange(0, 0.5)
+      .setAttr("partial", Struct.of(2));
+    var feature = collector.iterator().next();
+    var subFeature = feature.getLinearRangesAtZoom(14).getFirst();
+    assertEquals(Map.of(
+      "full", 1,
+      "partial", 2
+    ), subFeature.attrs());
+  }
+
+  @Test
+  void testUnwrapStructFull() {
+    var collector = factory.get(newReaderFeature(newLineString(0, 0, 1, 1), Map.of()));
+    collector.line("layername")
+      .setAttr("full", Struct.of(1));
+    var feature = collector.iterator().next();
+    assertEquals(Map.of(
+      "full", 1
+    ), feature.getAttrsAtZoom(14));
+  }
+
+  @Test
+  void testUnwrapStructFullWithMinzoom() {
+    var collector = factory.get(newReaderFeature(newLineString(0, 0, 1, 1), Map.of()));
+    collector.line("layername")
+      .setAttrWithMinzoom("full", Struct.of(1), 2);
+    var feature = collector.iterator().next();
+    assertEquals(Map.of(
+      "full", 1
+    ), feature.getAttrsAtZoom(14));
+  }
+
+  @Test
   void testSetAttrPartialWithMinSize() {
     var collector = factory.get(newReaderFeature(newLineString(0, 0, 1, 1), Map.of()));
     var line = collector.line("layername");

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
@@ -205,17 +205,6 @@ class PlanetilerTests {
     );
   }
 
-  private PlanetilerResults runWithOsmElements(
-    Map<String, String> args,
-    List<OsmElement> features,
-    BiConsumer<SourceFeature, FeatureCollector> profileFunction
-  ) throws Exception {
-    return run(
-      args,
-      (featureGroup, profile, config) -> processOsmFeatures(featureGroup, profile, config, features),
-      TestProfile.processSourceFeatures(profileFunction)
-    );
-  }
 
   private PlanetilerResults runWithOsmElements(
     Map<String, String> args,
@@ -300,8 +289,9 @@ class PlanetilerTests {
     ), results.metadata);
   }
 
-  @Test
-  void testSinglePoint() throws Exception {
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void testSinglePoint(boolean anyGeom) throws Exception {
     double x = 0.5 + Z14_WIDTH / 4;
     double y = 0.5 + Z14_WIDTH / 4;
     double lat = GeoUtils.getWorldLat(y);
@@ -314,7 +304,7 @@ class PlanetilerTests {
           "attr", "value"
         ))
       ),
-      (in, features) -> features.point("layer")
+      (in, features) -> (anyGeom ? features.anyGeometry("layer") : features.point("layer"))
         .setZoomRange(13, 15)
         .setAttr("name", "name value")
         .inheritAttrFromSource("attr")
@@ -438,8 +428,9 @@ class PlanetilerTests {
     ), results.tiles);
   }
 
-  @Test
-  void testLineString() throws Exception {
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void testLineString(boolean anyGeom) throws Exception {
     double x1 = 0.5 + Z14_WIDTH / 2;
     double y1 = 0.5 + Z14_WIDTH / 2;
     double x2 = x1 + Z14_WIDTH;
@@ -456,7 +447,7 @@ class PlanetilerTests {
           "attr", "value"
         ))
       ),
-      (in, features) -> features.line("layer")
+      (in, features) -> (anyGeom ? features.anyGeometry("layer") : features.line("layer"))
         .setZoomRange(13, 14)
         .setBufferPixels(4)
     );
@@ -690,8 +681,9 @@ class PlanetilerTests {
     );
   }
 
-  @Test
-  void testPolygonWithHoleSpanningMultipleTiles() throws Exception {
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void testPolygonWithHoleSpanningMultipleTiles(boolean anyGeom) throws Exception {
     List<Coordinate> outerPoints = z14CoordinateList(
       0.5, 0.5,
       3.5, 0.5,
@@ -715,7 +707,7 @@ class PlanetilerTests {
           List.of(innerPoints)
         ), Map.of())
       ),
-      (in, features) -> features.polygon("layer")
+      (in, features) -> (anyGeom ? features.anyGeometry("layer") : features.polygon("layer"))
         .setZoomRange(12, 14)
         .setBufferPixels(4)
     );

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/config/ArgumentsTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/config/ArgumentsTest.java
@@ -39,6 +39,20 @@ class ArgumentsTest {
   }
 
   @Test
+  void testWithFallback() {
+    Arguments args = Arguments.of("key1", "value1a", "key2", "value2a")
+      .withDefault("key2", "value2b")
+      .withDefault("--key3", "value3b")
+      .withDefault("key_5", true);
+
+    assertEquals("value1a", args.getString("key1", "key", "fallback"));
+    assertEquals("value2a", args.getString("key2", "key", "fallback"));
+    assertEquals("value3b", args.getString("key3", "key", "fallback"));
+    assertEquals("fallback", args.getString("key4", "key", "fallback"));
+    assertTrue(args.getBoolean("key-5", "key", false));
+  }
+
+  @Test
   void testConfigFileParsing() {
     Arguments args = Arguments.fromConfigFile(TestUtils.pathToResource("test.properties"));
 

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/expression/ExpressionTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/expression/ExpressionTest.java
@@ -341,6 +341,7 @@ class ExpressionTest {
   void testPartialEvaluateMatchAny() {
     var expr = matchAny("field", "value1", "other%");
     assertEquals(expr, expr.partialEvaluate(new PartialInput(Set.of(), Set.of(), Map.of("other", "value"), Set.of())));
+    assertEquals(expr, expr.partialEvaluate(new PartialInput(Set.of(), Set.of(), null, Set.of())));
     assertEquals(TRUE, expr.partialEvaluate(new PartialInput(Set.of(), Set.of(), Map.of("field", "value1"), Set.of())));
     assertEquals(TRUE, expr.partialEvaluate(new PartialInput(Set.of(), Set.of(), Map.of("field", "other"), Set.of())));
     assertEquals(TRUE,

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/expression/MultiExpressionTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/expression/MultiExpressionTest.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.onthegomap.planetiler.expression.MultiExpression.Index;
+import com.onthegomap.planetiler.geo.GeometryType;
 import com.onthegomap.planetiler.reader.SimpleFeature;
 import com.onthegomap.planetiler.reader.SourceFeature;
 import com.onthegomap.planetiler.reader.WithTags;
@@ -625,28 +626,10 @@ class MultiExpressionTest {
 
   @Test
   void testCustomExpression() {
-    Expression dontEvaluate = new Expression() {
-      @Override
-      public boolean evaluate(WithTags input, List<String> matchKeys) {
-        throw new AssertionError("should not evaluate");
-      }
-
-      @Override
-      public String generateJavaCode() {
-        return null;
-      }
+    Expression dontEvaluate = (input, matchKeys) -> {
+      throw new AssertionError("should not evaluate");
     };
-    Expression matchAbc = new Expression() {
-      @Override
-      public boolean evaluate(WithTags input, List<String> matchKeys) {
-        return input.hasTag("abc");
-      }
-
-      @Override
-      public String generateJavaCode() {
-        return null;
-      }
-    };
+    Expression matchAbc = (input, matchKeys) -> input.hasTag("abc");
     var index = MultiExpression.of(List.of(
       entry("a", matchAbc),
       entry("b", and(matchField("def"), dontEvaluate)),
@@ -693,6 +676,76 @@ class MultiExpressionTest {
     assertFalse(expr.evaluate(featureWithTags("otherkey", "otherval"), list));
     assertFalse(expr.evaluate(featureWithTags("key", "otherval"), list));
     assertFalse(expr.evaluate(featureWithTags(), list));
+  }
+
+
+  @Test
+  void testSourceFilter() {
+    var index = MultiExpression.of(List.of(
+      entry("a", matchSource("a")),
+      entry("b", and(matchSource("b"), matchField("field"))),
+      entry("c", or(matchField("abc"), matchSourceLayer("c")))
+    )).index();
+
+    assertSameElements(List.of(), index.getMatches(point("source", "layer", Map.of())));
+    assertSameElements(List.of("a"), index.getMatches(point("a", "layer", Map.of())));
+    assertSameElements(List.of(), index.getMatches(point("b", "layer", Map.of())));
+    assertSameElements(List.of("b"), index.getMatches(point("b", "layer", Map.of("field", "value"))));
+    assertSameElements(List.of("c"), index.getMatches(point("source", "layer", Map.of("abc", "value"))));
+    assertSameElements(List.of("c"), index.getMatches(point("source", "c", Map.of("abc", "value"))));
+    assertSameElements(List.of("c"), index.getMatches(point("source", "c", Map.of())));
+  }
+
+  @Test
+  void testSourceAndGeomFilter() {
+    var index = MultiExpression.of(List.of(
+      entry("a", and(matchGeometryType(GeometryType.POINT), matchSource("a"))),
+      entry("b", and(matchGeometryType(GeometryType.POLYGON), and(matchSource("b"), matchField("field")))),
+      entry("c", and(matchGeometryType(GeometryType.POLYGON), or(matchField("abc"), matchSourceLayer("c")))),
+      entry("d", and(matchField("field2")))
+    )).index();
+
+    assertSameElements(List.of(), index.getMatches(point("source", "layer", Map.of())));
+    assertSameElements(List.of("a"), index.getMatches(point("a", "layer", Map.of())));
+    assertSameElements(List.of(), index.getMatches(point("b", "layer", Map.of())));
+    assertSameElements(List.of(), index.getMatches(point("b", "layer", Map.of("field", "value"))));
+    assertSameElements(List.of(), index.getMatches(point("source", "layer", Map.of("abc", "value"))));
+    assertSameElements(List.of(), index.getMatches(point("source", "c", Map.of("abc", "value"))));
+    assertSameElements(List.of(), index.getMatches(point("source", "c", Map.of())));
+    assertSameElements(List.of("d"), index.getMatches(point("source", "layer", Map.of("field2", "value"))));
+  }
+
+  private static SourceFeature point(String source, String layer, Map<String, Object> tags) {
+    return SimpleFeature.create(newPoint(0, 0), tags, source, layer, 1);
+  }
+
+
+  @Test
+  void testNestedMatching() {
+    var index = MultiExpression.of(List.of(
+      entry("a", matchField("a.b")),
+      entry("b", matchAny("a.b", "c", "d")),
+      entry("c", matchAny("a", "e")),
+      entry("d", matchAny("a[].b", "c"))
+    )).index();
+
+    assertSameElements(List.of(), index.getMatches(WithTags.from(Map.of("k", "v"))));
+    assertSameElements(List.of("c"), index.getMatches(WithTags.from(Map.of("a", "e"))));
+    assertSameElements(List.of("c"), index.getMatches(WithTags.from(Map.of("a", List.of("e")))));
+    assertSameElements(List.of("c"), index.getMatches(WithTags.from(Map.of("a", List.of("e", "f")))));
+    assertSameElements(List.of(), index.getMatches(WithTags.from(Map.of("a", List.of("g", "f")))));
+
+
+    assertSameElements(List.of("a"), index.getMatches(WithTags.from(Map.of("a.b", "e"))));
+    assertSameElements(List.of("a", "b"), index.getMatches(WithTags.from(Map.of("a.b", "c"))));
+    assertSameElements(List.of(), index.getMatches(WithTags.from(Map.of("a", Map.of("b", List.of())))));
+    assertSameElements(List.of("a", "b", "d"), index.getMatches(WithTags.from(Map.of("a", Map.of("b", List.of("c"))))));
+    assertSameElements(List.of("a", "b"), index.getMatches(WithTags.from(Map.of("a", Map.of("b", List.of("d"))))));
+    assertSameElements(List.of("a"), index.getMatches(WithTags.from(Map.of("a", Map.of("b", List.of("e"))))));
+    assertSameElements(List.of("a"), index.getMatches(WithTags.from(Map.of("a", Map.of("b", Map.of("c", "e"))))));
+
+    assertSameElements(List.of("a", "b", "c", "d"),
+      index.getMatches(WithTags.from(Map.of("a", List.of("e", Map.of("b", List.of("c")))))));
   }
 
   private static <T> void assertSameElements(List<T> a, List<T> b) {

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/reader/StructTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/reader/StructTest.java
@@ -80,6 +80,15 @@ class StructTest {
   }
 
   @Test
+  void testListQueryOnList() {
+    var struct = Struct.of(List.of(Map.of("b", "c"), Map.of("b", "d")));
+    assertEquals("d", struct.flatMap(elem -> elem.get("b")).get(1).asString());
+    assertEquals(Struct.of(List.of("c", "d")), struct.get("[].b"));
+    assertEquals(Struct.of(List.of("c", "d")), struct.get("b"));
+    assertEquals(Struct.NULL, struct.get("e"));
+  }
+
+  @Test
   void testListGet() {
     var struct = Struct.of(List.of(1, 2, 3));
     assertEquals(1, struct.get(0).asInt());
@@ -340,12 +349,30 @@ class StructTest {
     ));
     assertEquals("""
       {"a":{"b":"c"}}
-      """.strip(), struct.asJson());
+      """.strip(), struct.tagsAsJson());
     assertEquals("""
       {"b":"c"}
       """.strip(), struct.getStruct("a").asJson());
     assertEquals("""
       "c"
       """.strip(), struct.getStruct("a").get("b").asJson());
+  }
+
+  @Test
+  void testRawValueList() {
+    var struct = Struct.of(List.of(1, 2, 3));
+    assertEquals(List.of(1, 2, 3), struct.rawValue());
+  }
+
+  @Test
+  void testRawValueListFlatmap() {
+    assertEquals(List.of(1, 3), Struct.of(List.of(1, List.of(3))).flatMap(d -> d).rawValue());
+    assertEquals(List.of(3), Struct.of(List.of(1, List.of(3))).flatMap(d -> d.get(0)).rawValue());
+  }
+
+  @Test
+  void testRawValueMap() {
+    var struct = Struct.of(Map.of(1, 2));
+    assertEquals(Map.of(1, 2), struct.rawValue());
   }
 }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/reader/parquet/ParquetFeatureTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/reader/parquet/ParquetFeatureTest.java
@@ -1,0 +1,46 @@
+package com.onthegomap.planetiler.reader.parquet;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.parquet.hadoop.metadata.FileMetaData;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Types;
+import org.junit.jupiter.api.Test;
+
+class ParquetFeatureTest {
+  private static ParquetFeature feature(Map<String, Object> tags) throws IOException {
+    var schema = Types.buildMessage().addField(Types.required(PrimitiveType.PrimitiveTypeName.BINARY).named("geometry"))
+      .named("root");
+    return new ParquetFeature("overture", "layer", 1,
+      new GeometryReader(GeoParquetMetadata.parse(new FileMetaData(schema, Map.of(), "geometry"))),
+      new HashMap<>(tags),
+      Path.of(""), schema);
+  }
+
+  @Test
+  void testHasTag() throws IOException {
+    var feature = feature(Map.of("names", Map.of("primary", "name")));
+    assertTrue(feature.hasTag("names.primary"));
+    assertTrue(feature.hasTag("names[].primary"));
+    assertTrue(feature.hasTag("names.primary", "name"));
+    assertTrue(feature.hasTag("names[].primary", "name"));
+    assertTrue(feature.hasTag("names[].primary", List.of("name", "name2")));
+    assertFalse(feature.hasTag("names.primary", "not name"));
+    assertFalse(feature.hasTag("names.primary", List.of("not name", "not name 2")));
+  }
+
+  @Test
+  void testHasTagWithArg() throws IOException {
+    var feature = feature(Map.of("names", Map.of("primary", "name")));
+    assertTrue(feature.hasTag("names.primary", "name1", "name"));
+    assertTrue(feature.hasTag("names.primary", "name", "name1"));
+    assertTrue(feature.hasTag("names.primary", List.of("name"), "name1"));
+    assertTrue(feature.hasTag("names.primary", "name1", List.of("name")));
+  }
+}

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/validator/BaseSchemaValidatorTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/validator/BaseSchemaValidatorTest.java
@@ -1,0 +1,235 @@
+package com.onthegomap.planetiler.validator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.onthegomap.planetiler.FeatureCollector;
+import com.onthegomap.planetiler.Profile;
+import com.onthegomap.planetiler.TestUtils;
+import com.onthegomap.planetiler.config.Arguments;
+import com.onthegomap.planetiler.config.PlanetilerConfig;
+import com.onthegomap.planetiler.reader.SourceFeature;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DynamicNode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class BaseSchemaValidatorTest {
+
+  private final String goodSpecString = """
+    examples:
+    - name: test output
+      input:
+        source: osm
+        geometry: polygon
+        tags:
+          natural: water
+      output:
+      - layer: water
+        geometry: polygon
+        tags:
+          natural: water
+    """;
+  private final SchemaSpecification goodSpec = SchemaSpecification.load(goodSpecString);
+
+  private final Profile waterSchema = new Profile() {
+    @Override
+    public void processFeature(SourceFeature sourceFeature, FeatureCollector features) {
+      if (sourceFeature.canBePolygon() && sourceFeature.hasTag("natural", "water")) {
+        features.polygon("water")
+          .setMinPixelSize(10)
+          .inheritAttrFromSource("natural");
+      }
+    }
+
+    @Override
+    public String name() {
+      return "test profile";
+    }
+  };
+
+  private Result validate(Profile profile, String spec) {
+    var result = BaseSchemaValidator.validate(
+      profile,
+      SchemaSpecification.load(spec),
+      PlanetilerConfig.defaults()
+    );
+    for (var example : result.results()) {
+      if (example.issues().isFailure()) {
+        assertNotNull(example.issues().get());
+      }
+    }
+    // also exercise the cli writer and return what it would have printed to stdout
+    var cliOutput = validateCli(profile, SchemaSpecification.load(spec));
+    return new Result(result, cliOutput);
+  }
+
+  private String validateCli(Profile profile, SchemaSpecification spec) {
+    try (
+      var baos = new ByteArrayOutputStream();
+      var printStream = new PrintStream(baos, true, StandardCharsets.UTF_8)
+    ) {
+      new BaseSchemaValidator(Arguments.of(), printStream) {
+        @Override
+        protected Result validate(Set<Path> pathsToWatch) {
+          return validate(profile, spec, PlanetilerConfig.defaults());
+        }
+      }.validateFromCli();
+      return baos.toString(StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  private Result validateWater(String layer, String geometry, String tags, String allowExtraTags) throws IOException {
+    return validate(
+      waterSchema,
+      """
+        examples:
+        - name: test output
+          input:
+            source: osm
+            geometry: polygon
+            tags:
+              natural: water
+          output:
+            layer: %s
+            geometry: %s
+            %s
+            tags:
+              %s
+        """.formatted(layer, geometry, allowExtraTags == null ? "" : allowExtraTags,
+        tags == null ? "" : tags.indent(6).strip())
+    );
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "true,water,polygon,natural: water,",
+    "true,water,polygon,,",
+    "true,water,polygon,'natural: water\nother: null',",
+    "false,water,polygon,natural: null,",
+    "false,water2,polygon,natural: water,",
+    "false,water,line,natural: water,",
+    "false,water,line,natural: water,",
+    "false,water,polygon,natural: water2,",
+    "false,water,polygon,'natural: water\nother: value',",
+
+    "true,water,polygon,natural: water,allow_extra_tags: true",
+    "true,water,polygon,natural: water,allow_extra_tags: false",
+    "true,water,polygon,,allow_extra_tags: true",
+    "false,water,polygon,,allow_extra_tags: false",
+
+    "true,water,polygon,,min_size: 10",
+    "false,water,polygon,,min_size: 9",
+  })
+  void testValidateWaterPolygon(boolean shouldBeOk, String layer, String geometry, String tags, String allowExtraTags)
+    throws IOException {
+    var results = validateWater(layer, geometry, tags, allowExtraTags);
+    assertEquals(1, results.output.results().size());
+    assertEquals("test output", results.output.results().get(0).example().name());
+    if (shouldBeOk) {
+      assertTrue(results.output.ok(), results.toString());
+      assertFalse(results.cliOutput.contains("FAIL"), "contained FAIL but should not have: " + results.cliOutput);
+    } else {
+      assertFalse(results.output.ok(), "Expected an issue, but there were none");
+      assertTrue(results.cliOutput.contains("FAIL"), "did not contain FAIL but should have: " + results.cliOutput);
+    }
+  }
+
+  @Test
+  void testPartialLengthAttribute() {
+    var results = validate(
+      (sourceFeature, features) -> features.line("layer")
+        .linearRange(0, 0.6).setAttr("a", 1)
+        .linearRange(0.4, 1).setAttr("b", 2),
+      """
+        examples:
+        - name: test output
+          input:
+            source: osm
+            geometry: line
+            tags:
+              natural: water
+          output:
+          - layer: layer
+            geometry: line
+            tags: {a:1}
+          - layer: layer
+            geometry: line
+            tags: {a:1,b:2}
+          - layer: layer
+            geometry: line
+            tags: {b:2}
+        """
+    );
+    assertEquals(1, results.output.results().size());
+    assertEquals("test output", results.output.results().getFirst().example().name());
+    assertTrue(results.output.results().getFirst().ok());
+  }
+
+  @Test
+  void testValidationFailsWrongNumberOfFeatures() {
+    var results = validate(
+      waterSchema,
+      """
+        examples:
+        - name: test output
+          input:
+            source: osm
+            geometry: polygon
+            tags:
+              natural: water
+          output:
+        """
+    );
+    assertFalse(results.output.ok(), results.toString());
+
+    results = validate(
+      waterSchema,
+      """
+        examples:
+        - name: test output
+          input:
+            source: osm
+            geometry: polygon
+            tags:
+              natural: water
+          output:
+          - layer: water
+            geometry: polygon
+            tags:
+              natural: water
+          - layer: water2
+            geometry: polygon
+            tags:
+              natural: water2
+        """
+    );
+    assertFalse(results.output.ok(), results.toString());
+  }
+
+  @TestFactory
+  Stream<DynamicNode> testJunitAdapterSpec() {
+    return TestUtils.validateProfile(waterSchema, goodSpec);
+  }
+
+  @TestFactory
+  Stream<DynamicNode> testJunitAdapterString() {
+    return TestUtils.validateProfile(waterSchema, goodSpecString);
+  }
+
+
+  record Result(BaseSchemaValidator.Result output, String cliOutput) {}
+}

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/validator/JavaProfileValidatorTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/validator/JavaProfileValidatorTest.java
@@ -1,0 +1,98 @@
+package com.onthegomap.planetiler.validator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.onthegomap.planetiler.Profile;
+import com.onthegomap.planetiler.config.Arguments;
+import com.onthegomap.planetiler.config.PlanetilerConfig;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class JavaProfileValidatorTest {
+  private final Arguments args = Arguments.of();
+  @TempDir
+  Path tmpDir;
+
+  record Result(BaseSchemaValidator.Result output, String cliOutput) {}
+
+  private Result validate(Profile profile, String spec) throws IOException {
+    var specPath = Files.writeString(tmpDir.resolve("spec.yaml"), spec);
+    try (
+      var baos = new ByteArrayOutputStream();
+      var printStream = new PrintStream(baos, true, StandardCharsets.UTF_8)
+    ) {
+      var validator = new JavaProfileValidator(PlanetilerConfig.from(args), specPath, profile, printStream);
+      var summary = validator.validateFromCli();
+      assertEquals(Set.of(specPath), summary.paths());
+      return new Result(summary.result(), baos.toString(StandardCharsets.UTF_8));
+    }
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "true,water,polygon,natural: water,",
+    "true,water,polygon,,",
+    "true,water,polygon,'natural: water\nother: null',",
+    "false,water,polygon,natural: null,",
+    "false,water2,polygon,natural: water,",
+    "false,water,line,natural: water,",
+    "false,water,line,natural: water,",
+    "false,water,polygon,natural: water2,",
+    "false,water,polygon,'natural: water\nother: value',",
+
+    "true,water,polygon,natural: water,allow_extra_tags: true",
+    "true,water,polygon,natural: water,allow_extra_tags: false",
+    "true,water,polygon,,allow_extra_tags: true",
+    "false,water,polygon,,allow_extra_tags: false",
+
+    "true,water,polygon,,min_size: 10",
+    "false,water,polygon,,min_size: 9",
+  })
+  void testValidateWaterPolygon(boolean shouldBeOk, String layer, String geometry, String tags, String allowExtraTags)
+    throws IOException {
+    var results = validate(
+      (sourceFeature, features) -> {
+        if (sourceFeature.canBePolygon() && sourceFeature.hasTag("natural", "water")) {
+          features.polygon("water")
+            .inheritAttrFromSource("natural")
+            .setMinPixelSize(10);
+        }
+      },
+      """
+        examples:
+        - name: test output
+          input:
+            source: osm
+            geometry: polygon
+            tags:
+              natural: water
+          output:
+            layer: %s
+            geometry: %s
+            %s
+            tags:
+              %s
+        """.formatted(layer, geometry, allowExtraTags == null ? "" : allowExtraTags,
+        tags == null ? "" : tags.indent(6).strip())
+    );
+    assertEquals(1, results.output.results().size());
+    assertEquals("test output", results.output.results().getFirst().example().name());
+    if (shouldBeOk) {
+      assertTrue(results.output.ok(), results.toString());
+      assertFalse(results.cliOutput.contains("FAIL"), "contained FAIL but should not have: " + results.cliOutput);
+    } else {
+      assertFalse(results.output.ok(), "Expected an issue, but there were none");
+      assertTrue(results.cliOutput.contains("FAIL"), "did not contain FAIL but should have: " + results.cliOutput);
+    }
+  }
+}

--- a/planetiler-custommap/pom.xml
+++ b/planetiler-custommap/pom.xml
@@ -19,10 +19,6 @@
       <version>${project.parent.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.snakeyaml</groupId>
-      <artifactId>snakeyaml-engine</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.commonmark</groupId>
       <artifactId>commonmark</artifactId>
     </dependency>

--- a/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/ConfiguredMapMain.java
+++ b/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/ConfiguredMapMain.java
@@ -5,6 +5,7 @@ import com.onthegomap.planetiler.config.Arguments;
 import com.onthegomap.planetiler.custommap.configschema.DataSourceType;
 import com.onthegomap.planetiler.custommap.configschema.SchemaConfig;
 import com.onthegomap.planetiler.custommap.expression.ParseException;
+import com.onthegomap.planetiler.util.YAML;
 import java.nio.file.Files;
 import java.nio.file.Path;
 

--- a/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/configschema/SchemaConfig.java
+++ b/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/configschema/SchemaConfig.java
@@ -1,7 +1,7 @@
 package com.onthegomap.planetiler.custommap.configschema;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.onthegomap.planetiler.custommap.YAML;
+import com.onthegomap.planetiler.util.YAML;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Map;

--- a/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/validator/SchemaValidator.java
+++ b/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/validator/SchemaValidator.java
@@ -1,44 +1,31 @@
 package com.onthegomap.planetiler.custommap.validator;
 
 import com.fasterxml.jackson.core.JacksonException;
-import com.onthegomap.planetiler.FeatureCollector;
-import com.onthegomap.planetiler.Profile;
 import com.onthegomap.planetiler.config.Arguments;
-import com.onthegomap.planetiler.config.PlanetilerConfig;
 import com.onthegomap.planetiler.custommap.ConfiguredProfile;
 import com.onthegomap.planetiler.custommap.Contexts;
-import com.onthegomap.planetiler.custommap.YAML;
 import com.onthegomap.planetiler.custommap.configschema.SchemaConfig;
-import com.onthegomap.planetiler.geo.GeometryType;
-import com.onthegomap.planetiler.reader.SimpleFeature;
-import com.onthegomap.planetiler.stats.Stats;
 import com.onthegomap.planetiler.util.AnsiColors;
-import com.onthegomap.planetiler.util.FileWatcher;
-import com.onthegomap.planetiler.util.Format;
-import com.onthegomap.planetiler.util.Try;
+import com.onthegomap.planetiler.util.YAML;
+import com.onthegomap.planetiler.validator.BaseSchemaValidator;
+import com.onthegomap.planetiler.validator.SchemaSpecification;
 import java.io.PrintStream;
 import java.nio.file.Path;
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
-import java.util.Objects;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.locationtech.jts.geom.Geometry;
-import org.locationtech.jts.io.ParseException;
-import org.locationtech.jts.io.WKTReader;
 import org.snakeyaml.engine.v2.exceptions.YamlEngineException;
 
-/** Verifies that a profile maps input elements map to expected output vector tile features. */
-public class SchemaValidator {
+public class SchemaValidator extends BaseSchemaValidator {
 
-  private static final String PASS_BADGE = AnsiColors.greenBackground(" PASS ");
-  private static final String FAIL_BADGE = AnsiColors.redBackground(" FAIL ");
+  private final Path schemaPath;
+
+  SchemaValidator(Arguments args, String schemaFile, PrintStream output) {
+    super(args, output);
+    schemaPath = schemaFile == null ? args.inputFile("schema", "Schema file") :
+      args.inputFile("schema", "Schema file", Path.of(schemaFile));
+  }
 
   public static void main(String[] args) {
     // let users run `verify schema.yml` as a shortcut
@@ -48,36 +35,23 @@ public class SchemaValidator {
       args = Stream.of(args).skip(1).toArray(String[]::new);
     }
     var arguments = Arguments.fromEnvOrArgs(args);
-    var schema = schemaFile == null ? arguments.inputFile("schema", "Schema file") :
-      arguments.inputFile("schema", "Schema file", Path.of(schemaFile));
-    var watch =
-      arguments.getBoolean("watch", "Watch files for changes and re-run validation when schema or spec changes", false);
-
-
-    PrintStream output = System.out;
-    output.println("OK");
-    var paths = validateFromCli(schema, output);
-
-    if (watch) {
-      output.println();
-      output.println("Watching filesystem for changes...");
-      var watcher = FileWatcher.newWatcher(paths.toArray(Path[]::new));
-      watcher.pollForChanges(Duration.ofMillis(300), changed -> validateFromCli(schema, output));
-    }
+    new SchemaValidator(arguments, schemaFile, System.out).runOrWatch();
   }
 
-  private static boolean hasCause(Throwable t, Class<?> cause) {
-    return t != null && (cause.isInstance(t) || hasCause(t.getCause(), cause));
+  /**
+   * Returns the result of validating the profile defined by {@code schema} against the examples in
+   * {@code specification}.
+   */
+  public static Result validate(SchemaConfig schema, SchemaSpecification specification) {
+    var context = Contexts.buildRootContext(Arguments.of().silence(), schema.args());
+    return validate(new ConfiguredProfile(schema, context), specification, context.config());
   }
 
-  static Set<Path> validateFromCli(Path schemaPath, PrintStream output) {
-    Set<Path> pathsToWatch = new HashSet<>();
-    pathsToWatch.add(schemaPath);
-    output.println();
-    output.println("Validating...");
-    output.println();
-    SchemaValidator.Result result;
+  @Override
+  protected Result validate(Set<Path> pathsToWatch) {
+    Result result = null;
     try {
+      pathsToWatch.add(schemaPath);
       var schema = SchemaConfig.load(schemaPath);
       var examples = schema.examples();
       // examples can either be embedded in the yaml file, or referenced
@@ -108,169 +82,8 @@ public class SchemaValidator {
             String.join("\n", ExceptionUtils.getStackTrace(rootCause)))
           .indent(4));
       }
-      return pathsToWatch;
     }
-    int failed = 0, passed = 0;
-    List<ExampleResult> failures = new ArrayList<>();
-    for (var example : result.results) {
-      if (example.ok()) {
-        passed++;
-        output.printf("%s %s%n", PASS_BADGE, example.example().name());
-      } else {
-        failed++;
-        printFailure(example, output);
-        failures.add(example);
-      }
-    }
-    if (!failures.isEmpty()) {
-      output.println();
-      output.println("Summary of failures:");
-      for (var failure : failures) {
-        printFailure(failure, output);
-      }
-    }
-    List<String> summary = new ArrayList<>();
-    boolean none = (passed + failed) == 0;
-    if (none || failed > 0) {
-      summary.add(AnsiColors.redBold(failed + " failed"));
-    }
-    if (none || passed > 0) {
-      summary.add(AnsiColors.greenBold(passed + " passed"));
-    }
-    if (none || passed > 0 && failed > 0) {
-      summary.add((failed + passed) + " total");
-    }
-    output.println();
-    output.println(String.join(", ", summary));
-    return pathsToWatch;
-  }
-
-  private static void printFailure(ExampleResult example, PrintStream output) {
-    output.printf("%s %s%n", FAIL_BADGE, example.example().name());
-    if (example.issues.isFailure()) {
-      output.println(ExceptionUtils.getStackTrace(example.issues.exception()).indent(4).stripTrailing());
-    } else {
-      for (var issue : example.issues().get()) {
-        output.println("  ● " + issue.indent(4).strip());
-      }
-    }
-  }
-
-  private static Geometry parseGeometry(String geometry) {
-    String wkt = switch (geometry.toLowerCase(Locale.ROOT).trim()) {
-      case "point" -> "POINT (0 0)";
-      case "line" -> "LINESTRING (0 0, 1 1)";
-      case "polygon" -> "POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))";
-      default -> geometry;
-    };
-    try {
-      return new WKTReader().read(wkt);
-    } catch (ParseException e) {
-      throw new IllegalArgumentException("""
-        Bad geometry: "%s", must be "point" "line" "polygon" or a valid WKT string.
-        """.formatted(geometry));
-    }
-  }
-
-  /**
-   * Returns the result of validating the profile defined by {@code schema} against the examples in
-   * {@code specification}.
-   */
-  public static Result validate(SchemaConfig schema, SchemaSpecification specification) {
-    var context = Contexts.buildRootContext(Arguments.of().silence(), schema.args());
-    return validate(new ConfiguredProfile(schema, context), specification, context.config());
-  }
-
-  /** Returns the result of validating {@code profile} against the examples in {@code specification}. */
-  public static Result validate(Profile profile, SchemaSpecification specification, PlanetilerConfig config) {
-    var featureCollectorFactory = new FeatureCollector.Factory(config, Stats.inMemory());
-    return new Result(specification.examples().stream().map(example -> new ExampleResult(example, Try.apply(() -> {
-      List<String> issues = new ArrayList<>();
-      var input = example.input();
-      var expectedFeatures = example.output();
-      var geometry = parseGeometry(input.geometry());
-      var feature = SimpleFeature.create(geometry, input.tags(), input.source(), null, 0);
-      var collector = featureCollectorFactory.get(feature);
-      profile.processFeature(feature, collector);
-      List<FeatureCollector.Feature> result = new ArrayList<>();
-      collector.forEach(result::add);
-      if (result.size() != expectedFeatures.size()) {
-        issues.add(
-          "Different number of elements, expected=%s actual=%s".formatted(expectedFeatures.size(), result.size()));
-      } else {
-        // TODO print a diff of the input and output feature YAML representations
-        for (int i = 0; i < expectedFeatures.size(); i++) {
-          var expected = expectedFeatures.get(i);
-          var actual = result.stream().max(proximityTo(expected)).orElseThrow();
-          result.remove(actual);
-          var actualTags = actual.getAttrsAtZoom(expected.atZoom());
-          String prefix = "feature[%d]".formatted(i);
-          validate(prefix + ".layer", issues, expected.layer(), actual.getLayer());
-          validate(prefix + ".minzoom", issues, expected.minZoom(), actual.getMinZoom());
-          validate(prefix + ".maxzoom", issues, expected.maxZoom(), actual.getMaxZoom());
-          validate(prefix + ".minsize", issues, expected.minSize(), actual.getMinPixelSizeAtZoom(expected.atZoom()));
-          validate(prefix + ".geometry", issues, expected.geometry(), GeometryType.typeOf(actual.getGeometry()));
-          Set<String> tags = new TreeSet<>(actualTags.keySet());
-          expected.tags().forEach((tag, value) -> {
-            validate(prefix + ".tags[\"%s\"]".formatted(tag), issues, value, actualTags.get(tag), false);
-            tags.remove(tag);
-          });
-          if (Boolean.FALSE.equals(expected.allowExtraTags())) {
-            for (var tag : tags) {
-              validate(prefix + ".tags[\"%s\"]".formatted(tag), issues, null, actualTags.get(tag), false);
-            }
-          }
-        }
-      }
-      return issues;
-    }))).toList());
-  }
-
-  private static Comparator<FeatureCollector.Feature> proximityTo(SchemaSpecification.OutputFeature expected) {
-    return Comparator.comparingInt(item -> (Objects.equals(item.getLayer(), expected.layer()) ? 2 : 0) +
-      (Objects.equals(GeometryType.typeOf(item.getGeometry()), expected.geometry()) ? 1 : 0));
-  }
-
-  private static <T> void validate(String field, List<String> issues, T expected, T actual, boolean ignoreWhenNull) {
-    if ((!ignoreWhenNull || expected != null) && !Objects.equals(expected, actual)) {
-      // handle when expected and actual are int/long or long/int
-      if (expected instanceof Number && actual instanceof Number && expected.toString().equals(actual.toString())) {
-        return;
-      }
-      issues.add("%s: expected <%s> actual <%s>".formatted(field, format(expected), format(actual)));
-    }
-  }
-
-  private static String format(Object o) {
-    if (o == null) {
-      return "null";
-    } else if (o instanceof String s) {
-      return Format.quote(s);
-    } else {
-      return o.toString();
-    }
-  }
-
-  private static <T> void validate(String field, List<String> issues, T expected, T actual) {
-    validate(field, issues, expected, actual, true);
-  }
-
-  /** Result of comparing the output vector tile feature to what was expected. */
-  public record ExampleResult(
-    SchemaSpecification.Example example,
-    // TODO include a symmetric diff so we can pretty-print the expected/actual output diff
-    Try<List<String>> issues
-  ) {
-
-    public boolean ok() {
-      return issues.isSuccess() && issues.get().isEmpty();
-    }
-  }
-
-  public record Result(List<ExampleResult> results) {
-
-    public boolean ok() {
-      return results.stream().allMatch(ExampleResult::ok);
-    }
+    return result;
   }
 }
+

--- a/planetiler-custommap/src/test/java/com/onthegomap/planetiler/custommap/BooleanExpressionParserTest.java
+++ b/planetiler-custommap/src/test/java/com/onthegomap/planetiler/custommap/BooleanExpressionParserTest.java
@@ -4,6 +4,7 @@ import static com.onthegomap.planetiler.expression.Expression.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.onthegomap.planetiler.expression.Expression;
+import com.onthegomap.planetiler.util.YAML;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 

--- a/planetiler-custommap/src/test/java/com/onthegomap/planetiler/custommap/ConfigExpressionParserTest.java
+++ b/planetiler-custommap/src/test/java/com/onthegomap/planetiler/custommap/ConfigExpressionParserTest.java
@@ -8,6 +8,7 @@ import com.onthegomap.planetiler.custommap.expression.ConfigExpression;
 import com.onthegomap.planetiler.expression.DataType;
 import com.onthegomap.planetiler.expression.Expression;
 import com.onthegomap.planetiler.expression.MultiExpression;
+import com.onthegomap.planetiler.util.YAML;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;

--- a/planetiler-custommap/src/test/java/com/onthegomap/planetiler/custommap/SchemaTests.java
+++ b/planetiler-custommap/src/test/java/com/onthegomap/planetiler/custommap/SchemaTests.java
@@ -3,8 +3,8 @@ package com.onthegomap.planetiler.custommap;
 import static org.junit.jupiter.api.DynamicTest.dynamicTest;
 
 import com.onthegomap.planetiler.custommap.configschema.SchemaConfig;
-import com.onthegomap.planetiler.custommap.validator.SchemaSpecification;
 import com.onthegomap.planetiler.custommap.validator.SchemaValidator;
+import com.onthegomap.planetiler.validator.SchemaSpecification;
 import java.nio.file.Path;
 import java.util.List;
 import org.junit.jupiter.api.DynamicTest;

--- a/planetiler-custommap/src/test/java/com/onthegomap/planetiler/custommap/validator/SchemaValidatorTest.java
+++ b/planetiler-custommap/src/test/java/com/onthegomap/planetiler/custommap/validator/SchemaValidatorTest.java
@@ -5,7 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.onthegomap.planetiler.config.Arguments;
 import com.onthegomap.planetiler.custommap.configschema.SchemaConfig;
+import com.onthegomap.planetiler.validator.BaseSchemaValidator;
+import com.onthegomap.planetiler.validator.SchemaSpecification;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -22,7 +25,7 @@ class SchemaValidatorTest {
   @TempDir
   Path tmpDir;
 
-  record Result(SchemaValidator.Result output, String cliOutput) {}
+  record Result(BaseSchemaValidator.Result output, String cliOutput) {}
 
   private Result validate(String schema, String spec) throws IOException {
     var result = SchemaValidator.validate(
@@ -57,53 +60,11 @@ class SchemaValidatorTest {
       var baos = new ByteArrayOutputStream();
       var printStream = new PrintStream(baos, true, StandardCharsets.UTF_8)
     ) {
-      SchemaValidator.validateFromCli(
-        path,
-        printStream
-      );
+      new SchemaValidator(Arguments.of(), path.toString(), printStream).validateFromCli();
       return baos.toString(StandardCharsets.UTF_8);
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }
-  }
-
-  String waterSchema = """
-    sources:
-      osm:
-        type: osm
-        url: geofabrik:rhode-island
-    layers:
-    - id: water
-      features:
-      - source: osm
-        geometry: polygon
-        min_size: 10
-        include_when:
-          natural: water
-        attributes:
-        - key: natural
-    """;
-
-  private Result validateWater(String layer, String geometry, String tags, String allowExtraTags) throws IOException {
-    return validate(
-      waterSchema,
-      """
-        examples:
-        - name: test output
-          input:
-            source: osm
-            geometry: polygon
-            tags:
-              natural: water
-          output:
-            layer: %s
-            geometry: %s
-            %s
-            tags:
-              %s
-        """.formatted(layer, geometry, allowExtraTags == null ? "" : allowExtraTags,
-        tags == null ? "" : tags.indent(6).strip())
-    );
   }
 
   @ParameterizedTest
@@ -128,9 +89,42 @@ class SchemaValidatorTest {
   })
   void testValidateWaterPolygon(boolean shouldBeOk, String layer, String geometry, String tags, String allowExtraTags)
     throws IOException {
-    var results = validateWater(layer, geometry, tags, allowExtraTags);
+    var results = validate(
+      """
+        sources:
+          osm:
+            type: osm
+            url: geofabrik:rhode-island
+        layers:
+        - id: water
+          features:
+          - source: osm
+            geometry: polygon
+            min_size: 10
+            include_when:
+              natural: water
+            attributes:
+            - key: natural
+        """,
+      """
+        examples:
+        - name: test output
+          input:
+            source: osm
+            geometry: polygon
+            tags:
+              natural: water
+          output:
+            layer: %s
+            geometry: %s
+            %s
+            tags:
+              %s
+        """.formatted(layer, geometry, allowExtraTags == null ? "" : allowExtraTags,
+        tags == null ? "" : tags.indent(6).strip())
+    );
     assertEquals(1, results.output.results().size());
-    assertEquals("test output", results.output.results().get(0).example().name());
+    assertEquals("test output", results.output.results().getFirst().example().name());
     if (shouldBeOk) {
       assertTrue(results.output.ok(), results.toString());
       assertFalse(results.cliOutput.contains("FAIL"), "contained FAIL but should not have: " + results.cliOutput);
@@ -138,47 +132,6 @@ class SchemaValidatorTest {
       assertFalse(results.output.ok(), "Expected an issue, but there were none");
       assertTrue(results.cliOutput.contains("FAIL"), "did not contain FAIL but should have: " + results.cliOutput);
     }
-  }
-
-  @Test
-  void testValidationFailsWrongNumberOfFeatures() throws IOException {
-    var results = validate(
-      waterSchema,
-      """
-        examples:
-        - name: test output
-          input:
-            source: osm
-            geometry: polygon
-            tags:
-              natural: water
-          output:
-        """
-    );
-    assertFalse(results.output.ok(), results.toString());
-
-    results = validate(
-      waterSchema,
-      """
-        examples:
-        - name: test output
-          input:
-            source: osm
-            geometry: polygon
-            tags:
-              natural: water
-          output:
-          - layer: water
-            geometry: polygon
-            tags:
-              natural: water
-          - layer: water2
-            geometry: polygon
-            tags:
-              natural: water2
-        """
-    );
-    assertFalse(results.output.ok(), results.toString());
   }
 
   @Test


### PR DESCRIPTION
Improvements and bug fixes found while using planetiler no-build-tool java profiles in https://github.com/onthegomap/planetiler-examples

improvements:
- move yaml profile validator to planetiler-core and hook it into PlanetilerRunner so you can run with `--tests spec.yaml` to run the profile against a set of example test case features
- add `features.anyGeometry(layer)` to FeatureCollector API that creates a line, point, or polygon vector tile feature based on the geometry type of the source feature
- add `inheritAttrsFromSource` and `inheritAttrsFromSourceWithMinzoom` to FeatureCollector API
- let `ForwardingProfile` handlers also return a boolean expression from `filter()` method that limits the features they are called with (and skip entire parquet files that are not of interest)
- add `Expression.matchSource` and `Expression.matchSourceLayer` boolean expressions that generate optimized indexes for matching features at runtime
- make `Expression.matchField` and `Expression.matchAny` handle structured attributes, for example: `matchField("names.primary", "Massachusetts Turnpike")`
- let `ForwardingProfile` skip or include only certain layers automatically with `--only-layers` and `--exclude-layers` option.
- throw only runtime exceptions from `PlanetilerRunner#run` so that profiles don't need to handle them
- add `OSM_ATTRIBUTION` constant to `Profile` with default recommended openstreetmap attribution
- add default `name` implementation to `Profile` so profiles only need to implement `processFeature` method - and they can use lambda method syntax
- use `Distributor` utility when reading parquet files to spread features from final row groups across other threads as they finish

fixes:
- make `setAttrWithMinSize` work correctly for partial-length line features
- fix unwrapping Struct and ZoomFunction attribute values for partial-length line features 
- `Struct#rawValue` was including nested structs for maps and lists, changed to return raw objects