### PR TITLE
Update README.md to reflect change in demo tile hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ for more of the backstory.
 
 ## Demo
 
-See the [live demo](https://onthegomap.github.io/planetiler-demo/) of vector tiles created by Planetiler and hosted by
-the [OpenStreetMap Americana Project](https://github.com/ZeLonewolf/openstreetmap-americana/).
+See the [live demo](https://onthegomap.github.io/planetiler-demo/) of vector tiles created by Planetiler and [hosted by OpenStreetMap US](https://github.com/osmus/tileservice).
 
 [![Planetiler Demo Screenshot](./diagrams/demo.png)](https://onthegomap.github.io/planetiler-demo/)
 [© OpenMapTiles](https://www.openmaptiles.org/) [© OpenStreetMap contributors](https://www.openstreetmap.org/copyright)


### PR DESCRIPTION
Vector tiles previously hosted by Americana are now hosted by OpenStreetMap US. CC: @ZeLonewolf 