### PR TITLE
Fix `min_tile_cover_size` docs

### DIFF
--- a/planetiler-custommap/README.md
+++ b/planetiler-custommap/README.md
@@ -225,8 +225,6 @@ A feature is a defined set of objects that meet a specified filter criteria.
   - `point_on_line` to match on lines, and emit a point somewhere along the line
   - `polygon_centroid_if_convex` to match on polygons, and if the polygon is convex emit the centroid, otherwise emit an
     interior point
-- `min_tile_cover_size` - Include objects of a certain geometry size, where 1.0 means "is
-  the same size as a tile at this zoom"
 - `include_when` - A [Boolean Expression](#boolean-expression) which determines the features to include.
   If unspecified, all features from the specified sources are included.
 - `exclude_when` - A [Boolean Expression](#boolean-expression) which determines if a feature that matched the include
@@ -268,6 +266,8 @@ Defines an attribute to include on an output vector tile feature and how to comp
   minimum zoom for each output value.
 - `type` - The [Data Type](#data-type) to coerce the value to, or `match_key` to set this attribute to the key that
   triggered the match in the include expression, or `match_value` to set it to the value for the matching key.
+- `min_tile_cover_size` - Include this attribute only on geometries over a certain size at a given zoom level, where 1.0
+  means the entire width of a tile for lines, or area of a tile for polygons.
 
 To define the value, use one of:
 

--- a/planetiler-custommap/planetiler.schema.json
+++ b/planetiler-custommap/planetiler.schema.json
@@ -375,12 +375,6 @@
             }
           ]
         },
-        "min_tile_cover_size": {
-          "description": "include objects of a certain geometry size, where 1.0 means \"is the same size as a tile at this zoom\"",
-          "type": "number",
-          "minimum": 0,
-          "maximum": 1
-        },
         "include_when": {
           "description": "A tag specification which determines the features to include. If unspecified, all features from the specified sources are included",
           "$ref": "#/$defs/boolean_expression"
@@ -487,6 +481,12 @@
               "additionalProperties": {
                 "$ref": "#/$defs/zoom_level"
               }
+            },
+            "min_tile_cover_size": {
+              "description": "Include this attribute only on geometries over a certain size at a given zoom level, where 1.0 means the entire width of a tile for lines, or area of a tile for polygons.",
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1
             }
           }
         }


### PR DESCRIPTION
Fix #961 by updated the docs to reflect this is an tag on attribute, not feature definitions.