### PR TITLE
Fix handling of string typed null values

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/expression/DataType.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/expression/DataType.java
@@ -10,7 +10,7 @@ import java.util.function.UnaryOperator;
  * Destination data types for an attribute that link the type to functions that can parse the value from an input object
  */
 public enum DataType implements BiFunction<WithTags, String, Object> {
-  GET_STRING("string", WithTags::getString, Objects::toString),
+  GET_STRING("string", WithTags::getString, Parse::parseStringOrNull),
   GET_BOOLEAN("boolean", WithTags::getBoolean, Parse::bool),
   GET_DIRECTION("direction", WithTags::getDirection, Parse::direction),
   GET_LONG("long", WithTags::getLong, Parse::parseLongOrNull),

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/expression/DataType.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/expression/DataType.java
@@ -2,7 +2,6 @@ package com.onthegomap.planetiler.expression;
 
 import com.onthegomap.planetiler.reader.WithTags;
 import com.onthegomap.planetiler.util.Parse;
-import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.UnaryOperator;
 

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/util/Parse.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/util/Parse.java
@@ -31,6 +31,11 @@ public class Parse {
 
   private Parse() {}
 
+  /** Returns {@code tag} as a string or null if null. */
+  public static String parseStringOrNull(Object tag) {
+    return tag == null ? null : tag.toString();
+  }
+
   /** Returns {@code tag} as a long or null if invalid. */
   public static Long parseLongOrNull(Object tag) {
     return tag == null ? null : tag instanceof Number number ? Long.valueOf(number.longValue()) :

--- a/planetiler-custommap/src/test/java/com/onthegomap/planetiler/custommap/ConfiguredFeatureTest.java
+++ b/planetiler-custommap/src/test/java/com/onthegomap/planetiler/custommap/ConfiguredFeatureTest.java
@@ -268,6 +268,15 @@ class ConfiguredFeatureTest {
   }
 
   @Test
+  void testTagNullValueAttributeTest() {
+    testPolygon(TEST_RESOURCE, "tag_attribute_null.yml", waterTags, f -> {
+      var attr = f.getAttrsAtZoom(14);
+      assertNull(attr.get("non_existent"));
+      assertNull(attr.get("non_existent_typed"));
+    }, 1);
+  }
+
+  @Test
   void testTagIncludeAttributeTest() {
     testPolygon(TEST_RESOURCE, "tag_include.yml", waterTags, f -> {
       var attr = f.getAttrsAtZoom(14);

--- a/planetiler-custommap/src/test/resources/validSchema/tag_attribute_null.yml
+++ b/planetiler-custommap/src/test/resources/validSchema/tag_attribute_null.yml
@@ -1,0 +1,19 @@
+schema_name: Test Case Schema
+schema_description: Test case tile schema
+attribution: Test attribution
+sources:
+  osm:
+    type: osm
+    url: geofabrik:rhode-island
+layers:
+- id: testLayer
+  features:
+  - source:
+    - osm
+    geometry: polygon
+    include_when:
+      natural: water
+    attributes:
+    - key: non_existent
+    - key: non_existent_typed
+      type: string


### PR DESCRIPTION
When using custom map as follows:

```
schema_name: Test Case Schema
schema_description: Test case tile schema
attribution: Test attribution
sources:
  osm:
    type: osm
    url: geofabrik:rhode-island
layers:
- id: testLayer
  features:
  - source:
    - osm
    geometry: polygon
    include_when:
      natural: water
    attributes:
    - key: non_existent
    - key: non_existent_typed
      type: string
```

then currently `non_existent` is handled differently than `non_existent_typed`:

- `non_existent` gives `null` value (since not present in source data) which gets properly handled so that resulting layer feature does NOT have a `non_existent` attribute
- `non_existent_typed` gives `null` value which gets converted into `"null"` string which is then handled so that resulting layer feature DOES have a `non_existent_typed` attribute with value `"null"`

Second case is inconsistent with the first and is considered a bug. This PR fixes that bug and adds unit test for this scenarios.

Other types seems to work as expected, e.g.:

```
...
    - key: non_existent_typed
      type: integer
```

generates features without `non_existent_typed` attribute.