### PR TITLE
Prevent double matching

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/expression/MultiExpression.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/expression/MultiExpression.java
@@ -44,7 +44,7 @@ public record MultiExpression<T>(List<Entry<T>> expressions) implements Simplifi
     for (var expression : expressions) {
       map.merge(expression.result, expression.expression, Expression::or);
     }
-    return new MultiExpression<>(map.entrySet().stream().map(e -> entry(e.getKey(), e.getValue())).toList());
+    return new MultiExpression<>(map.entrySet().stream().map(e -> entry(e.getKey(), e.getValue())).collect(Collectors.toList()));
   }
 
   public static <T> Entry<T> entry(T result, Expression expression) {

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/expression/MultiExpression.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/expression/MultiExpression.java
@@ -44,7 +44,7 @@ public record MultiExpression<T>(List<Entry<T>> expressions) implements Simplifi
     for (var expression : expressions) {
       map.merge(expression.result, expression.expression, Expression::or);
     }
-    return new MultiExpression<>(map.entrySet().stream().map(e -> entry(e.getKey(), e.getValue())).collect(Collectors.toList()));
+    return new MultiExpression<>(map.entrySet().stream().map(e -> entry(e.getKey(), e.getValue())).toList());
   }
 
   public static <T> Entry<T> entry(T result, Expression expression) {

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/expression/MultiExpression.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/expression/MultiExpression.java
@@ -44,7 +44,7 @@ public record MultiExpression<T>(List<Entry<T>> expressions) implements Simplifi
     for (var expression : expressions) {
       map.merge(expression.result, expression.expression, Expression::or);
     }
-    return new MultiExpression<>(map.entrySet().stream().map(e -> new Entry<>(e.getKey(), e.getValue())).toList());
+    return new MultiExpression<>(map.entrySet().stream().map(e -> entry(e.getKey(), e.getValue())).toList());
   }
 
   public static <T> Entry<T> entry(T result, Expression expression) {

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/expression/MultiExpression.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/expression/MultiExpression.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -39,7 +40,11 @@ public record MultiExpression<T>(List<Entry<T>> expressions) implements Simplifi
   private static final Comparator<WithId> BY_ID = Comparator.comparingInt(WithId::id);
 
   public static <T> MultiExpression<T> of(List<Entry<T>> expressions) {
-    return new MultiExpression<>(expressions);
+    LinkedHashMap<T, Expression> map = new LinkedHashMap<>();
+    for (var expression : expressions) {
+      map.merge(expression.result, expression.expression, Expression::or);
+    }
+    return new MultiExpression<>(map.entrySet().stream().map(e -> new Entry<>(e.getKey(), e.getValue())).toList());
   }
 
   public static <T> Entry<T> entry(T result, Expression expression) {

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/ForwardingProfileTests.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/ForwardingProfileTests.java
@@ -360,6 +360,19 @@ class ForwardingProfileTests {
     testFeatures(List.of(), b);
   }
 
+  @Test
+  void registerHandlerTwice() {
+    SourceFeature a = SimpleFeature.create(GeoUtils.EMPTY_POINT, Map.of(), "source", null, 1);
+    testFeatures(List.of(), a);
+
+    ForwardingProfile.FeatureProcessor processor = (elem, features) -> features.point("a");
+    profile.registerHandler(processor);
+    profile.registerSourceHandler("source", processor);
+    testFeatures(List.of(Map.of(
+      "_layer", "a"
+    )), a);
+  }
+
   @ParameterizedTest
   @ValueSource(strings = {
     "--only-layers=water",

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/expression/MultiExpressionTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/expression/MultiExpressionTest.java
@@ -46,6 +46,16 @@ class MultiExpressionTest {
   }
 
   @Test
+  void testDoubleElement() {
+    var index = MultiExpression.of(List.of(
+      entry("a", matchAny("key", "value")),
+      entry("a", matchAny("key", "value"))
+    )).index();
+    assertSameElements(List.of("a"), index.getMatches(featureWithTags("key", "value")));
+    assertSameElements(List.of(), index.getMatches(featureWithTags()));
+  }
+
+  @Test
   void testSingleElementBooleanTrue() {
     var index = MultiExpression.of(List.of(
       entry("a", matchAnyTyped("key", WithTags::getBoolean, true))


### PR DESCRIPTION
Prevent matching the same feature processor if added twice, or in general prevent an indexed `MultiExpression` from returning the same value twice.