### PR TITLE
Allow centroid for other geometry types in yaml configs

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/GeometryType.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/GeometryType.java
@@ -13,7 +13,12 @@ import org.locationtech.jts.geom.Puntal;
 import vector_tile.VectorTileProto;
 
 public enum GeometryType {
-  UNKNOWN(VectorTileProto.Tile.GeomType.UNKNOWN, 0, "unknown"),
+  UNKNOWN(VectorTileProto.Tile.GeomType.UNKNOWN, 0, "unknown") {
+    @Override
+    public Expression featureTest() {
+      return Expression.TRUE;
+    }
+  },
   @JsonProperty("point")
   POINT(VectorTileProto.Tile.GeomType.POINT, 1, "point"),
   @JsonProperty("line")

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/GeometryTypeTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/GeometryTypeTest.java
@@ -3,7 +3,6 @@ package com.onthegomap.planetiler.geo;
 import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.onthegomap.planetiler.TestUtils;
@@ -42,9 +41,9 @@ class GeometryTypeTest {
     assertFalse(GeometryType.POLYGON.featureTest().evaluate(point));
     assertTrue(GeometryType.POLYGON.featureTest().evaluate(poly));
 
-    assertThrows(Exception.class, () -> GeometryType.UNKNOWN.featureTest().evaluate(point));
-    assertThrows(Exception.class, () -> GeometryType.UNKNOWN.featureTest().evaluate(line));
-    assertThrows(Exception.class, () -> GeometryType.UNKNOWN.featureTest().evaluate(poly));
+    assertTrue(GeometryType.UNKNOWN.featureTest().evaluate(point));
+    assertTrue(GeometryType.UNKNOWN.featureTest().evaluate(line));
+    assertTrue(GeometryType.UNKNOWN.featureTest().evaluate(poly));
   }
 
   @ParameterizedTest

--- a/planetiler-custommap/README.md
+++ b/planetiler-custommap/README.md
@@ -144,6 +144,7 @@ to regenerate:
 
 cat planetiler-custommap/planetiler.schema.json | jq -r '.properties.args.properties | to_entries[] | "- `" + .key + "` - " + .value.description' | pbcopy
 -->
+
 - `threads` - Default number of threads to use.
 - `write_threads` - Default number of threads to use when writing temp features
 - `process_threads` - Default number of threads to use when processing input features
@@ -219,7 +220,10 @@ A feature is a defined set of objects that meet a specified filter criteria.
   of:
   - `point` `line` or `polygon` to pass the original feature through
   - `polygon_centroid` to match on polygons, and emit a point at the center
+  - `line_centroid` to match on lines, and emit a point at the center
+  - `centroid` to match any geometry, and emit a point at the center
   - `polygon_point_on_surface` to match on polygons, and emit an interior point
+  - `line_point_on_surface` to match on lines, and emit a point somewhere along the line
   - `polygon_centroid_if_convex` to match on polygons, and if the polygon is convex emit the centroid, otherwise emit an
     interior point
 - `min_tile_cover_size` - Include objects of a certain geometry size, where 1.0 means "is

--- a/planetiler-custommap/README.md
+++ b/planetiler-custommap/README.md
@@ -144,7 +144,6 @@ to regenerate:
 
 cat planetiler-custommap/planetiler.schema.json | jq -r '.properties.args.properties | to_entries[] | "- `" + .key + "` - " + .value.description' | pbcopy
 -->
-
 - `threads` - Default number of threads to use.
 - `write_threads` - Default number of threads to use when writing temp features
 - `process_threads` - Default number of threads to use when processing input features

--- a/planetiler-custommap/README.md
+++ b/planetiler-custommap/README.md
@@ -223,7 +223,7 @@ A feature is a defined set of objects that meet a specified filter criteria.
   - `line_centroid` to match on lines, and emit a point at the center
   - `centroid` to match any geometry, and emit a point at the center
   - `polygon_point_on_surface` to match on polygons, and emit an interior point
-  - `line_point_on_surface` to match on lines, and emit a point somewhere along the line
+  - `point_on_line` to match on lines, and emit a point somewhere along the line
   - `polygon_centroid_if_convex` to match on polygons, and if the polygon is convex emit the centroid, otherwise emit an
     interior point
 - `min_tile_cover_size` - Include objects of a certain geometry size, where 1.0 means "is

--- a/planetiler-custommap/planetiler.schema.json
+++ b/planetiler-custommap/planetiler.schema.json
@@ -358,7 +358,7 @@
             "centroid",
             "polygon_centroid_if_convex",
             "polygon_point_on_surface",
-            "line_point_on_surface"
+            "point_on_line"
           ]
         },
         "source": {

--- a/planetiler-custommap/planetiler.schema.json
+++ b/planetiler-custommap/planetiler.schema.json
@@ -354,8 +354,11 @@
             "line",
             "polygon",
             "polygon_centroid",
+            "line_centroid",
+            "centroid",
             "polygon_centroid_if_convex",
-            "polygon_point_on_surface"
+            "polygon_point_on_surface",
+            "line_point_on_surface"
           ]
         },
         "source": {

--- a/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/configschema/FeatureGeometry.java
+++ b/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/configschema/FeatureGeometry.java
@@ -24,8 +24,8 @@ public enum FeatureGeometry {
   POLYGON_CENTROID_IF_CONVEX(GeometryType.POLYGON, FeatureCollector::centroidIfConvex),
   @JsonProperty("polygon_point_on_surface")
   POLYGON_POINT_ON_SURFACE(GeometryType.POLYGON, FeatureCollector::pointOnSurface),
-  @JsonProperty("line_point_on_surface")
-  LINE_POINT_ON_SURFACE(GeometryType.LINE, FeatureCollector::pointOnSurface);
+  @JsonProperty("point_on_line")
+  POINT_ON_LINE(GeometryType.LINE, FeatureCollector::pointOnSurface);
 
   public final GeometryType geometryType;
   public final BiFunction<FeatureCollector, String, FeatureCollector.Feature> geometryFactory;

--- a/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/configschema/FeatureGeometry.java
+++ b/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/configschema/FeatureGeometry.java
@@ -16,10 +16,16 @@ public enum FeatureGeometry {
   POLYGON(GeometryType.POLYGON, FeatureCollector::polygon),
   @JsonProperty("polygon_centroid")
   POLYGON_CENTROID(GeometryType.POLYGON, FeatureCollector::centroid),
+  @JsonProperty("line_centroid")
+  LINE_CENTROID(GeometryType.LINE, FeatureCollector::centroid),
+  @JsonProperty("centroid")
+  CENTROID(GeometryType.UNKNOWN, FeatureCollector::centroid),
   @JsonProperty("polygon_centroid_if_convex")
   POLYGON_CENTROID_IF_CONVEX(GeometryType.POLYGON, FeatureCollector::centroidIfConvex),
   @JsonProperty("polygon_point_on_surface")
-  POLYGON_POINT_ON_SURFACE(GeometryType.POLYGON, FeatureCollector::pointOnSurface);
+  POLYGON_POINT_ON_SURFACE(GeometryType.POLYGON, FeatureCollector::pointOnSurface),
+  @JsonProperty("line_point_on_surface")
+  LINE_POINT_ON_SURFACE(GeometryType.LINE, FeatureCollector::pointOnSurface);
 
   public final GeometryType geometryType;
   public final BiFunction<FeatureCollector, String, FeatureCollector.Feature> geometryFactory;

--- a/planetiler-custommap/src/test/java/com/onthegomap/planetiler/custommap/ConfiguredFeatureTest.java
+++ b/planetiler-custommap/src/test/java/com/onthegomap/planetiler/custommap/ConfiguredFeatureTest.java
@@ -1257,7 +1257,7 @@ class ConfiguredFeatureTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"line_centroid", "line_point_on_surface"})
+  @ValueSource(strings = {"line_centroid", "point_on_line"})
   void testLineCentroid(String type) {
     var config = """
       sources:

--- a/planetiler-custommap/src/test/java/com/onthegomap/planetiler/custommap/ConfiguredFeatureTest.java
+++ b/planetiler-custommap/src/test/java/com/onthegomap/planetiler/custommap/ConfiguredFeatureTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.locationtech.jts.geom.Puntal;
 
 class ConfiguredFeatureTest {
   private PlanetilerConfig planetilerConfig = PlanetilerConfig.defaults();
@@ -1221,5 +1222,60 @@ class ConfiguredFeatureTest {
         3
       )
     ), loadConfig(config).findFeatureLayer("testLayer").postProcess());
+  }
+
+  @Test
+  void testCentroid() {
+    var config = """
+      sources:
+        osm:
+          type: osm
+          url: geofabrik:rhode-island
+          local_path: data/rhode-island.osm.pbf
+      layers:
+      - id: testLayer
+        features:
+        - source: osm
+          geometry: centroid
+      """;
+    this.planetilerConfig = PlanetilerConfig.from(Arguments.of(Map.of()));
+    testPolygon(config, Map.of(
+      "natural", "water"
+    ), feature -> {
+      assertInstanceOf(Puntal.class, feature.getGeometry());
+    }, 1);
+    testLinestring(config, Map.of(
+      "natural", "water"
+    ), feature -> {
+      assertInstanceOf(Puntal.class, feature.getGeometry());
+    }, 1);
+    testPoint(config, Map.of(
+      "natural", "water"
+    ), feature -> {
+      assertInstanceOf(Puntal.class, feature.getGeometry());
+    }, 1);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"line_centroid", "line_point_on_surface"})
+  void testLineCentroid(String type) {
+    var config = """
+      sources:
+        osm:
+          type: osm
+          url: geofabrik:rhode-island
+          local_path: data/rhode-island.osm.pbf
+      layers:
+      - id: testLayer
+        features:
+        - source: osm
+          geometry: %s
+      """.formatted(type);
+    this.planetilerConfig = PlanetilerConfig.from(Arguments.of(Map.of()));
+    testLinestring(config, Map.of(
+      "natural", "water"
+    ), feature -> {
+      assertInstanceOf(Puntal.class, feature.getGeometry());
+    }, 1);
   }
 }


### PR DESCRIPTION
Fix #890 by adding yaml support for `line_centroid` `point_on_line` and `centroid` geometry types in yaml configs.