### PR TITLE
added `dependsOnLayer()` ...

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/ForwardingProfile.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/ForwardingProfile.java
@@ -98,7 +98,7 @@ public abstract class ForwardingProfile implements Profile {
   /**
    * Indicate to {@link #caresAboutLayer(String)} what layers (dependents) rely on other layers (dependencies) so that
    * methods like {@link #registerFeatureHandler(FeatureProcessor)}, {@link #registerHandler(Handler)} or
-   * {@link #registerSourceHandler(String, FeatureProcessor)} do register also those dependencies.
+   * {@link #registerSourceHandler(String, FeatureProcessor)} do not block registration of those dependencies.
    * <p>
    * Dependencies are described as a map with dependent layer names as keys and lists containing dependency layer names
    * as map values. Example: Layer named {@code transportation_name} depends on layer named {@code transportation}:

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/ForwardingProfile.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/ForwardingProfile.java
@@ -85,6 +85,7 @@ public abstract class ForwardingProfile implements Profile {
       this.handlers.stream()
         .filter(HandlerForLayer.class::isInstance)
         .map(HandlerForLayer.class::cast)
+        .filter(l -> !l.name().equals(layer))
         .anyMatch(existing -> dependsOnLayer(existing.name(), layer));
   }
 

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/ForwardingProfile.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/ForwardingProfile.java
@@ -81,11 +81,19 @@ public abstract class ForwardingProfile implements Profile {
   }
 
   private boolean caresAboutLayer(String layer) {
-    return (onlyLayers.isEmpty() || onlyLayers.contains(layer)) && !excludeLayers.contains(layer);
+    if (excludeLayers.contains(layer) || excludeLayers.stream().anyMatch(excluded -> dependsOnLayer(layer, excluded))) {
+      return false;
+    }
+    return onlyLayers.isEmpty() || onlyLayers.contains(layer) ||
+      onlyLayers.stream().anyMatch(included -> dependsOnLayer(included, layer));
   }
 
   public boolean caresAboutLayer(Object obj) {
     return !(obj instanceof HandlerForLayer l) || caresAboutLayer(l.name());
+  }
+
+  public boolean dependsOnLayer(String dependent, String dependency) {
+    return false;
   }
 
   /**

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/ForwardingProfile.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/ForwardingProfile.java
@@ -83,8 +83,8 @@ public abstract class ForwardingProfile implements Profile {
   private boolean caresAboutLayer(String layer) {
     return ((onlyLayers.isEmpty() || onlyLayers.contains(layer)) && !excludeLayers.contains(layer)) ||
       this.handlers.stream()
-        .filter(h -> h instanceof HandlerForLayer)
-        .map(h -> (HandlerForLayer) h)
+        .filter(HandlerForLayer.class::isInstance)
+        .map(HandlerForLayer.class::cast)
         .anyMatch(existing -> dependsOnLayer(existing.name(), layer));
   }
 

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/ForwardingProfile.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/ForwardingProfile.java
@@ -81,20 +81,22 @@ public abstract class ForwardingProfile implements Profile {
   }
 
   private boolean caresAboutLayer(String layer) {
+    var dependencies = dependsOnLayer();
     return ((onlyLayers.isEmpty() || onlyLayers.contains(layer)) && !excludeLayers.contains(layer)) ||
       this.handlers.stream()
         .filter(HandlerForLayer.class::isInstance)
         .map(HandlerForLayer.class::cast)
         .filter(l -> !l.name().equals(layer))
-        .anyMatch(existing -> dependsOnLayer(existing.name(), layer));
+        .anyMatch(
+          existing -> dependencies.containsKey(existing.name()) && dependencies.get(existing.name()).contains(layer));
   }
 
   public boolean caresAboutLayer(Object obj) {
     return !(obj instanceof HandlerForLayer l) || caresAboutLayer(l.name());
   }
 
-  public boolean dependsOnLayer(String dependent, String dependency) {
-    return false;
+  public Map<String, List<String>> dependsOnLayer() {
+    return Map.of();
   }
 
   /**

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/ForwardingProfile.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/ForwardingProfile.java
@@ -81,11 +81,11 @@ public abstract class ForwardingProfile implements Profile {
   }
 
   private boolean caresAboutLayer(String layer) {
-    if (excludeLayers.contains(layer) || excludeLayers.stream().anyMatch(excluded -> dependsOnLayer(layer, excluded))) {
-      return false;
-    }
-    return onlyLayers.isEmpty() || onlyLayers.contains(layer) ||
-      onlyLayers.stream().anyMatch(included -> dependsOnLayer(included, layer));
+    return ((onlyLayers.isEmpty() || onlyLayers.contains(layer)) && !excludeLayers.contains(layer)) ||
+      this.handlers.stream()
+        .filter(h -> h instanceof HandlerForLayer)
+        .map(h -> (HandlerForLayer) h)
+        .anyMatch(existing -> dependsOnLayer(existing.name(), layer));
   }
 
   public boolean caresAboutLayer(Object obj) {

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/ForwardingProfile.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/ForwardingProfile.java
@@ -95,6 +95,20 @@ public abstract class ForwardingProfile implements Profile {
     return !(obj instanceof HandlerForLayer l) || caresAboutLayer(l.name());
   }
 
+  /**
+   * Indicate to {@link #caresAboutLayer(String)} what layers (dependents) rely on other layers (dependencies) so that
+   * methods like {@link #registerFeatureHandler(FeatureProcessor)}, {@link #registerHandler(Handler)} or
+   * {@link #registerSourceHandler(String, FeatureProcessor)} do register also those dependencies.
+   * <p>
+   * Dependencies are described as a map with dependent layer names as keys and lists containing dependency layer names
+   * as map values. Example: Layer named {@code transportation_name} depends on layer named {@code transportation}:
+   * <p>
+   * {@snippet :
+   * Map.of("transportation_name", List.of("transportation"));
+   * }
+   *
+   * @return a map describing dependencies
+   */
   public Map<String, List<String>> dependsOnLayer() {
     return Map.of();
   }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/ForwardingProfileTests.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/ForwardingProfileTests.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class ForwardingProfileTests {
@@ -454,5 +455,50 @@ class ForwardingProfileTests {
     testFeatures(List.of(Map.of(
       "_layer", "water"
     )), a);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "'--only-layers=water', water",
+    "'--exclude-layers=land,transportation,transportation_name', water",
+    "'--exclude-layers=land,transportation', water",
+    // transportation does not depend on any excluded layer and is not excluded => will be processed
+    "'--exclude-layers=land,transportation_name', water transportation",
+    "'--exclude-layers=land --only-layers=water,land', water",
+    "'--exclude-layers=transportation --only-layers=water,transportation,transportation_name', water",
+    // transportation does not depend on any excluded layer and is not excluded => will be processed
+    "'--exclude-layers=transportation_name --only-layers=water,transportation,transportation_name', water transportation",
+    "'--exclude-layers=transportation,transportation_name --only-layers=water,transportation,transportation_name', water",
+    "'--exclude-layers=transportation --only-layers=water,transportation_name', water",
+    // transportation does not depend on any excluded layer and is not excluded => will be processed
+    "'--exclude-layers=transportation_name --only-layers=water,transportation', water transportation",
+  })
+  void testLayerWithDepsCliArgFilter(String args, String expectedLayers) {
+    profile = new ForwardingProfile(PlanetilerConfig.from(Arguments.fromArgs(args.split(" ")))) {
+      @Override
+      public boolean dependsOnLayer(String dependent, String dependency) {
+        return "transportation_name".equals(dependent) && "transportation".equals(dependency);
+      }
+    };
+    record Processor(String name) implements ForwardingProfile.HandlerForLayer, ForwardingProfile.FeatureProcessor {
+
+      @Override
+      public void processFeature(SourceFeature sourceFeature, FeatureCollector features) {
+        features.point(name);
+      }
+    }
+
+    SourceFeature a = SimpleFeature.create(GeoUtils.EMPTY_POINT, Map.of("key", "value"), "source", "source layer", 1);
+    profile.registerHandler(new Processor("water"));
+    profile.registerHandler(new Processor("transportation"));
+    profile.registerHandler(new Processor("transportation_name"));
+    profile.registerHandler(new Processor("land"));
+
+    List<Map<String, Object>> expected = new ArrayList<>();
+    for (var expectedLayer : expectedLayers.split(" ")) {
+      expected.add(Map.of("_layer", expectedLayer));
+    }
+
+    testFeatures(expected, a);
   }
 }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/ForwardingProfileTests.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/ForwardingProfileTests.java
