### PR TITLE
Support yaml merge operator

### DIFF
--- a/planetiler-core/pom.xml
+++ b/planetiler-core/pom.xml
@@ -130,6 +130,11 @@
       <artifactId>snakeyaml-engine</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+      <version>2.3</version>
+    </dependency>
+    <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient</artifactId>
       <version>${prometheus.version}</version>

--- a/planetiler-core/pom.xml
+++ b/planetiler-core/pom.xml
@@ -130,11 +130,6 @@
       <artifactId>snakeyaml-engine</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.yaml</groupId>
-      <artifactId>snakeyaml</artifactId>
-      <version>2.3</version>
-    </dependency>
-    <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient</artifactId>
       <version>${prometheus.version}</version>

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/util/YAML.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/util/YAML.java
@@ -1,6 +1,7 @@
 package com.onthegomap.planetiler.util;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.onthegomap.planetiler.reader.FileFormatException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -8,9 +9,12 @@ import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.snakeyaml.engine.v2.api.Load;
 import org.snakeyaml.engine.v2.api.LoadSettings;
 
@@ -43,32 +47,43 @@ public class YAML {
     }
   }
 
+  private static void handleMergeOperator(Object parsed) {
+    handleMergeOperator(parsed, Collections.newSetFromMap(new IdentityHashMap<>()));
+  }
+
   /**
    * SnakeYaml doesn't handle the <a href="https://yaml.org/type/merge.html">merge operator</a> so manually post-process
    * the parsed yaml object to merge referenced objects into the parent one.
    */
