### PR TITLE
rename LayerPostProcesser to LayerPostProcessor

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/ForwardingProfile.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/ForwardingProfile.java
@@ -28,7 +28,7 @@ import java.util.function.Consumer;
  * <li>{@link FeatureProcessor} to handle features from a particular source (added through
  * {@link #registerSourceHandler(String, FeatureProcessor)})</li>
  * <li>{@link FinishHandler} to be notified whenever we finish processing each source</li>
- * <li>{@link LayerPostProcesser} to post-process features in a layer before rendering the output tile</li>
+ * <li>{@link LayerPostProcessor} to post-process features in a layer before rendering the output tile</li>
  * <li>{@link TilePostProcessor} to post-process features in a tile before rendering the output tile</li>
  * </ul>
  * See {@code OpenMapTilesProfile} for a full implementation using this framework.
@@ -44,8 +44,8 @@ public abstract class ForwardingProfile implements Profile {
   private final List<OsmRelationPreprocessor> osmRelationPreprocessors = new ArrayList<>();
   /** Handlers that get a callback when each source is finished reading. */
   private final List<FinishHandler> finishHandlers = new ArrayList<>();
-  /** Map from layer name to its handler if it implements {@link LayerPostProcesser}. */
-  private final Map<String, List<LayerPostProcesser>> layerPostProcessors = new HashMap<>();
+  /** Map from layer name to its handler if it implements {@link LayerPostProcessor}. */
+  private final Map<String, List<LayerPostProcessor>> layerPostProcessors = new HashMap<>();
   /** List of handlers that implement {@link TilePostProcessor}. */
   private final List<TilePostProcessor> tilePostProcessors = new ArrayList<>();
   /** List of handlers that implements {@link FeatureProcessor} along with a filter expression. */
@@ -147,7 +147,7 @@ public abstract class ForwardingProfile implements Profile {
 
   /**
    * Call {@code handler} for different events based on which interfaces {@code handler} implements:
-   * {@link OsmRelationPreprocessor}, {@link FinishHandler}, {@link TilePostProcessor} or {@link LayerPostProcesser}.
+   * {@link OsmRelationPreprocessor}, {@link FinishHandler}, {@link TilePostProcessor} or {@link LayerPostProcessor}.
    */
   public void registerHandler(Handler handler) {
     if (!caresAboutLayer(handler)) {
@@ -166,7 +166,7 @@ public abstract class ForwardingProfile implements Profile {
     if (handler instanceof FinishHandler finishHandler) {
       finishHandlers.add(finishHandler);
     }
-    if (handler instanceof LayerPostProcesser postProcessor) {
+    if (handler instanceof LayerPostProcessor postProcessor) {
       layerPostProcessors.computeIfAbsent(postProcessor.name(), name -> new ArrayList<>())
         .add(postProcessor);
     }
@@ -247,7 +247,7 @@ public abstract class ForwardingProfile implements Profile {
   public List<VectorTile.Feature> postProcessLayerFeatures(String layer, int zoom, List<VectorTile.Feature> items)
     throws GeometryException {
     // delegate feature post-processing to each layer, if it implements FeaturePostProcessor
-    List<LayerPostProcesser> postProcessers = layerPostProcessors.get(layer);
+    List<LayerPostProcessor> postProcessers = layerPostProcessors.get(layer);
     List<VectorTile.Feature> result = makeMutable(items);
     if (postProcessers != null) {
       for (var handler : postProcessers) {
@@ -350,7 +350,7 @@ public abstract class ForwardingProfile implements Profile {
   }
 
   /** Handlers should implement this interface to post-process vector tile features before emitting an output layer. */
-  public interface LayerPostProcesser extends HandlerForLayer {
+  public interface LayerPostProcessor extends HandlerForLayer {
 
     /**
      * Apply any post-processing to features in this output layer of a tile before writing it to the output archive.
@@ -361,9 +361,13 @@ public abstract class ForwardingProfile implements Profile {
     List<VectorTile.Feature> postProcess(int zoom, List<VectorTile.Feature> items) throws GeometryException;
   }
 
-  /** @deprecated use {@link LayerPostProcesser} or {@link TilePostProcessor} instead */
+  /** @deprecated use {@link LayerPostProcessor} instead */
   @Deprecated(forRemoval = true)
-  public interface FeaturePostProcessor extends LayerPostProcesser {}
+  public interface LayerPostProcesser extends LayerPostProcessor {}
+
+  /** @deprecated use {@link LayerPostProcessor} or {@link TilePostProcessor} instead */
+  @Deprecated(forRemoval = true)
+  public interface FeaturePostProcessor extends LayerPostProcessor {}
 
   /**
    * Handlers should implement this interface to post-process all features in a vector tile before writing to an

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/ForwardingProfileTests.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/ForwardingProfileTests.java
@@ -157,7 +157,7 @@ class ForwardingProfileTests {
   }
 
   @Test
-  void testLayerPostProcesser() throws GeometryException {
+  void testLayerPostProcessor() throws GeometryException {
     VectorTile.Feature feature = new VectorTile.Feature(
       "layer",
       1,
@@ -167,7 +167,7 @@ class ForwardingProfileTests {
     assertEquals(List.of(feature), profile.postProcessLayerFeatures("layer", 0, List.of(feature)));
 
     // ignore null response
-    profile.registerHandler(new ForwardingProfile.LayerPostProcesser() {
+    profile.registerHandler(new ForwardingProfile.LayerPostProcessor() {
       @Override
       public List<VectorTile.Feature> postProcess(int zoom, List<VectorTile.Feature> items) {
         return null;
@@ -181,7 +181,7 @@ class ForwardingProfileTests {
     assertEquals(List.of(feature), profile.postProcessLayerFeatures("a", 0, List.of(feature)));
 
     // allow mutations on initial input
-    profile.registerHandler(new ForwardingProfile.LayerPostProcesser() {
+    profile.registerHandler(new ForwardingProfile.LayerPostProcessor() {
       @Override
       public List<VectorTile.Feature> postProcess(int zoom, List<VectorTile.Feature> items) {
         items.set(0, items.getFirst());
@@ -196,7 +196,7 @@ class ForwardingProfileTests {
     assertEquals(List.of(feature), profile.postProcessLayerFeatures("a", 0, List.of(feature)));
 
     // empty list removes
-    profile.registerHandler(new ForwardingProfile.LayerPostProcesser() {
+    profile.registerHandler(new ForwardingProfile.LayerPostProcessor() {
       @Override
       public List<VectorTile.Feature> postProcess(int zoom, List<VectorTile.Feature> items) {
         return List.of();
@@ -212,7 +212,7 @@ class ForwardingProfileTests {
     assertEquals(List.of(feature), profile.postProcessLayerFeatures("b", 0, List.of(feature)));
 
     // allow mutations on subsequent input
-    profile.registerHandler(new ForwardingProfile.LayerPostProcesser() {
+    profile.registerHandler(new ForwardingProfile.LayerPostProcessor() {
       @Override
       public List<VectorTile.Feature> postProcess(int zoom, List<VectorTile.Feature> items) {
         items.add(null);
@@ -229,7 +229,7 @@ class ForwardingProfileTests {
     assertEquals(List.of(), profile.postProcessLayerFeatures("a", 0, new ArrayList<>(List.of(feature))));
 
     // 2 handlers for same layer run one after another
-    var skip1 = new ForwardingProfile.LayerPostProcesser() {
+    var skip1 = new ForwardingProfile.LayerPostProcessor() {
       @Override
       public List<VectorTile.Feature> postProcess(int zoom, List<VectorTile.Feature> items) {
         return items.stream().skip(1).toList();
@@ -242,7 +242,7 @@ class ForwardingProfileTests {
     };
     profile.registerHandler(skip1);
     profile.registerHandler(skip1);
-    profile.registerHandler(new ForwardingProfile.LayerPostProcesser() {
+    profile.registerHandler(new ForwardingProfile.LayerPostProcessor() {
       @Override
       public List<VectorTile.Feature> postProcess(int zoom, List<VectorTile.Feature> items) {
         return null; // ensure that returning null after initial post-processors run keeps the postprocessed result


### PR DESCRIPTION
Unfortunately this new interface name contained a typo.

Fix the typo and mark the typo as deprecated!