@@ -476,8 +476,8 @@ class ForwardingProfileTests {
   void testLayerWithDepsCliArgFilter(String args, String expectedLayers) {
     profile = new ForwardingProfile(PlanetilerConfig.from(Arguments.fromArgs(args.split(" ")))) {
       @Override
-      public boolean dependsOnLayer(String dependent, String dependency) {
-        return "transportation_name".equals(dependent) && "transportation".equals(dependency);
+      public Map<String, List<String>> dependsOnLayer() {
+        return Map.of("transportation_name", List.of("transportation"));
       }
     };
     record Processor(String name) implements ForwardingProfile.HandlerForLayer, ForwardingProfile.FeatureProcessor {

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/ForwardingProfileTests.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/ForwardingProfileTests.java
@@ -493,7 +493,7 @@ class ForwardingProfileTests {
     profile.registerHandler(new Processor("transportation"));
     profile.registerHandler(new Processor("transportation_name"));
     profile.registerHandler(new Processor("land"));
-    // profiles like OpenMapTiles will trying to add "transportation" once again to cover for dependency
+    // profiles like OpenMapTiles will try to add "transportation" once again to cover for dependency
     profile.registerHandler(new Processor("transportation"));
 
     List<Map<String, Object>> expected = new ArrayList<>();

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/ForwardingProfileTests.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/ForwardingProfileTests.java
@@ -461,16 +461,16 @@ class ForwardingProfileTests {
   @CsvSource({
     "'--only-layers=water', water",
     "'--exclude-layers=land,transportation,transportation_name', water",
-    "'--exclude-layers=land,transportation', water",
-    // transportation does not depend on any excluded layer and is not excluded => will be processed
+    // transportation excluded but transportation_name NOT => transportation will be processed
+    "'--exclude-layers=land,transportation', water transportation_name transportation",
     "'--exclude-layers=land,transportation_name', water transportation",
     "'--exclude-layers=land --only-layers=water,land', water",
-    "'--exclude-layers=transportation --only-layers=water,transportation,transportation_name', water",
-    // transportation does not depend on any excluded layer and is not excluded => will be processed
+    // transportation excluded but transportation_name NOT => transportation will be processed
+    "'--exclude-layers=transportation --only-layers=water,transportation,transportation_name', water transportation_name transportation",
     "'--exclude-layers=transportation_name --only-layers=water,transportation,transportation_name', water transportation",
     "'--exclude-layers=transportation,transportation_name --only-layers=water,transportation,transportation_name', water",
-    "'--exclude-layers=transportation --only-layers=water,transportation_name', water",
-    // transportation does not depend on any excluded layer and is not excluded => will be processed
+    // transportation excluded but transportation_name NOT => transportation will be processed
+    "'--exclude-layers=transportation --only-layers=water,transportation_name', water transportation_name transportation",
     "'--exclude-layers=transportation_name --only-layers=water,transportation', water transportation",
   })
   void testLayerWithDepsCliArgFilter(String args, String expectedLayers) {
@@ -493,6 +493,8 @@ class ForwardingProfileTests {
     profile.registerHandler(new Processor("transportation"));
     profile.registerHandler(new Processor("transportation_name"));
     profile.registerHandler(new Processor("land"));
+    // profiles like OpenMapTiles will trying to add "transportation" once again to cover for dependency
+    profile.registerHandler(new Processor("transportation"));
 
     List<Map<String, Object>> expected = new ArrayList<>();
     for (var expectedLayer : expectedLayers.split(" ")) {


### PR DESCRIPTION
... so that `caresAboutLayer()` can handle situations when some layer depends on another layer, e.g. for example in OpenMapTiles:

- <s>when 'transportation' is excluded, then also 'transportation_name' needs to be also treated as excluded</s>
- when 'transportation' is included (e.g. mentioned in --only-layers or not exluded) then 'transportation_name' needs to be also treated as included

This is a follow-up on #968.