### PR TITLE
Use 23 jdk for docker image

### DIFF
--- a/planetiler-dist/pom.xml
+++ b/planetiler-dist/pom.xml
@@ -73,7 +73,7 @@
           <skip>false</skip>
           <from>
             <image>
-              eclipse-temurin:21-jre
+              eclipse-temurin:23-jdk
             </image>
             <platforms>
               <platform>


### PR DESCRIPTION
So that you can run multifile java programs from source with the docker container.