### PR TITLE
Support larger GeoPackage files

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/util/FileUtils.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/util/FileUtils.java
@@ -38,7 +38,7 @@ public class FileUtils {
   private static final Format FORMAT = Format.defaultInstance();
   // Prevent zip-bomb attack, see https://rules.sonarsource.com/java/RSPEC-5042
   private static final int ZIP_THRESHOLD_ENTRIES = 10_000;
-  private static final int ZIP_THRESHOLD_SIZE = 1_000_000_000;
+  private static final long ZIP_THRESHOLD_SIZE = 100_000_000_000L;
   private static final double ZIP_THRESHOLD_RATIO = 1_000;
 
   private static final Logger LOGGER = LoggerFactory.getLogger(FileUtils.class);
@@ -271,7 +271,7 @@ public class FileUtils {
    */
   public static void safeCopy(InputStream inputStream, Path destPath) {
     try (var outputStream = Files.newOutputStream(destPath, StandardOpenOption.CREATE, WRITE)) {
-      int totalSize = 0;
+      long totalSize = 0;
 
       int nBytes;
       byte[] buffer = new byte[2048];
@@ -295,7 +295,7 @@ public class FileUtils {
    * @throws UncheckedIOException if an IO exception occurs
    */
   public static void unzip(InputStream input, Path destDir) {
-    int totalSizeArchive = 0;
+    long totalSizeArchive = 0;
     int totalEntryArchive = 0;
     try (var zip = new ZipInputStream(input)) {
       ZipEntry entry;


### PR DESCRIPTION
This pull request increases the `ZIP_THRESHOLD_SIZE` from 1GB to 100GB in `FileUtils.java` to accommodate larger GeoPackage files.

**Reason for Change:**
- Larger GeoPackage files can easily exceed the previous 1GB limit, causing processing errors as described in issue #940.
- This change ensures that the application can handle larger files without running into resource capacity issues.

**Related Issue:**
- Fixes [#940](https://github.com/onthegomap/planetiler/issues/940)

Please review and merge if everything looks good. If possible, please make a new release after merging this, as it is currently a roadblock for working with large GeoPackages. Thank you!