### PR TITLE
Make projection configurable for yaml sources

### DIFF
--- a/planetiler-custommap/README.md
+++ b/planetiler-custommap/README.md
@@ -65,6 +65,10 @@ A description that tells planetiler how to read geospatial objects with tags fro
   For [geofabrik](https://download.geofabrik.de/) named areas, use `geofabrik:`  prefixes, for
   example `geofabrik:rhode-island`. Can be a string or [expression](#expression) that can
   reference [argument values](#arguments).
+- `projection` - Planetiler will try to determine the projection automatically for shapefile/geopackage sources, but if
+  that is not correct you can override the projection by specifying a coordinate reference system authority code
+  like `EPSG:3857` or `EPSG:4326` here. Can be a string or [expression](#expression) that can
+  reference [argument values](#arguments).
 
 For example:
 

--- a/planetiler-custommap/planetiler.schema.json
+++ b/planetiler-custommap/planetiler.schema.json
@@ -51,6 +51,20 @@
           "local_path": {
             "description": "Local path to the file to use, inferred from `url` if missing",
             "$ref": "#/$defs/expression"
+          },
+          "projection": {
+            "description": "Override the coordinate reference system authority code for a shapefile or geopackage source if it can not be determined automatically",
+            "anyOf": [
+              {
+                "enum": [
+                  "EPSG:3857",
+                  "EPSG:4326"
+                ]
+              },
+              {
+                "type": "#/$defs/expression"
+              }
+            ]
           }
         },
         "anyOf": [

--- a/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/ConfiguredMapMain.java
+++ b/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/ConfiguredMapMain.java
@@ -62,6 +62,7 @@ public class ConfiguredMapMain {
 
     DataSourceType sourceType = source.type();
     Path localPath = source.localPath();
+    String projection = source.projection();
     if (localPath == null) {
       if (source.url() == null) {
         throw new ParseException("Must provide either a url or path for " + source.id());
@@ -71,8 +72,8 @@ public class ConfiguredMapMain {
 
     switch (sourceType) {
       case OSM -> planetiler.addOsmSource(source.id(), localPath, source.url());
-      case SHAPEFILE -> planetiler.addShapefileSource(source.id(), localPath, source.url());
-      case GEOPACKAGE -> planetiler.addGeoPackageSource(source.id(), localPath, source.url());
+      case SHAPEFILE -> planetiler.addShapefileSource(projection, source.id(), localPath, source.url());
+      case GEOPACKAGE -> planetiler.addGeoPackageSource(projection, source.id(), localPath, source.url());
       default -> throw new IllegalArgumentException("Unhandled source type for " + source.id() + ": " + sourceType);
     }
   }

--- a/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/ConfiguredProfile.java
+++ b/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/ConfiguredProfile.java
@@ -117,11 +117,16 @@ public class ConfiguredProfile implements Profile {
   public List<Source> sources() {
     List<Source> sources = new ArrayList<>();
     schema.sources().forEach((key, value) -> {
-      var url = ConfigExpressionParser.tryStaticEvaluate(rootContext, value.url(), String.class).get();
-      var path = ConfigExpressionParser.tryStaticEvaluate(rootContext, value.localPath(), String.class).get();
-      sources.add(new Source(key, value.type(), url, path == null ? null : Path.of(path)));
+      var url = evaluate(value.url(), String.class);
+      var path = evaluate(value.localPath(), String.class);
+      var projection = evaluate(value.projection(), String.class);
+      sources.add(new Source(key, value.type(), url, path == null ? null : Path.of(path), projection));
     });
     return sources;
+  }
+
+  private <T> T evaluate(Object expression, Class<T> returnType) {
+    return ConfigExpressionParser.tryStaticEvaluate(rootContext, expression, returnType).get();
   }
 
   public FeatureLayer findFeatureLayer(String layerId) {

--- a/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/Source.java
+++ b/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/Source.java
@@ -8,7 +8,8 @@ public record Source(
   String id,
   DataSourceType type,
   String url,
-  Path localPath
+  Path localPath,
+  String projection
 ) {
 
   public String defaultFileUrl() {

--- a/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/configschema/DataSource.java
+++ b/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/configschema/DataSource.java
@@ -5,5 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public record DataSource(
   DataSourceType type,
   Object url,
-  @JsonProperty("local_path") Object localPath
+  @JsonProperty("local_path") Object localPath,
+  Object projection
 ) {}

--- a/planetiler-custommap/src/main/resources/samples/owg_simple.yml
+++ b/planetiler-custommap/src/main/resources/samples/owg_simple.yml
@@ -6,7 +6,7 @@ sources:
   water_polygons:
     type: shapefile
     url: https://osmdata.openstreetmap.de/download/water-polygons-split-3857.zip
-    projection: PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,ID["EPSG","7030"]],ID["EPSG","6326"]],PRIMEM["Greenwich",0,ID["EPSG","8901"]],UNIT["degree",0.0174532925199433,ID["EPSG","9122"]],ID["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,ID["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],ID["EPSG","3857"]]
+    projection: EPSG:3857
   osm:
     type: osm
     url: geofabrik:monaco

--- a/planetiler-custommap/src/main/resources/samples/owg_simple.yml
+++ b/planetiler-custommap/src/main/resources/samples/owg_simple.yml
@@ -6,6 +6,7 @@ sources:
   water_polygons:
     type: shapefile
     url: https://osmdata.openstreetmap.de/download/water-polygons-split-3857.zip
+    projection: PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,ID["EPSG","7030"]],ID["EPSG","6326"]],PRIMEM["Greenwich",0,ID["EPSG","8901"]],UNIT["degree",0.0174532925199433,ID["EPSG","9122"]],ID["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,ID["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],ID["EPSG","3857"]]
   osm:
     type: osm
     url: geofabrik:monaco

--- a/planetiler-custommap/src/test/java/com/onthegomap/planetiler/custommap/ConfiguredFeatureTest.java
+++ b/planetiler-custommap/src/test/java/com/onthegomap/planetiler/custommap/ConfiguredFeatureTest.java
@@ -1117,6 +1117,7 @@ class ConfiguredFeatureTest {
       "osm",
       DataSourceType.OSM,
       "geofabrik:boston",
+      null,
       null
     )), loadConfig(config).sources());
 
@@ -1125,6 +1126,7 @@ class ConfiguredFeatureTest {
       "osm",
       DataSourceType.OSM,
       "geofabrik:rhode-island",
+      null,
       null
     )), loadConfig(config).sources());
 
@@ -1135,6 +1137,35 @@ class ConfiguredFeatureTest {
       "url", "https://example.com/file.osm.pbf"
     )));
     assertEquals("example.com_file.osm.pbf", loadConfig(config).sources().get(0).defaultFileUrl());
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "EPSG:3875, EPSG:3875",
+    "${'EPSG:' + '3875'}, EPSG:3875",
+  })
+  void testSetProjection(String in, String out) {
+    var config = """
+      sources:
+        osm:
+          type: osm
+          url: geofabrik:rhode-island
+          projection: %s
+      layers:
+      - id: testLayer
+        features:
+        - source: osm
+          geometry: point
+      """.formatted(in);
+
+    this.planetilerConfig = PlanetilerConfig.from(Arguments.of(Map.of()));
+    assertEquals(List.of(new Source(
+      "osm",
+      DataSourceType.OSM,
+      "geofabrik:rhode-island",
+      null,
+      out
+    )), loadConfig(config).sources());
   }
 
   @ParameterizedTest

--- a/planetiler-custommap/src/test/java/com/onthegomap/planetiler/custommap/ConfiguredMapTest.java
+++ b/planetiler-custommap/src/test/java/com/onthegomap/planetiler/custommap/ConfiguredMapTest.java
@@ -81,11 +81,11 @@ class ConfiguredMapTest {
     }
   }
 
-  //  @Test --TODO FIX after adding water layer
+  @Test
   void testContainsOceanPolyons() {
     assertMinFeatures("water", Map.of(
       "natural", "water"
-    ), 0, 1, Polygon.class);
+    ), 6, 1, Polygon.class);
   }
 
   @Test


### PR DESCRIPTION
Allow source definitions in a YAML file to specify a projection explicitly for a source.