### PR TITLE
Convert `${feature.source/source_layer}: [ ... ]` match expression to `MatchSource`/`MatchSourceLayer`

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/expression/Expression.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/expression/Expression.java
@@ -50,7 +50,7 @@ public interface Expression extends Simplifiable<Expression> {
     return and(List.of(children));
   }
 
-  static And and(List<Expression> children) {
+  static And and(List<? extends Expression> children) {
     return new And(children);
   }
 
@@ -58,7 +58,7 @@ public interface Expression extends Simplifiable<Expression> {
     return or(List.of(children));
   }
 
-  static Or or(List<Expression> children) {
+  static Or or(List<? extends Expression> children) {
     return new Or(children);
   }
 
@@ -100,8 +100,7 @@ public interface Expression extends Simplifiable<Expression> {
    * <p>
    * {@code values} can contain exact matches, "%text%" to match any value containing "text", or "" to match any value.
    */
-  static MatchAny matchAnyTyped(String field, TypedGetter typeGetter,
-    List<?> values) {
+  static MatchAny matchAnyTyped(String field, TypedGetter typeGetter, List<?> values) {
     return MatchAny.from(field, typeGetter, values);
   }
 
@@ -153,7 +152,7 @@ public interface Expression extends Simplifiable<Expression> {
     return new MatchSourceLayer(layer);
   }
 
-  private static String generateJavaCodeList(List<Expression> items) {
+  private static String generateJavaCodeList(List<? extends Expression> items) {
     return items.stream().map(Expression::generateJavaCode).collect(Collectors.joining(", "));
   }
 
@@ -268,7 +267,7 @@ public interface Expression extends Simplifiable<Expression> {
     }
   }
 
-  record And(List<Expression> children) implements Expression {
+  record And(List<? extends Expression> children) implements Expression {
 
     @Override
     public String generateJavaCode() {
@@ -306,7 +305,7 @@ public interface Expression extends Simplifiable<Expression> {
     }
   }
 
-  record Or(List<Expression> children) implements Expression {
+  record Or(List<? extends Expression> children) implements Expression {
 
     @Override
     public String generateJavaCode() {

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/expression/MultiExpression.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/expression/MultiExpression.java
@@ -4,8 +4,9 @@ import static com.onthegomap.planetiler.expression.Expression.FALSE;
 import static com.onthegomap.planetiler.expression.Expression.TRUE;
 import static com.onthegomap.planetiler.expression.Expression.matchType;
 
-import com.onthegomap.planetiler.reader.SourceFeature;
 import com.onthegomap.planetiler.reader.WithGeometryType;
+import com.onthegomap.planetiler.reader.WithSource;
+import com.onthegomap.planetiler.reader.WithSourceLayer;
 import com.onthegomap.planetiler.reader.WithTags;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -436,7 +437,7 @@ public record MultiExpression<T>(List<Entry<T>> expressions) implements Simplifi
 
     @Override
     String extract(WithTags input) {
-      return input instanceof SourceFeature feature ? feature.getSourceLayer() : null;
+      return input instanceof WithSourceLayer feature ? feature.getSourceLayer() : null;
     }
   }
 
@@ -451,7 +452,7 @@ public record MultiExpression<T>(List<Entry<T>> expressions) implements Simplifi
 
     @Override
     String extract(WithTags input) {
-      return input instanceof SourceFeature feature ? feature.getSource() : null;
+      return input instanceof WithSource feature ? feature.getSource() : null;
     }
   }
 

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/SourceFeature.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/SourceFeature.java
@@ -26,7 +26,7 @@ import org.locationtech.jts.geom.Polygon;
  * All geometries except for {@link #latLonGeometry()} return elements in world web mercator coordinates where (0,0) is
  * the northwest corner and (1,1) is the southeast corner of the planet.
  */
-public abstract class SourceFeature implements WithTags, WithGeometryType {
+public abstract class SourceFeature implements WithTags, WithGeometryType, WithSource, WithSourceLayer {
 
   private final Map<String, Object> tags;
   private final String source;
@@ -279,11 +279,13 @@ public abstract class SourceFeature implements WithTags, WithGeometryType {
   }
 
   /** Returns the ID of the source that this feature came from. */
+  @Override
   public String getSource() {
     return source;
   }
 
   /** Returns the layer ID within a source that this feature comes from. */
+  @Override
   public String getSourceLayer() {
     return sourceLayer;
   }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/WithSource.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/WithSource.java
@@ -1,0 +1,5 @@
+package com.onthegomap.planetiler.reader;
+
+public interface WithSource {
+  String getSource();
+}

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/WithSourceLayer.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/reader/WithSourceLayer.java
@@ -1,0 +1,5 @@
+package com.onthegomap.planetiler.reader;
+
+public interface WithSourceLayer {
+  String getSourceLayer();
+}

--- a/planetiler-custommap/README.md
+++ b/planetiler-custommap/README.md
@@ -214,7 +214,8 @@ layers:
 
 A feature is a defined set of objects that meet a specified filter criteria.
 
-- `source` - A string [source](#source) ID, or list of source IDs from which features should be extracted
+- `source` - A string [source](#source) ID, or list of source IDs from which features should be extracted. If missing,
+  features from all sources are included.
 - `geometry` - A string enum that indicates which geometry types to include, and how to transform them. Can be one
   of:
   - `point` `line` or `polygon` to pass the original feature through

--- a/planetiler-custommap/planetiler.schema.json
+++ b/planetiler-custommap/planetiler.schema.json
@@ -360,7 +360,7 @@
           ]
         },
         "source": {
-          "description": "A source ID or list of source IDs from which features should be extracted",
+          "description": "A source ID or list of source IDs from which features should be extracted. If unspecified, all sources are included",
           "oneOf": [
             {
               "type": "string"

--- a/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/ConfiguredFeature.java
+++ b/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/ConfiguredFeature.java
@@ -64,6 +64,12 @@ public class ConfiguredFeature {
         BooleanExpressionParser.parse(feature.includeWhen(), tagValueProducer,
           processFeatureContext);
     }
+    if (!feature.source().isEmpty()) {
+      filter = Expression.and(
+        filter,
+        Expression.or(feature.source().stream().map(Expression::matchSource).toList())
+      );
+    }
     if (feature.excludeWhen() != null) {
       filter = Expression.and(
         filter,

--- a/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/ConfiguredFeature.java
+++ b/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/ConfiguredFeature.java
@@ -280,7 +280,7 @@ public class ConfiguredFeature {
     var sourceFeature = context.feature();
 
     // Ensure that this feature is from the correct source (index should enforce this, so just check when assertions enabled)
-    assert sources.contains(sourceFeature.getSource());
+    assert sources.isEmpty() || sources.contains(sourceFeature.getSource());
 
     var f = geometryFactory.apply(features);
     for (var processor : featureProcessors) {

--- a/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/Contexts.java
+++ b/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/Contexts.java
@@ -13,6 +13,8 @@ import com.onthegomap.planetiler.custommap.expression.ScriptEnvironment;
 import com.onthegomap.planetiler.expression.DataType;
 import com.onthegomap.planetiler.reader.SourceFeature;
 import com.onthegomap.planetiler.reader.WithGeometryType;
+import com.onthegomap.planetiler.reader.WithSource;
+import com.onthegomap.planetiler.reader.WithSourceLayer;
 import com.onthegomap.planetiler.reader.WithTags;
 import com.onthegomap.planetiler.reader.osm.OsmElement;
 import com.onthegomap.planetiler.reader.osm.OsmSourceFeature;
@@ -285,7 +287,8 @@ public class Contexts {
    * Makes nested contexts adhere to {@link WithTags} and {@link WithGeometryType} by recursively fetching source
    * feature from the root context.
    */
-  private interface FeatureContext extends ScriptContext, WithTags, WithGeometryType, NestedContext {
+  private interface FeatureContext extends ScriptContext, WithTags, WithGeometryType, NestedContext, WithSourceLayer,
+    WithSource {
 
     default FeatureContext parent() {
       return null;
@@ -324,6 +327,16 @@ public class Contexts {
     @Override
     default boolean canBePolygon() {
       return feature().canBePolygon();
+    }
+
+    @Override
+    default String getSource() {
+      return feature().getSource();
+    }
+
+    @Override
+    default String getSourceLayer() {
+      return feature().getSourceLayer();
     }
   }
 

--- a/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/configschema/FeatureItem.java
+++ b/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/configschema/FeatureItem.java
@@ -25,4 +25,9 @@ public record FeatureItem(
   public FeatureGeometry geometry() {
     return geometry == null ? FeatureGeometry.ANY : geometry;
   }
+
+  @Override
+  public List<String> source() {
+    return source == null ? List.of() : source;
+  }
 }

--- a/planetiler-custommap/src/test/java/com/onthegomap/planetiler/custommap/ConfiguredFeatureTest.java
+++ b/planetiler-custommap/src/test/java/com/onthegomap/planetiler/custommap/ConfiguredFeatureTest.java
@@ -1321,6 +1321,32 @@ class ConfiguredFeatureTest {
     }, 1);
   }
 
+  @ParameterizedTest
+  @ValueSource(strings = {"source: []", ""})
+  void testAnySource(String expression) {
+    var config = """
+      sources:
+        osm:
+          type: osm
+          url: geofabrik:rhode-island
+          local_path: data/rhode-island.osm.pbf
+      layers:
+      - id: testLayer
+        features:
+        - geometry: point
+          %s
+      """.formatted(expression).strip();
+    this.planetilerConfig = PlanetilerConfig.from(Arguments.of(Map.of()));
+    testFeature(config, SimpleFeature.createFakeOsmFeature(newPoint(0, 0), Map.of(
+    ), "osm", null, 1, emptyList(), OSM_INFO), feature -> {
+      assertInstanceOf(Puntal.class, feature.getGeometry());
+    }, 1);
+    testFeature(config, SimpleFeature.createFakeOsmFeature(newPoint(0, 0), Map.of(
+    ), "other", null, 1, emptyList(), OSM_INFO), feature -> {
+      assertInstanceOf(Puntal.class, feature.getGeometry());
+    }, 1);
+  }
+
   @Test
   void testWikidataParse() {
     var config = """


### PR DESCRIPTION
This is a followup to #1063 that converts simple match expressions where the left hand side is `${feature.source}` or `${feature.source_layer}` and don't contain a wildcard, `__any__` `""` to a `MatchSource` / `MatchSourceLayer` expression that gets optimized when matching against features.

Also make `source` optional on features, when missing it matches features from any source.