### PR TITLE
Handle no content length in downloader

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/util/Downloader.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/util/Downloader.java
@@ -258,7 +258,6 @@ public class Downloader {
     record Range(long start, long end) {}
     List<Range> chunks = new ArrayList<>();
     boolean ranges = metadata.acceptRange && config.downloadThreads() > 1;
-    boolean supportsRange = ranges && metadata.size.isPresent();
     long fileSize = metadata.size.orElse(Long.MAX_VALUE);
     long chunkSize = ranges ? chunkSizeBytes : fileSize;
     for (long start = 0; start < fileSize; start += chunkSize) {


### PR DESCRIPTION
Fix #928 by making the downloader support when the server doesn't report content length for a file.  It works now, just will not split it up into ranges or report % progress.