### PR TITLE
Shortcut through simplification step if distanceTolerance is negative

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/DouglasPeuckerSimplifier.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/DouglasPeuckerSimplifier.java
@@ -38,7 +38,7 @@ public class DouglasPeuckerSimplifier {
    * @return the simplified geometry
    */
   public static Geometry simplify(Geometry geom, double distanceTolerance) {
-    if (geom.isEmpty()) {
+    if (geom.isEmpty() || (distanceTolerance < 0.0)) {
       return geom.copy();
     }
 

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/FeatureMergeTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/FeatureMergeTest.java
@@ -165,6 +165,21 @@ class FeatureMergeTest {
         true
       )
     );
+    // but doesn't resimplify if the tolerance is negative even when resimplify=true
+    assertEquals(
+      List.of(
+        feature(1, newLineString(10, 10, 20, 20, 30, 30), Map.of("a", 1))
+      ),
+      FeatureMerge.mergeLineStrings(
+        List.of(
+          feature(1, newLineString(10, 10, 20, 20, 30, 30), Map.of("a", 1))
+        ),
+        0,
+        -1,
+        0,
+        true
+      )
+    );
   }
 
   @Test


### PR DESCRIPTION
If the simplification tolerance has been set to less than 0.0 then there's no need to run the DouglasPeuckerSimplifier algorithm. This change checks the tolerance and simply returns a copy of the Geometry if no simplification is requested.
This change is required for the case where the user wants no simplification to take place e.g. to preserve all intersection nodes. Without this change any negative value for distanceTolerance is squared inside DPTransformer and immediately loses its meaning.