### PR TITLE
Allow dynamic expressions on left hand side of match statements

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/expression/DataType.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/expression/DataType.java
@@ -2,13 +2,12 @@ package com.onthegomap.planetiler.expression;
 
 import com.onthegomap.planetiler.reader.WithTags;
 import com.onthegomap.planetiler.util.Parse;
-import java.util.function.BiFunction;
 import java.util.function.UnaryOperator;
 
 /**
  * Destination data types for an attribute that link the type to functions that can parse the value from an input object
  */
-public enum DataType implements BiFunction<WithTags, String, Object> {
+public enum DataType implements TypedGetter {
   GET_STRING("string", WithTags::getString, Parse::parseStringOrNull),
   GET_BOOLEAN("boolean", WithTags::getBoolean, Parse::bool),
   GET_DIRECTION("direction", WithTags::getDirection, Parse::direction),
@@ -17,11 +16,11 @@ public enum DataType implements BiFunction<WithTags, String, Object> {
   GET_DOUBLE("double", Parse::parseDoubleOrNull),
   GET_TAG("get", WithTags::getTag, s -> s);
 
-  private final BiFunction<WithTags, String, Object> getter;
+  private final TypedGetter getter;
   private final String id;
   private final UnaryOperator<Object> parser;
 
-  DataType(String id, BiFunction<WithTags, String, Object> getter, UnaryOperator<Object> parser) {
+  DataType(String id, TypedGetter getter, UnaryOperator<Object> parser) {
     this.id = id;
     this.getter = getter;
     this.parser = parser;

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/expression/Expression.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/expression/Expression.java
@@ -473,6 +473,10 @@ public interface Expression extends Simplifiable<Expression> {
 
     @Override
     public Expression partialEvaluate(PartialInput input) {
+      if (field == null) {
+        // dynamic getters always need to be evaluated
+        return this;
+      }
       Object value = input.getTag(field);
       return value == null ? this : constBool(evaluate(new ArrayList<>(), value));
     }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/expression/Expression.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/expression/Expression.java
@@ -496,7 +496,9 @@ public interface Expression extends Simplifiable<Expression> {
         return false;
       } else {
         String str = value.toString();
-        if (exactMatches.contains(str)) {
+        // when field is null, we rely on a dynamic getter function so when exactMatches is empty we match
+        // on any value
+        if (exactMatches.contains(str) || (field == null && exactMatches.isEmpty())) {
           matchKeys.add(field);
           return true;
         }
@@ -556,6 +558,11 @@ public interface Expression extends Simplifiable<Expression> {
     @Override
     public int hashCode() {
       return Objects.hash(field, values, exactMatches, patternString(), matchWhenMissing, valueGetter);
+    }
+
+    public boolean mustAlwaysEvaluate() {
+      // when field is null we rely on a dynamic getter function
+      return field == null || matchWhenMissing;
     }
   }
 

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/expression/Expression.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/expression/Expression.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
@@ -91,7 +90,7 @@ public interface Expression extends Simplifiable<Expression> {
    * <p>
    * {@code values} can contain exact matches, "%text%" to match any value containing "text", or "" to match any value.
    */
-  static MatchAny matchAnyTyped(String field, BiFunction<WithTags, String, Object> typeGetter, Object... values) {
+  static MatchAny matchAnyTyped(String field, TypedGetter typeGetter, Object... values) {
     return matchAnyTyped(field, typeGetter, List.of(values));
   }
 
@@ -101,7 +100,7 @@ public interface Expression extends Simplifiable<Expression> {
    * <p>
    * {@code values} can contain exact matches, "%text%" to match any value containing "text", or "" to match any value.
    */
-  static MatchAny matchAnyTyped(String field, BiFunction<WithTags, String, Object> typeGetter,
+  static MatchAny matchAnyTyped(String field, TypedGetter typeGetter,
     List<?> values) {
     return MatchAny.from(field, typeGetter, values);
   }
@@ -405,10 +404,10 @@ public interface Expression extends Simplifiable<Expression> {
     String field, List<?> values, Set<String> exactMatches,
     Pattern pattern,
     boolean matchWhenMissing,
-    BiFunction<WithTags, String, Object> valueGetter
+    TypedGetter valueGetter
   ) implements Expression {
 
-    static MatchAny from(String field, BiFunction<WithTags, String, Object> valueGetter, List<?> values) {
+    static MatchAny from(String field, TypedGetter valueGetter, List<?> values) {
       List<String> exactMatches = new ArrayList<>();
       List<String> patterns = new ArrayList<>();
 
@@ -512,7 +511,13 @@ public interface Expression extends Simplifiable<Expression> {
 
     @Override
     public Expression simplifyOnce() {
-      return isMatchAnything() ? matchField(field) : this;
+      if (isMatchAnything()) {
+        return matchField(field);
+      } else if (valueGetter instanceof Simplifiable<?> simplifiable) {
+        return new MatchAny(field, values, exactMatches, pattern, matchWhenMissing,
+          (TypedGetter) simplifiable.simplifyOnce());
+      }
+      return this;
     }
 
     @Override

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/expression/MultiExpression.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/expression/MultiExpression.java
@@ -60,7 +60,7 @@ public record MultiExpression<T>(List<Entry<T>> expressions) implements Simplifi
       case Expression.Or(var children) -> children.stream().anyMatch(MultiExpression::mustAlwaysEvaluate);
       case Expression.And(var children) -> children.stream().allMatch(MultiExpression::mustAlwaysEvaluate);
       case Expression.Not(var child) -> !mustAlwaysEvaluate(child);
-      case Expression.MatchAny any when any.matchWhenMissing() -> true;
+      case Expression.MatchAny any when any.mustAlwaysEvaluate() -> true;
       case null, default -> !(expression instanceof Expression.MatchAny) &&
           !(expression instanceof Expression.MatchField) &&
           !FALSE.equals(expression);
@@ -79,7 +79,7 @@ public record MultiExpression<T>(List<Entry<T>> expressions) implements Simplifi
         or.children().forEach(child -> getRelevantKeys(child, acceptKey));
       } else if (exp instanceof Expression.MatchField field) {
         acceptKey.accept(field.field());
-      } else if (exp instanceof Expression.MatchAny any && !any.matchWhenMissing()) {
+      } else if (exp instanceof Expression.MatchAny any && !any.mustAlwaysEvaluate()) {
         acceptKey.accept(any.field());
       }
       // ignore not case since not(matchAny("field", "")) should track "field" as a relevant key, but that gets

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/expression/TypedGetter.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/expression/TypedGetter.java
@@ -1,0 +1,8 @@
+package com.onthegomap.planetiler.expression;
+
+import com.onthegomap.planetiler.reader.WithTags;
+
+@FunctionalInterface
+public interface TypedGetter {
+  Object apply(WithTags withTags, String tag);
+}

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/expression/ExpressionTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/expression/ExpressionTest.java
@@ -351,6 +351,19 @@ class ExpressionTest {
   }
 
   @Test
+  void testPartialEvaluateMatchAnyDynamicGetter() {
+    var expr = matchAnyTyped(null, ((withTags, tag) -> ""), 1, 2, 3);
+    assertEquals(expr, expr.partialEvaluate(new PartialInput(Set.of(), Set.of(), Map.of("other", "value"), Set.of())));
+    assertEquals(expr, expr.partialEvaluate(new PartialInput(Set.of(), Set.of(), null, Set.of())));
+    assertEquals(expr, expr.partialEvaluate(new PartialInput(Set.of(), Set.of(), Map.of("field", "value1"), Set.of())));
+    assertEquals(expr, expr.partialEvaluate(new PartialInput(Set.of(), Set.of(), Map.of("field", "other"), Set.of())));
+    assertEquals(expr,
+      expr.partialEvaluate(new PartialInput(Set.of(), Set.of(), Map.of("field", "other..."), Set.of())));
+    assertEquals(expr, expr.partialEvaluate(
+      new PartialInput(Set.of(), Set.of(), Map.of("field", "not a value"), Set.of())));
+  }
+
+  @Test
   void testPartialEvaluateMatchGeometryType() {
     var expr = matchGeometryType(GeometryType.POINT);
     assertEquals(expr, expr.partialEvaluate(new PartialInput(Set.of(), Set.of(), Map.of(), Set.of())));

--- a/planetiler-custommap/README.md
+++ b/planetiler-custommap/README.md
@@ -218,6 +218,7 @@ A feature is a defined set of objects that meet a specified filter criteria.
 - `geometry` - A string enum that indicates which geometry types to include, and how to transform them. Can be one
   of:
   - `point` `line` or `polygon` to pass the original feature through
+  - `any` (default) to pass the original feature through regardless of geometry type
   - `polygon_centroid` to match on polygons, and emit a point at the center
   - `line_centroid` to match on lines, and emit a point at the center
   - `centroid` to match any geometry, and emit a point at the center

--- a/planetiler-custommap/planetiler.schema.json
+++ b/planetiler-custommap/planetiler.schema.json
@@ -342,9 +342,6 @@
     },
     "feature": {
       "type": "object",
-      "required": [
-        "geometry"
-      ],
       "properties": {
         "geometry": {
           "description": "Include objects of a certain geometry type",

--- a/planetiler-custommap/planetiler.schema.json
+++ b/planetiler-custommap/planetiler.schema.json
@@ -350,6 +350,7 @@
           "description": "Include objects of a certain geometry type",
           "type": "string",
           "enum": [
+            "any",
             "point",
             "line",
             "polygon",

--- a/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/BooleanExpressionParser.java
+++ b/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/BooleanExpressionParser.java
@@ -123,10 +123,7 @@ public class BooleanExpressionParser<T extends ScriptContext> {
         if (isAny) {
           values = List.of();
         }
-        return matchAnyTyped(null,
-          (withTags, any) -> context.clazz().isInstance(withTags) ?
-            expression.apply(context.clazz().cast(withTags)) : null,
-          values);
+        return matchAnyTyped(null, expression, values);
       }
       String field = unescape(key);
       if (isAny) {

--- a/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/BooleanExpressionParser.java
+++ b/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/BooleanExpressionParser.java
@@ -110,25 +110,30 @@ public class BooleanExpressionParser<T extends ScriptContext> {
     } else if (IS_NOT.test(key)) {
       // __not__ negates its children
       return not(parse(value));
-    } else if (value == null || IS_ANY.test(value.toString()) ||
-      (value instanceof Collection<?> values &&
-        values.stream().anyMatch(d -> d != null && IS_ANY.test(d.toString().trim())))) {
-      //If only a key is provided, with no value, match any object tagged with that key.
-      return matchField(unescape(key));
-
-    } else if (value instanceof Collection<?> values) {
-      //If a collection is provided, match any of these values.
-      return matchAnyTyped(
-        unescape(key),
-        tagValueProducer.valueGetterForKey(key),
-        values.stream().map(BooleanExpressionParser::unescape).toList());
-
     } else {
-      //Otherwise, a key and single value were passed, so match that exact tag
-      return matchAnyTyped(
-        unescape(key),
-        tagValueProducer.valueGetterForKey(key),
-        unescape(value));
+      //If only a key is provided, with no value, match any object tagged with that key.
+      boolean isAny = value == null || IS_ANY.test(value.toString()) ||
+        (value instanceof Collection<?> values &&
+          values.stream().anyMatch(d -> d != null && IS_ANY.test(d.toString().trim())));
+      //If a collection or single item are provided, match any of these values.
+      List<?> values = (value instanceof Collection<?> items ? items : value == null ? List.of() : List.of(value))
+        .stream().map(BooleanExpressionParser::unescape).toList();
+      if (ConfigExpressionScript.isScript(key)) {
+        var expression = ConfigExpressionScript.parse(ConfigExpressionScript.extractScript(key), context);
+        if (isAny) {
+          values = List.of();
+        }
+        return matchAnyTyped(null,
+          (withTags, any) -> context.clazz().isInstance(withTags) ?
+            expression.apply(context.clazz().cast(withTags)) : null,
+          values);
+      }
+      String field = unescape(key);
+      if (isAny) {
+        return matchField(field);
+      } else {
+        return matchAnyTyped(field, tagValueProducer.valueGetterForKey(key), values);
+      }
     }
   }
 }

--- a/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/ConfigExpressionParser.java
+++ b/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/ConfigExpressionParser.java
@@ -51,7 +51,7 @@ public class ConfigExpressionParser<I extends ScriptContext> {
    */
   public static <I extends ScriptContext, O> ConfigExpression<I, O> parse(Object object,
     TagValueProducer tagValueProducer, ScriptEnvironment<I> context, Class<O> outputClass) {
-    return new ConfigExpressionParser<>(tagValueProducer, context).parse(object, outputClass).simplify();
+    return new ConfigExpressionParser<>(tagValueProducer, context).parse(object, outputClass);
   }
 
   /**

--- a/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/ConfigExpressionParser.java
+++ b/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/ConfigExpressionParser.java
@@ -51,7 +51,7 @@ public class ConfigExpressionParser<I extends ScriptContext> {
    */
   public static <I extends ScriptContext, O> ConfigExpression<I, O> parse(Object object,
     TagValueProducer tagValueProducer, ScriptEnvironment<I> context, Class<O> outputClass) {
-    return new ConfigExpressionParser<>(tagValueProducer, context).parse(object, outputClass);
+    return new ConfigExpressionParser<>(tagValueProducer, context).parse(object, outputClass).simplify();
   }
 
   /**

--- a/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/TagValueProducer.java
+++ b/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/TagValueProducer.java
@@ -3,11 +3,11 @@ package com.onthegomap.planetiler.custommap;
 import static com.onthegomap.planetiler.expression.DataType.GET_TAG;
 
 import com.onthegomap.planetiler.expression.DataType;
+import com.onthegomap.planetiler.expression.TypedGetter;
 import com.onthegomap.planetiler.reader.WithTags;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
@@ -17,7 +17,7 @@ import java.util.function.UnaryOperator;
 public class TagValueProducer {
   public static final TagValueProducer EMPTY = new TagValueProducer(null);
 
-  private final Map<String, BiFunction<WithTags, String, Object>> valueRetriever = new HashMap<>();
+  private final Map<String, TypedGetter> valueRetriever = new HashMap<>();
 
   private final Map<String, String> keyType = new HashMap<>();
 
@@ -50,7 +50,7 @@ public class TagValueProducer {
   /**
    * Returns a function that extracts the value for {@code key} from a {@link WithTags} instance.
    */
-  public BiFunction<WithTags, String, Object> valueGetterForKey(String key) {
+  public TypedGetter valueGetterForKey(String key) {
     return valueRetriever.getOrDefault(key, GET_TAG);
   }
 

--- a/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/TypeConversion.java
+++ b/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/TypeConversion.java
@@ -3,6 +3,7 @@ package com.onthegomap.planetiler.custommap;
 import com.onthegomap.planetiler.util.Parse;
 import java.util.List;
 import java.util.function.Function;
+import org.projectnessie.cel.common.types.NullT;
 
 /**
  * Utility for convert between types in a forgiving way (parse strings to get a number, call toString to get a string,
@@ -49,6 +50,9 @@ public class TypeConversion {
    */
   @SuppressWarnings("unchecked")
   public static <O> O convert(Object in, Class<O> out) {
+    if (in == NullT.NullValue) {
+      return null;
+    }
     if (in == null || out.isInstance(in)) {
       return (O) in;
     }

--- a/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/configschema/FeatureGeometry.java
+++ b/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/configschema/FeatureGeometry.java
@@ -1,5 +1,6 @@
 package com.onthegomap.planetiler.custommap.configschema;
 
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.onthegomap.planetiler.FeatureCollector;
 import com.onthegomap.planetiler.expression.Expression;
@@ -8,6 +9,8 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 public enum FeatureGeometry {
+  @JsonProperty("any") @JsonEnumDefaultValue
+  ANY(GeometryType.UNKNOWN, FeatureCollector::anyGeometry),
   @JsonProperty("point")
   POINT(GeometryType.POINT, FeatureCollector::point),
   @JsonProperty("line")

--- a/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/configschema/FeatureItem.java
+++ b/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/configschema/FeatureItem.java
@@ -10,7 +10,7 @@ public record FeatureItem(
   @JsonProperty("min_zoom") Object minZoom,
   @JsonProperty("max_zoom") Object maxZoom,
   @JsonProperty("min_size") Object minSize,
-  @JsonProperty(required = true) FeatureGeometry geometry,
+  @JsonProperty FeatureGeometry geometry,
   @JsonProperty("include_when") Object includeWhen,
   @JsonProperty("exclude_when") Object excludeWhen,
   Collection<AttributeDefinition> attributes
@@ -19,5 +19,10 @@ public record FeatureItem(
   @Override
   public Collection<AttributeDefinition> attributes() {
     return attributes == null ? List.of() : attributes;
+  }
+
+  @Override
+  public FeatureGeometry geometry() {
+    return geometry == null ? FeatureGeometry.ANY : geometry;
   }
 }

--- a/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/expression/ConfigExpressionScript.java
+++ b/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/expression/ConfigExpressionScript.java
@@ -173,4 +173,9 @@ public class ConfigExpressionScript<I extends ScriptContext, O> implements Confi
     }
     return this;
   }
+
+  @Override
+  public ScriptEnvironment<I> environment() {
+    return descriptor;
+  }
 }

--- a/planetiler-custommap/src/test/java/com/onthegomap/planetiler/custommap/ConfigExpressionParserTest.java
+++ b/planetiler-custommap/src/test/java/com/onthegomap/planetiler/custommap/ConfigExpressionParserTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class ConfigExpressionParserTest {
@@ -42,11 +43,19 @@ class ConfigExpressionParserTest {
     assertParse(input, constOf(1d), Double.class);
   }
 
-  @Test
-  void testVar() {
-    assertParse("${feature.id}", variable(FEATURE_SIGNATURE.withOutput(Integer.class), "feature.id"), Integer.class);
-    assertParse("${feature.id}", variable(FEATURE_SIGNATURE.withOutput(Long.class), "feature.id"), Long.class);
-    assertParse("${feature.id}", variable(FEATURE_SIGNATURE.withOutput(Double.class), "feature.id"), Double.class);
+  @ParameterizedTest
+  @CsvSource({
+    "feature.id",
+    "feature.source",
+    "feature.source_layer",
+    "feature.osm_user_name"
+  })
+  void testVar(String var) {
+    String script = "${" + var + "}";
+    assertParse(script, variable(FEATURE_SIGNATURE.withOutput(Integer.class), var), Integer.class);
+    assertParse(script, variable(FEATURE_SIGNATURE.withOutput(Long.class), var), Long.class);
+    assertParse(script, variable(FEATURE_SIGNATURE.withOutput(Double.class), var), Double.class);
+    assertParse(script, variable(FEATURE_SIGNATURE.withOutput(String.class), var), String.class);
   }
 
   @Test

--- a/planetiler-custommap/src/test/java/com/onthegomap/planetiler/custommap/ConfiguredFeatureTest.java
+++ b/planetiler-custommap/src/test/java/com/onthegomap/planetiler/custommap/ConfiguredFeatureTest.java
@@ -25,7 +25,6 @@ import com.onthegomap.planetiler.reader.SimpleFeature;
 import com.onthegomap.planetiler.reader.SourceFeature;
 import com.onthegomap.planetiler.reader.osm.OsmElement;
 import com.onthegomap.planetiler.stats.Stats;
-import com.onthegomap.planetiler.util.YAML;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -1359,10 +1358,10 @@ class ConfiguredFeatureTest {
   @ParameterizedTest
   @CsvSource(value = {
     "${feature.id}: 1",
+    "${feature.id + 1}: 2",
     "${feature.id}: [1, 3]",
-    "${feature.source}: source",
-    "${feature.source}: [source, source2]",
     "${feature.source_layer}: layer",
+    "${  feature .  source_layer  }: [layer, layer2]",
     "${feature.osm_changeset}: 2",
     "${feature.osm_version}: 5",
     "${feature.osm_timestamp}: 3",
@@ -1384,16 +1383,82 @@ class ConfiguredFeatureTest {
           include_when:
             %s
       """.formatted(matchString);
-    System.err.println(YAML.load(config, Object.class));
     var sfMatch =
       SimpleFeature.createFakeOsmFeature(rectangle(0, 1), Map.of(), "osm", "layer", 1, emptyList(),
         new OsmElement.Info(2, 3, 4, 5, "user"));
     var sfNoMatch =
-      SimpleFeature.createFakeOsmFeature(newPoint(0, 0), Map.of(), "other source", "other layer", 2, emptyList(),
+      SimpleFeature.createFakeOsmFeature(newPoint(0, 0), Map.of(), "osm", "other layer", 2, emptyList(),
         new OsmElement.Info(6, 7, 8, 9, "other user"));
     testFeature(config, sfMatch, any -> {
     }, 1);
     testFeature(config, sfNoMatch, any -> {
     }, 0);
+  }
+
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "${feature.osm_user_name}: __any__",
+    "${feature.osm_user_name}: null",
+    "${feature.source_layer}: __any__",
+    "${feature.source_layer}: null",
+  }, delimiter = '\t')
+  void testLeftHandSideExpressionMatchAny(String matchString) {
+    var config = """
+      sources:
+        osm:
+          type: osm
+          url: geofabrik:rhode-island
+          local_path: data/rhode-island.osm.pbf
+      layers:
+      - id: testLayer
+        features:
+        - source: osm
+          include_when:
+            %s
+      """.formatted(matchString);
+    var sfMatch =
+      SimpleFeature.createFakeOsmFeature(rectangle(0, 1), Map.of(), "osm", "layer", 1, emptyList(),
+        new OsmElement.Info(2, 3, 4, 5, "user"));
+    var sfNoMatch =
+      SimpleFeature.createFakeOsmFeature(newPoint(0, 0), Map.of(), "osm", null, 2, emptyList(),
+        new OsmElement.Info(6, 7, 8, 9, ""));
+    testFeature(config, sfMatch, any -> {
+    }, 1);
+    testFeature(config, sfNoMatch, any -> {
+    }, 0);
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "${feature.osm_user_name}: ''",
+    "${feature.osm_user_name}: ['']",
+    "${feature.source_layer}: ''",
+    "${feature.source_layer}: ['']",
+  }, delimiter = '\t')
+  void testLeftHandSideExpressionMatchNone(String matchString) {
+    var config = """
+      sources:
+        osm:
+          type: osm
+          url: geofabrik:rhode-island
+          local_path: data/rhode-island.osm.pbf
+      layers:
+      - id: testLayer
+        features:
+        - source: osm
+          include_when:
+            %s
+      """.formatted(matchString);
+    var sfMatch =
+      SimpleFeature.createFakeOsmFeature(rectangle(0, 1), Map.of(), "osm", "layer", 1, emptyList(),
+        new OsmElement.Info(2, 3, 4, 5, "user"));
+    var sfNoMatch =
+      SimpleFeature.createFakeOsmFeature(newPoint(0, 0), Map.of(), "osm", null, 2, emptyList(),
+        new OsmElement.Info(6, 7, 8, 9, ""));
+    testFeature(config, sfMatch, any -> {
+    }, 0);
+    testFeature(config, sfNoMatch, any -> {
+    }, 1);
   }
 }

--- a/planetiler-custommap/src/test/java/com/onthegomap/planetiler/custommap/ConfiguredFeatureTest.java
+++ b/planetiler-custommap/src/test/java/com/onthegomap/planetiler/custommap/ConfiguredFeatureTest.java
@@ -3,6 +3,7 @@ package com.onthegomap.planetiler.custommap;
 import static com.onthegomap.planetiler.TestUtils.newLineString;
 import static com.onthegomap.planetiler.TestUtils.newPoint;
 import static com.onthegomap.planetiler.TestUtils.newPolygon;
+import static com.onthegomap.planetiler.TestUtils.rectangle;
 import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -24,6 +25,7 @@ import com.onthegomap.planetiler.reader.SimpleFeature;
 import com.onthegomap.planetiler.reader.SourceFeature;
 import com.onthegomap.planetiler.reader.osm.OsmElement;
 import com.onthegomap.planetiler.stats.Stats;
+import com.onthegomap.planetiler.util.YAML;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -1320,5 +1322,46 @@ class ConfiguredFeatureTest {
     ), feature -> {
       assertEquals(Map.of("wikidata", 0L), feature.getAttrsAtZoom(14));
     }, 1);
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "${feature.id}: 1",
+    "${feature.id}: [1, 3]",
+    "${feature.source}: source",
+    "${feature.source}: [source, source2]",
+    "${feature.source_layer}: layer",
+    "${feature.osm_changeset}: 2",
+    "${feature.osm_version}: 5",
+    "${feature.osm_timestamp}: 3",
+    "${feature.osm_user_id}: 4",
+    "${feature.osm_user_name}: user",
+    "${feature.osm_type}: way",
+  }, delimiter = '\t')
+  void testLeftHandSideExpression(String matchString) {
+    var config = """
+      sources:
+        osm:
+          type: osm
+          url: geofabrik:rhode-island
+          local_path: data/rhode-island.osm.pbf
+      layers:
+      - id: testLayer
+        features:
+        - source: osm
+          include_when:
+            %s
+      """.formatted(matchString);
+    System.err.println(YAML.load(config, Object.class));
+    var sfMatch =
+      SimpleFeature.createFakeOsmFeature(rectangle(0, 1), Map.of(), "osm", "layer", 1, emptyList(),
+        new OsmElement.Info(2, 3, 4, 5, "user"));
+    var sfNoMatch =
+      SimpleFeature.createFakeOsmFeature(newPoint(0, 0), Map.of(), "other source", "other layer", 2, emptyList(),
+        new OsmElement.Info(6, 7, 8, 9, "other user"));
+    testFeature(config, sfMatch, any -> {
+    }, 1);
+    testFeature(config, sfNoMatch, any -> {
+    }, 0);
   }
 }

--- a/planetiler-custommap/src/test/java/com/onthegomap/planetiler/custommap/ConfiguredFeatureTest.java
+++ b/planetiler-custommap/src/test/java/com/onthegomap/planetiler/custommap/ConfiguredFeatureTest.java
@@ -36,6 +36,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.locationtech.jts.geom.Lineal;
+import org.locationtech.jts.geom.Polygonal;
 import org.locationtech.jts.geom.Puntal;
 
 class ConfiguredFeatureTest {
@@ -1287,6 +1289,36 @@ class ConfiguredFeatureTest {
       "natural", "water"
     ), feature -> {
       assertInstanceOf(Puntal.class, feature.getGeometry());
+    }, 1);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"geometry: any", ""})
+  void testAnyGeometry(String expression) {
+    var config = """
+      sources:
+        osm:
+          type: osm
+          url: geofabrik:rhode-island
+          local_path: data/rhode-island.osm.pbf
+      layers:
+      - id: testLayer
+        features:
+        - source: osm
+          %s
+      """.formatted(expression).strip();
+    this.planetilerConfig = PlanetilerConfig.from(Arguments.of(Map.of()));
+    testLinestring(config, Map.of(
+    ), feature -> {
+      assertInstanceOf(Lineal.class, feature.getGeometry());
+    }, 1);
+    testPoint(config, Map.of(
+    ), feature -> {
+      assertInstanceOf(Puntal.class, feature.getGeometry());
+    }, 1);
+    testPolygon(config, Map.of(
+    ), feature -> {
+      assertInstanceOf(Polygonal.class, feature.getGeometry());
     }, 1);
   }
 


### PR DESCRIPTION
Allow left-hand dynamic expressions on the left-hand side of a match statement in addition to just tag names so you can do something like this to match on fields by ID:

```yaml
include_when:
  ${feature.id}:
  - 1
  - 2
  - 3
```

The expression can be `feature.source` `feature.source_layer` `feature.osm_timestamp` `feature.osm_type` etc.

This also adds an `any` geometry type that passes through any point/line/polygon and  makes geometry optional on features (defaults to any).

As a followup a `${feature.source}`/`${feature.source_layer}` expression could be converted to a matchSource/matchSourceLayer expression to optimize execution a bit more.