### PR TITLE
Expose caresAboutLayer() and new ForwardingProfile(config) ...

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/ForwardingProfile.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/ForwardingProfile.java
@@ -55,7 +55,7 @@ public abstract class ForwardingProfile implements Profile {
   @SuppressWarnings("java:S3077")
   private volatile MultiExpression.Index<FeatureProcessor> indexedSourceElementProcessors = null;
 
-  public ForwardingProfile(PlanetilerConfig config) {
+  protected ForwardingProfile(PlanetilerConfig config) {
     onlyLayers = config.arguments().getList("only_layers", "Include only certain layers", List.of());
     excludeLayers = config.arguments().getList("exclude_layers", "Exclude certain layers", List.of());
   }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/ForwardingProfile.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/ForwardingProfile.java
@@ -55,9 +55,13 @@ public abstract class ForwardingProfile implements Profile {
   @SuppressWarnings("java:S3077")
   private volatile MultiExpression.Index<FeatureProcessor> indexedSourceElementProcessors = null;
 
-  protected ForwardingProfile(PlanetilerConfig config, Handler... handlers) {
+  public ForwardingProfile(PlanetilerConfig config) {
     onlyLayers = config.arguments().getList("only_layers", "Include only certain layers", List.of());
     excludeLayers = config.arguments().getList("exclude_layers", "Exclude certain layers", List.of());
+  }
+
+  protected ForwardingProfile(PlanetilerConfig config, Handler... handlers) {
+    this(config);
     for (var handler : handlers) {
       registerHandler(handler);
     }
@@ -80,7 +84,7 @@ public abstract class ForwardingProfile implements Profile {
     return (onlyLayers.isEmpty() || onlyLayers.contains(layer)) && !excludeLayers.contains(layer);
   }
 
-  private boolean caresAboutLayer(Object obj) {
+  public boolean caresAboutLayer(Object obj) {
     return !(obj instanceof HandlerForLayer l) || caresAboutLayer(l.name());
   }
 


### PR DESCRIPTION
... constructor so that profiles do not need to process `--only-layer` and `--exclude-layers` on their own, making sure we're working with `onlyLayers` and `excludeLayers` in `OpenMapTilesProfile` and `ForwardingProfile` in consistent manner.

This relates to https://github.com/openmaptiles/planetiler-openmaptiles/pull/182 .