### PR TITLE
Fix match ordering

### DIFF
--- a/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/ConfigExpressionParser.java
+++ b/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/ConfigExpressionParser.java
@@ -146,7 +146,7 @@ public class ConfigExpressionParser<I extends ScriptContext> {
     } else {
       throw new ParseException("Invalid match block. Expected a list or map, but got: " + match);
     }
-    return ConfigExpression.match(signature(output), MultiExpression.of(List.copyOf(conditions)), fallback);
+    return ConfigExpression.match(signature(output), MultiExpression.ofOrdered(List.copyOf(conditions)), fallback);
   }
 
   private <O> Signature<I, O> signature(Class<O> outputClass) {

--- a/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/expression/ConfigExpression.java
+++ b/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/expression/ConfigExpression.java
@@ -152,7 +152,7 @@ public interface ConfigExpression<I extends ScriptContext, O>
         if (Expression.TRUE.equals(expression.expression())) {
           return new Match<>(
             signature,
-            MultiExpression.of(expressions.stream().limit(i).toList()),
+            MultiExpression.ofOrdered(expressions.stream().limit(i).toList()),
             expression.result()
           );
         }

--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
             <importOrder/>
             <removeUnusedImports/>
             <eclipse>
-              <version>4.29</version>
+              <version>4.33</version>
               <!--suppress UnresolvedMavenProperty -->
               <file>${maven.multiModuleProjectDirectory}/eclipse-formatter.xml</file>
             </eclipse>


### PR DESCRIPTION
Fix yaml match ordering so that returns the first match when there are multiple conditions for the same value.

Previously this case:

```yaml
- if: condition 1
  value: a
- if condition 2
  value: b
- if: condition 3
  value a
```

condition 1 and condition 2 were getting combined into 1 expression for a:

```yaml
- if: condition 1 OR condition 3
  value: a
- if condition 2
  value: b
```

So when condition 2 and 3 match, it returned the first match in that new expression (a) instead of the first match from the original expression (b)

This PR changes to prevent condition combining in multi-expressions when used in this match expression in yaml configs.

Fixes #1091 