-  private static void handleMergeOperator(Object parsed) {
+  private static void handleMergeOperator(Object parsed, Set<Object> parentNodes) {
+    if (!parentNodes.add(parsed)) {
+      throw new FileFormatException("Illegal recursive reference in yaml file");
+    }
     if (parsed instanceof Map<?, ?> map) {
       Object toMerge = map.remove("<<");
       if (toMerge != null) {
         var orig = new LinkedHashMap<>(map);
         // to preserve the map key order we insert the merged operator objects first, then the original ones
         map.clear();
-        mergeInto(map, toMerge, false);
-        mergeInto(map, orig, true);
+        mergeInto(map, toMerge, false, parentNodes);
+        mergeInto(map, orig, true, parentNodes);
       }
       for (var value : map.values()) {
-        handleMergeOperator(value);
+        handleMergeOperator(value, parentNodes);
       }
     } else if (parsed instanceof List<?> list) {
       for (var item : list) {
-        handleMergeOperator(item);
+        handleMergeOperator(item, parentNodes);
       }
     }
+    parentNodes.remove(parsed);
   }
 
   @SuppressWarnings("rawtypes")
-  private static void mergeInto(Map dest, Object source, boolean replace) {
+  private static void mergeInto(Map dest, Object source, boolean replace, Set<Object> parentNodes) {
+    if (!parentNodes.add(source)) {
+      throw new FileFormatException("Illegal recursive reference in yaml file");
+    }
     if (source instanceof Map<?, ?> map) {
       if (replace) {
         dest.putAll(map);
@@ -77,9 +92,10 @@ public class YAML {
       }
     } else if (source instanceof List<?> nesteds) {
       for (var nested : nesteds) {
-        mergeInto(dest, nested, replace);
+        mergeInto(dest, nested, replace, parentNodes);
       }
     }
+    parentNodes.remove(source);
   }
 
   public static <T> T load(String config, Class<T> clazz) {

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/util/YAML.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/util/YAML.java
@@ -43,6 +43,10 @@ public class YAML {
     }
   }
 
+  /**
+   * SnakeYaml doesn't handle the <a href="https://yaml.org/type/merge.html">merge operator</a> so manually post-process
+   * the parsed yaml object to merge referenced objects into the parent one.
+   */
   private static void handleMergeOperator(Object parsed) {
     if (parsed instanceof Map<?, ?> map) {
       Object toMerge = map.remove("<<");

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/util/YAML.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/util/YAML.java
@@ -51,11 +51,11 @@ public class YAML {
     if (parsed instanceof Map<?, ?> map) {
       Object toMerge = map.remove("<<");
       if (toMerge != null) {
-        Map<?, ?> orig = new LinkedHashMap<>(map);
+        var orig = new LinkedHashMap<>(map);
         // to preserve the map key order we insert the merged operator objects first, then the original ones
         map.clear();
-        mergeInto(map, toMerge);
-        mergeInto(map, orig);
+        mergeInto(map, toMerge, false);
+        mergeInto(map, orig, true);
       }
       for (var value : map.values()) {
         handleMergeOperator(value);
@@ -68,12 +68,16 @@ public class YAML {
   }
 
   @SuppressWarnings("rawtypes")
-  private static void mergeInto(Map dest, Object source) {
+  private static void mergeInto(Map dest, Object source, boolean replace) {
     if (source instanceof Map<?, ?> map) {
-      dest.putAll(map);
+      if (replace) {
+        dest.putAll(map);
+      } else {
+        map.forEach(dest::putIfAbsent);
+      }
     } else if (source instanceof List<?> nesteds) {
       for (var nested : nesteds) {
-        mergeInto(dest, nested);
+        mergeInto(dest, nested, replace);
       }
     }
   }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/util/YamlTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/util/YamlTest.java
@@ -123,7 +123,7 @@ class YamlTest {
         a: 2
         b: 3
       dest:
-        a: 2
+        a: 1 # from label1 since it came first
         b: 4
         c: 5
         z: 1
@@ -182,10 +182,11 @@ class YamlTest {
       - &BIG { r: 10 }
       - &SMALL { r: 1 }
       - # Merge one map
-	      << : *CENTER
-	      r: 10
-	      label: center/big
+       << : *CENTER
+       r: 10
+       label: center/big
       """);
+  }
 
   @Test
   void testMergeOperatorFromDraft2() {

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/util/YamlTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/util/YamlTest.java
@@ -164,6 +164,76 @@ class YamlTest {
       """);
   }
 
+  @Test
+  void testMergeOperatorFromDraft1() {
+    assertSameYaml("""
+      - { x: 1, y: 2 }
+      - { x: 0, y: 2 }
+      - { r: 10 }
+      - { r: 1 }
+      - # Explicit keys
+        x: 1
+        y: 2
+        r: 10
+        label: center/big
+      """, """
+      - &CENTER { x: 1, y: 2 }
+      - &LEFT { x: 0, y: 2 }
+      - &BIG { r: 10 }
+      - &SMALL { r: 1 }
+      - # Merge one map
+	      << : *CENTER
+	      r: 10
+	      label: center/big
+      """);
+
+  @Test
+  void testMergeOperatorFromDraft2() {
+    assertSameYaml("""
+      - { x: 1, y: 2 }
+      - { x: 0, y: 2 }
+      - { r: 10 }
+      - { r: 1 }
+      - # Explicit keys
+        x: 1
+        y: 2
+        r: 10
+        label: center/big
+      """, """
+      - &CENTER { x: 1, y: 2 }
+      - &LEFT { x: 0, y: 2 }
+      - &BIG { r: 10 }
+      - &SMALL { r: 1 }
+      - # Merge multiple maps
+        << : [ *CENTER, *BIG ]
+        label: center/big
+      """);
+  }
+
+  @Test
+  void testMergeOperatorFromDraft3() {
+    assertSameYaml("""
+      - { x: 1, y: 2 }
+      - { x: 0, y: 2 }
+      - { r: 10 }
+      - { r: 1 }
+      - # Explicit keys
+        x: 1
+        y: 2
+        r: 10
+        label: center/big
+      """, """
+      - &CENTER { x: 1, y: 2 }
+      - &LEFT { x: 0, y: 2 }
+      - &BIG { r: 10 }
+      - &SMALL { r: 1 }
+      - # Override
+        << : [ *BIG, *LEFT, *SMALL ]
+        x: 1
+        label: center/big
+      """);
+  }
+
   private static void assertSameYaml(String a, String b) {
     assertEquals(
       YAML.load(b, Object.class),

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/util/YamlTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/util/YamlTest.java
@@ -45,4 +45,129 @@ class YamlTest {
     }
     assertEquals(expected, YAML.load(builder.toString(), Map.class));
   }
+
+  @Test
+  void testMergeOperator() {
+    assertSameYaml("""
+      source: &label
+        a: 1
+      dest:
+        <<: *label
+        b: 2
+      """, """
+      source:
+        a: 1
+      dest:
+        a: 1
+        b: 2
+      """);
+  }
+
+  @Test
+  void testMergeOperatorNested() {
+    assertSameYaml("""
+      source: &label
+        a: 1
+      dest:
+        l1:
+          l2:
+            l3:
+              <<: *label
+              b: 2
+      """, """
+      source:
+        a: 1
+      dest:
+        l1:
+          l2:
+            l3:
+              a: 1
+              b: 2
+      """);
+  }
+
+  @Test
+  void testMergeOperatorOverride() {
+    assertSameYaml("""
+      source: &label
+        a: 1
+      dest:
+        <<: *label
+        a: 2
+      """, """
+      source:
+        a: 1
+      dest:
+        a: 2
+      """);
+  }
+
+  @Test
+  void testMergeOperatorMultiple() {
+    assertSameYaml("""
+      source: &label1
+        a: 1
+        z: 1
+      source2: &label2
+        a: 2
+        b: 3
+      dest:
+        <<: [*label1, *label2]
+        b: 4
+        c: 5
+      """, """
+      source:
+        a: 1
+        z: 1
+      source2:
+        a: 2
+        b: 3
+      dest:
+        a: 2
+        b: 4
+        c: 5
+        z: 1
+      """);
+  }
+
+  @Test
+  void testMergeNotAnchor() {
+    assertSameYaml("""
+      <<:
+        a: 1
+        b: 2
+      b: 3
+      c: 4
+      """, """
+      a: 1
+      b: 3
+      c: 4
+      """);
+  }
+
+  @Test
+  void testMergeOperatorSecond() {
+    assertSameYaml("""
+      source: &label
+        a: 1
+      dest:
+        c: 3
+        <<: *label
+        b: 2
+      """, """
+      source:
+        a: 1
+      dest:
+        a: 1
+        b: 2
+        c: 3
+      """);
+  }
+
+  private static void assertSameYaml(String a, String b) {
+    assertEquals(
+      YAML.load(b, Object.class),
+      YAML.load(a, Object.class)
+    );
+  }
 }


### PR DESCRIPTION
Support yaml merge operator so you can do things like this in custom yaml files to reuse a block and override values in it.

```yaml
source: &label
  key: value
dest:
  <<: *label
  other_key: other_value
```

Fixes #1038 