### PR TITLE
Update old wikidata items

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
@@ -579,9 +579,8 @@ public class Planetiler {
     wikidataMaxAge =
       arguments.getDuration("wikidata_max_age",
         "Maximum age of Wikidata translations (in ISO-8601 duration format PnDTnHnMn.nS; 0S = disabled)", "P30D");
-    // limit of 100_000 is roughly 5% of total amount of entries for whole Planet
     wikidataUpdateLimit = arguments.getInteger("wikidata_update_limit",
-      "Limit on how many old translations to update during one download (0 = disabled)", 100_000);
+      "Limit on how many old translations to update during one download (0 = disabled)", 0);
     return this;
   }
 

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
@@ -577,7 +577,8 @@ public class Planetiler {
     useWikidata = fetchWikidata || arguments.getBoolean("use_wikidata", "use wikidata translations", true);
     wikidataNamesFile = arguments.file("wikidata_cache", "wikidata cache file", defaultWikidataCache);
     wikidataMaxAge =
-      arguments.getDuration("wikidata_max_age", "Maximum age of Wikidata translations (0 = disabled)", "720H");
+      arguments.getDuration("wikidata_max_age",
+        "Maximum age of Wikidata translations (in ISO-8601 duration format PnDTnHnMn.nS; 0S = disabled)", "P30D");
     // limit of 100_000 is roughly 5% of total amount of entries for whole Planet
     wikidataUpdateLimit = arguments.getInteger("wikidata_update_limit",
       "Limit on how many old translations to update during one download (0 = disabled)", 100_000);

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
@@ -578,7 +578,7 @@ public class Planetiler {
     wikidataNamesFile = arguments.file("wikidata_cache", "wikidata cache file", defaultWikidataCache);
     wikidataMaxAge =
       arguments.getDuration("wikidata_max_age",
-        "Maximum age of Wikidata translations (in ISO-8601 duration format PnDTnHnMn.nS; 0S = disabled)", "P30D");
+        "Maximum age of Wikidata translations (in ISO-8601 duration format PnDTnHnMn.nS; 0S = disabled)", "0s");
     wikidataUpdateLimit = arguments.getInteger("wikidata_update_limit",
       "Limit on how many old translations to update during one download (0 = disabled)", 0);
     return this;

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
@@ -805,11 +805,7 @@ public class Planetiler {
         wikidataUpdateLimit);
     }
     if (useWikidata) {
-      // update of old items handled by "fetch" above => do NOT use age checks here
-      var translationsProvider = Wikidata.load(wikidataNamesFile, Duration.ZERO, 0);
-      translationsProvider.clearUpdateTimes();
-      translations()
-        .addFallbackTranslationProvider(translationsProvider);
+      translations().addFallbackTranslationProvider(Wikidata.load(wikidataNamesFile));
     }
     if (onlyDownloadSources || onlyFetchWikidata) {
       return; // exit only if just fetching wikidata or downloading sources

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/config/Arguments.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/config/Arguments.java
@@ -473,7 +473,10 @@ public class Arguments {
    */
   public Duration getDuration(String key, String description, String defaultValue) {
     String value = getArg(key, defaultValue);
-    Duration parsed = Duration.parse("PT" + value);
+    if (!value.startsWith("P") && !value.startsWith("T") && !value.startsWith("-")) {
+      value = "PT" + value;
+    }
+    Duration parsed = Duration.parse(value);
     logArgValue(key, description, parsed.get(ChronoUnit.SECONDS) + " seconds");
     return parsed;
   }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/util/Wikidata.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/util/Wikidata.java
@@ -37,6 +37,7 @@ import java.net.http.HttpResponse.BodyHandlers;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -189,7 +190,7 @@ public class Wikidata {
       return new WikidataTranslations();
     } else {
       try (BufferedReader fis = Files.newBufferedReader(path)) {
-        WikidataTranslations result = load(fis, maxAge, updateLimit);
+        WikidataTranslations result = load(fis, maxAge, updateLimit, Clock.systemUTC());
         LOGGER.info(
           "loaded from " + result.getAll().size() + " mappings from " + path.toAbsolutePath() + " in " + timer.stop());
         return result;
@@ -205,14 +206,14 @@ public class Wikidata {
    * second element is a map from language to translation.
    */
   static WikidataTranslations load(BufferedReader reader) throws IOException {
-    return load(reader, Duration.ZERO, 0);
+    return load(reader, Duration.ZERO, 0, Clock.systemUTC());
   }
 
-  protected static WikidataTranslations load(BufferedReader reader, Duration maxAge, int updateLimit)
+  protected static WikidataTranslations load(BufferedReader reader, Duration maxAge, int updateLimit, Clock clock)
     throws IOException {
     WikidataTranslations mappings = new WikidataTranslations();
     String line;
-    Instant updateTimeLimit = maxAge.isZero() ? null : Instant.now().minus(maxAge);
+    Instant updateTimeLimit = maxAge.isZero() ? null : Instant.now(clock).minus(maxAge);
     int updateCounter = 0;
     while ((line = reader.readLine()) != null) {
       JsonNode node = objectMapper.readTree(line);

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/util/Wikidata.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/util/Wikidata.java
@@ -166,7 +166,13 @@ public class Wikidata {
   /**
    * Returns translations parsed from {@code path} that was written by a previous run of the downloader.
    */
-  public static WikidataTranslations load(Path path, Duration maxAge, int updateLimit) {
+  public static WikidataTranslations load(Path path) {
+    var translationsProvider = Wikidata.load(path, Duration.ZERO, 0);
+    translationsProvider.clearUpdateTimes();
+    return translationsProvider;
+  }
+
+  private static WikidataTranslations load(Path path, Duration maxAge, int updateLimit) {
     Timer timer = Timer.start();
     if (!Files.exists(path)) {
       LOGGER.info("no wikidata translations found, run with --fetch-wikidata to download");
@@ -188,7 +194,8 @@ public class Wikidata {
    * Returns translations parsed from {@code reader} where each line is a JSON array where first element is the ID and
    * second element is a map from language to translation.
    */
-  static WikidataTranslations load(BufferedReader reader, Duration maxAge, int updateLimit) throws IOException {
+  protected static WikidataTranslations load(BufferedReader reader, Duration maxAge, int updateLimit)
+    throws IOException {
     WikidataTranslations mappings = new WikidataTranslations();
     String line;
     Instant updateTimeLimit = maxAge.isZero() ? null : Instant.now().minus(maxAge);

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/util/Wikidata.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/util/Wikidata.java
@@ -218,9 +218,9 @@ public class Wikidata {
       JsonNode node = objectMapper.readTree(line);
       long id = Long.parseLong(node.get(0).asText());
 
-      Instant updateTime = Instant.MIN;
+      Instant updateTime = Instant.ofEpochMilli(0);
       if (node.has(2)) {
-        updateTime = Instant.parse(node.get(2).asText());
+        updateTime = Instant.ofEpochMilli(node.get(2).asLong());
       }
       if (updateTimeLimit != null && updateTime.isBefore(updateTimeLimit) &&
         (updateLimit <= 0 || updateCounter < updateLimit)) {
@@ -386,10 +386,10 @@ public class Wikidata {
   /** Flushes a batch of translations to disk. */
   private void writeTranslations(LongObjectMap<Map<String, String>> results, LongObjectMap<Instant> updateTimes)
     throws IOException {
-    final String updateTimeDefault = Instant.now().toString();
+    final long updateTimeDefault = Instant.now().toEpochMilli();
     for (LongObjectCursor<Map<String, String>> cursor : results) {
-      String updateTime =
-        updateTimes.containsKey(cursor.key) ? updateTimes.get(cursor.key).toString() : updateTimeDefault;
+      long updateTime =
+        updateTimes.containsKey(cursor.key) ? updateTimes.get(cursor.key).toEpochMilli() : updateTimeDefault;
       writer.write(objectMapper.writeValueAsString(List.of(
         Long.toString(cursor.key),
         cursor.value,

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/util/Wikidata.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/util/Wikidata.java
@@ -37,6 +37,8 @@ import java.net.http.HttpResponse.BodyHandlers;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -110,12 +112,14 @@ public class Wikidata {
    *
    * @throws UncheckedIOException if an error occurs
    */
-  public static void fetch(OsmInputFile infile, Path outfile, PlanetilerConfig config, Profile profile, Stats stats) {
+  public static void fetch(OsmInputFile infile, Path outfile, PlanetilerConfig config, Profile profile, Stats stats,
+    Duration maxAge, int updateLimit) {
+
     var timer = stats.startStage("wikidata");
     int processThreads = Math.max(1, config.threads() - 1);
     LOGGER.info("Starting with " + processThreads + " process threads");
 
-    WikidataTranslations oldMappings = load(outfile);
+    WikidataTranslations oldMappings = load(outfile, maxAge, updateLimit);
     try (
       Writer writer = Files.newBufferedWriter(outfile);
       OsmBlockSource osmSource = infile.get()
@@ -162,14 +166,14 @@ public class Wikidata {
   /**
    * Returns translations parsed from {@code path} that was written by a previous run of the downloader.
    */
-  public static WikidataTranslations load(Path path) {
+  public static WikidataTranslations load(Path path, Duration maxAge, int updateLimit) {
     Timer timer = Timer.start();
     if (!Files.exists(path)) {
       LOGGER.info("no wikidata translations found, run with --fetch-wikidata to download");
       return new WikidataTranslations();
     } else {
       try (BufferedReader fis = Files.newBufferedReader(path)) {
-        WikidataTranslations result = load(fis);
+        WikidataTranslations result = load(fis, maxAge, updateLimit);
         LOGGER.info(
           "loaded from " + result.getAll().size() + " mappings from " + path.toAbsolutePath() + " in " + timer.stop());
         return result;
@@ -184,14 +188,32 @@ public class Wikidata {
    * Returns translations parsed from {@code reader} where each line is a JSON array where first element is the ID and
    * second element is a map from language to translation.
    */
-  static WikidataTranslations load(BufferedReader reader) throws IOException {
+  static WikidataTranslations load(BufferedReader reader, Duration maxAge, int updateLimit) throws IOException {
     WikidataTranslations mappings = new WikidataTranslations();
     String line;
+    Instant updateTimeLimit = maxAge.isZero() ? null : Instant.now().minus(maxAge);
+    int updateCounter = 0;
     while ((line = reader.readLine()) != null) {
       JsonNode node = objectMapper.readTree(line);
       long id = Long.parseLong(node.get(0).asText());
+
+      Instant updateTime = Instant.MIN;
+      if (node.has(2)) {
+        updateTime = Instant.parse(node.get(2).asText());
+      }
+      if (updateTimeLimit != null && updateTime.isBefore(updateTimeLimit) &&
+        (updateLimit <= 0 || updateCounter < updateLimit)) {
+        // do not load old entries => new translations will be fetched later
+        updateCounter++;
+        continue;
+      }
+      mappings.putUpdateTime(id, updateTime);
+
       ObjectNode theseMappings = (ObjectNode) node.get(1);
       theseMappings.fields().forEachRemaining(entry -> mappings.put(id, entry.getKey(), entry.getValue().asText()));
+    }
+    if (updateCounter > 0) {
+      LOGGER.info("{} translations dropped as too old, will be re-fetched", updateCounter);
     }
     return mappings;
   }
@@ -255,7 +277,7 @@ public class Wikidata {
       LongObjectMap<Map<String, String>> results = queryWikidata(qidsToFetch);
       batches.inc();
       LOGGER.info("Fetched batch {} ({} qids) {}", batches.get(), qidsToFetch.size(), timer.stop());
-      writeTranslations(results);
+      writeTranslations(results, Hppc.newLongObjectHashMap());
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       throwFatalException(e);
@@ -330,9 +352,10 @@ public class Wikidata {
 
   void loadExisting(WikidataTranslations oldMappings) throws IOException {
     LongObjectMap<Map<String, String>> alreadyHave = oldMappings.getAll();
+    LongObjectMap<Instant> alreadyHaveUpdateTimes = oldMappings.getUpdateTimes();
     if (!alreadyHave.isEmpty()) {
       LOGGER.info("skipping " + alreadyHave.size() + " mappings we already have");
-      writeTranslations(alreadyHave);
+      writeTranslations(alreadyHave, alreadyHaveUpdateTimes);
       for (LongObjectCursor<Map<String, String>> cursor : alreadyHave) {
         visited.add(cursor.key);
       }
@@ -340,11 +363,16 @@ public class Wikidata {
   }
 
   /** Flushes a batch of translations to disk. */
-  private void writeTranslations(LongObjectMap<Map<String, String>> results) throws IOException {
+  private void writeTranslations(LongObjectMap<Map<String, String>> results, LongObjectMap<Instant> updateTimes)
+    throws IOException {
+    final String updateTimeDefault = Instant.now().toString();
     for (LongObjectCursor<Map<String, String>> cursor : results) {
+      String updateTime =
+        updateTimes.containsKey(cursor.key) ? updateTimes.get(cursor.key).toString() : updateTimeDefault;
       writer.write(objectMapper.writeValueAsString(List.of(
         Long.toString(cursor.key),
-        cursor.value
+        cursor.value,
+        updateTime
       )));
       writer.write(System.lineSeparator());
     }
@@ -383,6 +411,7 @@ public class Wikidata {
   public static class WikidataTranslations implements Translations.TranslationProvider {
 
     private final LongObjectMap<Map<String, String>> data = Hppc.newLongObjectHashMap();
+    private final LongObjectMap<Instant> updateTimes = Hppc.newLongObjectHashMap();
 
     public WikidataTranslations() {}
 
@@ -391,9 +420,23 @@ public class Wikidata {
       return data.get(qid);
     }
 
+    public void clearUpdateTimes() {
+      updateTimes.clear();
+    }
+
     /** Returns all maps from language code to translated name for {@code qid}. */
     public LongObjectMap<Map<String, String>> getAll() {
       return data;
+    }
+
+    /** Returns all maps from language code to translated name for {@code qid}. */
+    public LongObjectMap<Instant> getUpdateTimes() {
+      return updateTimes;
+    }
+
+    /** Stores a update date+time for {@code qid}. */
+    public void putUpdateTime(long qid, Instant updateTime) {
+      updateTimes.put(qid, updateTime);
     }
 
     /** Stores a name translation for {@code qid} in {@code lang}. */

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/util/Wikidata.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/util/Wikidata.java
@@ -112,6 +112,16 @@ public class Wikidata {
    *
    * @throws UncheckedIOException if an error occurs
    */
+  public static void fetch(OsmInputFile infile, Path outfile, PlanetilerConfig config, Profile profile, Stats stats) {
+    fetch(infile, outfile, config, profile, stats, Duration.ofSeconds(0), 0);
+  }
+
+  /**
+   * Loads any existing translations from {@code outfile}, then downloads translations for any wikidata element in
+   * {@code infile} that have not already been downloaded and writes the results to {@code outfile}.
+   *
+   * @throws UncheckedIOException if an error occurs
+   */
   public static void fetch(OsmInputFile infile, Path outfile, PlanetilerConfig config, Profile profile, Stats stats,
     Duration maxAge, int updateLimit) {
 
@@ -194,6 +204,10 @@ public class Wikidata {
    * Returns translations parsed from {@code reader} where each line is a JSON array where first element is the ID and
    * second element is a map from language to translation.
    */
+  static WikidataTranslations load(BufferedReader reader) throws IOException {
+    return load(reader, Duration.ZERO, 0);
+  }
+
   protected static WikidataTranslations load(BufferedReader reader, Duration maxAge, int updateLimit)
     throws IOException {
     WikidataTranslations mappings = new WikidataTranslations();

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/util/Wikidata.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/util/Wikidata.java
@@ -218,7 +218,7 @@ public class Wikidata {
       JsonNode node = objectMapper.readTree(line);
       long id = Long.parseLong(node.get(0).asText());
 
-      Instant updateTime = Instant.ofEpochMilli(0);
+      Instant updateTime = Instant.EPOCH;
       if (node.has(2)) {
         updateTime = Instant.ofEpochMilli(node.get(2).asLong());
       }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/util/WikidataTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/util/WikidataTest.java
@@ -127,8 +127,7 @@ class WikidataTest {
           """, body);
       }),
       dynamicTest("can load serialized data", () -> {
-        var translations = Wikidata.load(new BufferedReader(new StringReader(writer.toString())),
-          Duration.ofSeconds(0), 0);
+        var translations = Wikidata.load(new BufferedReader(new StringReader(writer.toString())));
         assertEquals(Map.of("en", "en name", "es", "es name"), translations.get(1));
         assertEquals(Map.of("es", "es name2"), translations.get(2));
       }),
@@ -136,8 +135,7 @@ class WikidataTest {
         StringWriter writer2 = new StringWriter();
         Wikidata.Client client2 = Mockito.mock(Wikidata.Client.class, Mockito.RETURNS_SMART_NULLS);
         Wikidata fixture2 = new Wikidata(writer2, client2, 2, profile, config);
-        fixture2.loadExisting(Wikidata.load(new BufferedReader(new StringReader(writer.toString())),
-          Duration.ofSeconds(0), 0));
+        fixture2.loadExisting(Wikidata.load(new BufferedReader(new StringReader(writer.toString()))));
         fixture2.fetch(1L);
         fixture2.fetch(2L);
         fixture2.fetch(1L);
@@ -157,8 +155,7 @@ class WikidataTest {
       .thenThrow(IOException.class)
       .thenReturn(new ByteArrayInputStream(response.getBytes(StandardCharsets.UTF_8)));
     fixture.fetch(1L);
-    var translations = Wikidata.load(new BufferedReader(new StringReader(writer.toString())),
-      Duration.ofSeconds(0), 0);
+    var translations = Wikidata.load(new BufferedReader(new StringReader(writer.toString())));
     assertEquals(Map.of("en", "en name", "es", "es name"), translations.get(1));
     assertEquals(Map.of("es", "es name2"), translations.get(2));
 

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/util/WikidataTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/util/WikidataTest.java
@@ -186,7 +186,7 @@ class WikidataTest {
 
   @Test
   void testWikidataNamesJsonMaxAge() throws IOException {
-    // 10s => item 1 is 1s old hence fresh, the rest (30s and 50s) are older
+    // 10s => item 1 is 5s old hence fresh, the rest is 30s old hence outdated
     Duration maxAge = Duration.ofSeconds(10);
 
     var reader = new BufferedReader(new StringReader(wikidataNamesJson));


### PR DESCRIPTION
When Planetiler is used with `--fetch-wikidata` it works roughly like this:

1. Planetiler run 1: `wikidata_names.json` does not exist, hence all the translations are fetched from WikiData
2. Some OSM data gets updated, e.g. some new items get added and some existing items get updated
3. Some WikiData items gets updated, e.g. some new items get added and some existing items get updated
4. Planetiler run 2: `wikidata_names.json` exists, so translations are loaded from it and only translations for new OSM elements are fetched from WikiData

Good thing is, that this lowers the load on WikiData and speeds-up tileset generation.

Problem: If some translation changed for existing OSM element, old value from `wikidata_names.json` is used. If we want to get updates, we can delete `wikidata_names.json` and fetch all translations once again.

This PR tries to partially address the problem without the need for deletion (or manual tweaking of) `wikidata_names.json`:

- It adds new option `wikidata_max_age` (with default value 0, e.g. "disabled")
- Is adds new option `wikidata_update_limit` (with default value 0, e.g. "disabled")
- It tweaks loading of translations during fetch phase to:
  - Skip up to `wikidata_update_limit` items which are older than `wikidata_max_age`
  - This then causes subsequent fetch to load those values once again

With the defaults Planetiler works as before.

When called with for example `--wikidata-max-age=P30D --wikidata-update-limit=100000`, it should then work roughly as follows:

1. Planetiler run 1: `wikidata_names.json` does not exist, hence all the translations are fetched from WikiData
2. Some OSM data gets updated, e.g. some new items get added and some existing items get updated
3. Some WikiData items gets updated, e.g. some new items get added and some existing items get updated
4. Planetiler run 2, say one month after 1st run: `wikidata_names.json` exists, so translations are loaded from it and only translations for new OSM elements are fetched from WikiData
    - Given `wikidata_max_age=P30D` all translations are now considered outdated
    - But given `wikidata_update_limit=100000` (which is roughly 5% of existing translations for full Planet) only up-to 100'000 translations are dropped and fetched from WikiData again
5. ...

Other combination might be `--wikidata-max-age=P30D` and `--wikidata-update-limit=0` which would keep using the cached translations for a month but the run after a month will drop all (now outdated) translations and fetch them again from WikiData.