### PR TITLE
Fast tests script

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/config/PlanetilerConfig.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/config/PlanetilerConfig.java
@@ -124,7 +124,7 @@ public record PlanetilerConfig(
     int renderMaxzoom =
       arguments.getInteger("render_maxzoom", "maximum rendering zoom level up to " + MAX_MAXZOOM,
         Math.max(maxzoom, DEFAULT_MAXZOOM));
-    Path tmpDir = arguments.file("tmpdir", "temp directory", Path.of("data", "tmp"));
+    Path tmpDir = arguments.file("tmpdir|tmp", "temp directory", Path.of("data", "tmp"));
 
     return new PlanetilerConfig(
       arguments,

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/FeatureMergeTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/FeatureMergeTest.java
@@ -638,6 +638,7 @@ class FeatureMergeTest {
     );
   }
 
+  @Slow
   @ParameterizedTest
   @CsvSource({
     "bostonbuildings.mbtiles, 2477, 3028, 13, 1141",

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
@@ -72,6 +72,7 @@ import org.slf4j.LoggerFactory;
 /**
  * In-memory tests with fake data and profiles to ensure all features work end-to-end.
  */
+@Slow
 class PlanetilerTests {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(PlanetilerTests.class);

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/Slow.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/Slow.java
@@ -1,0 +1,14 @@
+package com.onthegomap.planetiler;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.Tag;
+
+/** Add to any junit test classes or methods to exclude when run with {@code -Pfast} maven argument. */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Tag("slow")
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Slow {
+}

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/collection/AppendStoreTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/collection/AppendStoreTest.java
@@ -10,15 +10,15 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-class AppendStoreTest {
+abstract class AppendStoreTest {
 
-  static abstract class IntsTest {
+  abstract static class IntsTest {
 
     protected AppendStore.Ints store;
 
     @ParameterizedTest
     @ValueSource(ints = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
-    public void writeThenRead(int num) {
+    void writeThenRead(int num) {
       for (int i = 0; i < num; i++) {
         store.appendInt(i + 1);
       }
@@ -30,7 +30,7 @@ class AppendStoreTest {
     }
 
     @Test
-    public void readBig() {
+    void readBig() {
       store.appendInt(Integer.MAX_VALUE);
       store.appendInt(Integer.MAX_VALUE - 1);
       store.appendInt(Integer.MAX_VALUE - 2);
@@ -40,13 +40,13 @@ class AppendStoreTest {
     }
   }
 
-  static abstract class LongsTest {
+  abstract static class LongsTest {
 
     protected AppendStore.Longs store;
 
     @ParameterizedTest
     @ValueSource(ints = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
-    public void writeThenRead(int num) {
+    void writeThenRead(int num) {
       for (int i = 0; i < num; i++) {
         store.appendLong(i + 1);
       }
@@ -61,82 +61,82 @@ class AppendStoreTest {
 
     @ParameterizedTest
     @ValueSource(longs = {maxInt - 1, maxInt, maxInt + 1, 2 * maxInt - 1, 2 * maxInt, 5 * maxInt - 1, 5 * maxInt + 1})
-    public void readBig(long value) {
+    void readBig(long value) {
       store.appendLong(value);
       assertEquals(value, store.getLong(0));
     }
 
   }
 
-  static class RamInt extends IntsTest {
+  static class RamIntTest extends IntsTest {
 
     @BeforeEach
-    public void setup() {
+    void setup() {
       this.store = new AppendStoreRam.Ints(false, 4 << 2);
     }
   }
 
-  static class MMapInt extends IntsTest {
+  static class MMapIntTest extends IntsTest {
 
     @BeforeEach
-    public void setup(@TempDir Path path) {
+    void setup(@TempDir Path path) {
       this.store = new AppendStoreMmap.Ints(path.resolve("ints"), 4 << 2, true);
     }
   }
 
-  static class DirectInt extends IntsTest {
+  static class DirectIntTest extends IntsTest {
 
     @BeforeEach
-    public void setup() {
+    void setup() {
       this.store = new AppendStoreRam.Ints(true, 4 << 2);
     }
   }
 
-  static class RamLong extends LongsTest {
+  static class RamLongTest extends LongsTest {
 
     @BeforeEach
-    public void setup() {
+    void setup() {
       this.store = new AppendStoreRam.Longs(false, 4 << 2);
     }
   }
 
-  static class MMapLong extends LongsTest {
+  static class MMapLongTest extends LongsTest {
 
     @BeforeEach
-    public void setup(@TempDir Path path) {
+    void setup(@TempDir Path path) {
       this.store = new AppendStoreMmap.Longs(path.resolve("longs"), 4 << 2, true);
     }
   }
 
-  static class DirectLong extends LongsTest {
+  static class DirectLongTest extends LongsTest {
 
     @BeforeEach
-    public void setup() {
+    void setup() {
       this.store = new AppendStoreRam.Longs(true, 4 << 2);
     }
   }
 
-  static class MMapSmallLong extends LongsTest {
+  static class MMapSmallLongTest extends LongsTest {
 
     @BeforeEach
-    public void setup(@TempDir Path path) {
+    void setup(@TempDir Path path) {
       this.store = new AppendStore.SmallLongs(
         (i) -> new AppendStoreMmap.Ints(path.resolve("smalllongs" + i), 4 << 2, true));
     }
   }
 
-  static class RamSmallLong extends LongsTest {
+  static class RamSmallLongTest extends LongsTest {
 
     @BeforeEach
-    public void setup() {
+    void setup() {
       this.store = new AppendStore.SmallLongs((i) -> new AppendStoreRam.Ints(false, 4 << 2));
     }
   }
 
-  static class DirectSmallLong extends LongsTest {
+  static class DirectSmallLongTest extends LongsTest {
 
     @BeforeEach
-    public void setup() {
+    void setup() {
       this.store = new AppendStore.SmallLongs((i) -> new AppendStoreRam.Ints(true, 4 << 2));
     }
   }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/collection/AppendStoreTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/collection/AppendStoreTest.java
@@ -3,7 +3,9 @@ package com.onthegomap.planetiler.collection;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.io.IOException;
 import java.nio.file.Path;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -15,6 +17,11 @@ abstract class AppendStoreTest {
   abstract static class IntsTest {
 
     protected AppendStore.Ints store;
+
+    @AfterEach
+    void close() throws IOException {
+      store.close();
+    }
 
     @ParameterizedTest
     @ValueSource(ints = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
@@ -44,6 +51,11 @@ abstract class AppendStoreTest {
 
     protected AppendStore.Longs store;
 
+    @AfterEach
+    void close() throws IOException {
+      store.close();
+    }
+
     @ParameterizedTest
     @ValueSource(ints = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
     void writeThenRead(int num) {
@@ -57,10 +69,11 @@ abstract class AppendStoreTest {
       assertThrows(IndexOutOfBoundsException.class, () -> store.getLong(num + 1));
     }
 
-    private static final long maxInt = Integer.MAX_VALUE;
+    private static final long MAX_INT = Integer.MAX_VALUE;
 
     @ParameterizedTest
-    @ValueSource(longs = {maxInt - 1, maxInt, maxInt + 1, 2 * maxInt - 1, 2 * maxInt, 5 * maxInt - 1, 5 * maxInt + 1})
+    @ValueSource(longs = {MAX_INT - 1,
+      MAX_INT, MAX_INT + 1, 2 * MAX_INT - 1, 2 * MAX_INT, 5 * MAX_INT - 1, 5 * MAX_INT + 1})
     void readBig(long value) {
       store.appendLong(value);
       assertEquals(value, store.getLong(0));
@@ -121,7 +134,7 @@ abstract class AppendStoreTest {
     @BeforeEach
     void setup(@TempDir Path path) {
       this.store = new AppendStore.SmallLongs(
-        (i) -> new AppendStoreMmap.Ints(path.resolve("smalllongs" + i), 4 << 2, true));
+        i -> new AppendStoreMmap.Ints(path.resolve("smalllongs" + i), 4 << 2, true));
     }
   }
 
@@ -129,7 +142,7 @@ abstract class AppendStoreTest {
 
     @BeforeEach
     void setup() {
-      this.store = new AppendStore.SmallLongs((i) -> new AppendStoreRam.Ints(false, 4 << 2));
+      this.store = new AppendStore.SmallLongs(i -> new AppendStoreRam.Ints(false, 4 << 2));
     }
   }
 
@@ -137,7 +150,7 @@ abstract class AppendStoreTest {
 
     @BeforeEach
     void setup() {
-      this.store = new AppendStore.SmallLongs((i) -> new AppendStoreRam.Ints(true, 4 << 2));
+      this.store = new AppendStore.SmallLongs(i -> new AppendStoreRam.Ints(true, 4 << 2));
     }
   }
 }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/collection/LongLongMultimapTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/collection/LongLongMultimapTest.java
@@ -11,18 +11,18 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-public abstract class LongLongMultimapTest {
+abstract class LongLongMultimapTest {
 
   protected LongLongMultimap map;
   protected boolean retainInputOrder = false;
 
   @Test
-  public void missingValue() {
+  void missingValue() {
     assertTrue(map.get(0).isEmpty());
   }
 
   @Test
-  public void oneValue() {
+  void oneValue() {
     put(1, 1);
     assertResultLists(LongArrayList.from(), map.get(0));
     assertResultLists(LongArrayList.from(1), map.get(1));
@@ -50,7 +50,7 @@ public abstract class LongLongMultimapTest {
   }
 
   @Test
-  public void twoConsecutiveValues() {
+  void twoConsecutiveValues() {
     put(1, 1);
     put(2, 2);
     assertResultLists(LongArrayList.from(), map.get(0));
@@ -60,7 +60,7 @@ public abstract class LongLongMultimapTest {
   }
 
   @Test
-  public void twoNonconsecutiveValues() {
+  void twoNonconsecutiveValues() {
     put(1, 1);
     put(3, 3);
     assertResultLists(LongArrayList.from(), map.get(0));
@@ -71,7 +71,7 @@ public abstract class LongLongMultimapTest {
   }
 
   @Test
-  public void returnToFirstKey() {
+  void returnToFirstKey() {
     if (retainInputOrder) {
       return;
     }
@@ -91,7 +91,7 @@ public abstract class LongLongMultimapTest {
   }
 
   @Test
-  public void manyInsertsOrdered() {
+  void manyInsertsOrdered() {
     long[] toInsert = new long[10];
     for (int i = 0; i < 100; i++) {
       for (int j = 0; j < 10; j++) {
@@ -128,7 +128,7 @@ public abstract class LongLongMultimapTest {
   }
 
   @Test
-  public void manyInsertsUnordered() {
+  void manyInsertsUnordered() {
     for (long i = 99; i >= 0; i--) {
       putAll(i, LongArrayList.from(
         i * 10 + 10,
@@ -160,7 +160,7 @@ public abstract class LongLongMultimapTest {
   }
 
   @Test
-  public void multiInsert() {
+  void multiInsert() {
     putAll(1, LongArrayList.from(1, 2, 3));
     put(0, 3);
     assertResultLists(LongArrayList.from(3), map.get(0));
@@ -168,35 +168,35 @@ public abstract class LongLongMultimapTest {
     assertResultLists(LongArrayList.from(), map.get(2));
   }
 
-  public static class SparseUnorderedTest extends LongLongMultimapTest {
+  static class SparseUnorderedTest extends LongLongMultimapTest {
 
     @BeforeEach
-    public void setup() {
+    void setup() {
       this.map = LongLongMultimap.newAppendableMultimap();
     }
   }
 
-  public static class DenseOrderedTest extends LongLongMultimapTest {
+  static class DenseOrderedTest extends LongLongMultimapTest {
 
     @BeforeEach
-    public void setup() {
+    void setup() {
       retainInputOrder = true;
       this.map =
         LongLongMultimap.newInMemoryReplaceableMultimap();
     }
   }
 
-  public static class DenseOrderedMmapTest extends LongLongMultimapTest {
+  static class DenseOrderedMmapTest extends LongLongMultimapTest {
 
     @BeforeEach
-    public void setup(@TempDir Path dir) {
+    void setup(@TempDir Path dir) {
       retainInputOrder = true;
       this.map =
         LongLongMultimap.newReplaceableMultimap(Storage.MMAP, new Storage.Params(dir.resolve("multimap"), true));
     }
 
     @AfterEach
-    public void teardown() {
+    void teardown() {
       this.map.close();
     }
   }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/util/WikidataTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/util/WikidataTest.java
@@ -111,7 +111,7 @@ class WikidataTest {
   List<DynamicTest> testFetchWikidata() throws IOException, InterruptedException {
     StringWriter writer = new StringWriter();
     Wikidata.Client client = Mockito.mock(Wikidata.Client.class, Mockito.RETURNS_SMART_NULLS);
-    Wikidata fixture = new Wikidata(writer, client, 2, profile, config);
+    Wikidata fixture = createFixture(writer, client, 2);
     fixture.fetch(1L);
     Mockito.verifyNoInteractions(client);
     Mockito.when(client.send(Mockito.any()))
@@ -142,7 +142,7 @@ class WikidataTest {
       dynamicTest("do not re-request on subsequent loads", () -> {
         StringWriter writer2 = new StringWriter();
         Wikidata.Client client2 = Mockito.mock(Wikidata.Client.class, Mockito.RETURNS_SMART_NULLS);
-        Wikidata fixture2 = new Wikidata(writer2, client2, 2, profile, config);
+        Wikidata fixture2 = createFixture(writer2, client2, 2);
         fixture2.loadExisting(Wikidata.load(new BufferedReader(new StringReader(writer.toString()))));
         fixture2.fetch(1L);
         fixture2.fetch(2L);
@@ -157,7 +157,7 @@ class WikidataTest {
   void testRetryFailedRequestOnce() throws IOException, InterruptedException {
     StringWriter writer = new StringWriter();
     Wikidata.Client client = Mockito.mock(Wikidata.Client.class, Mockito.RETURNS_SMART_NULLS);
-    Wikidata fixture = new Wikidata(writer, client, 1, profile, config);
+    Wikidata fixture = createFixture(writer, client, 1);
     Mockito.when(client.send(Mockito.any()))
       // fail once then succeed
       .thenThrow(IOException.class)
@@ -235,5 +235,14 @@ class WikidataTest {
       }
     }));
     return stringSubscriber.getBody().toCompletableFuture().join();
+  }
+
+  private Wikidata createFixture(StringWriter writer, Wikidata.Client client, int batchSize) {
+    return new Wikidata(writer, client, batchSize, profile, config) {
+      @Override
+      protected void sleep(Duration duration) {
+        // don't sleep in tests
+      }
+    };
   }
 }

--- a/planetiler-examples/src/test/java/com/onthegomap/planetiler/examples/BikeRouteOverlayTest.java
+++ b/planetiler-examples/src/test/java/com/onthegomap/planetiler/examples/BikeRouteOverlayTest.java
@@ -96,7 +96,7 @@ class BikeRouteOverlayTest {
       // Override input source locations
       "osm_path", TestUtils.pathToResource("monaco-latest.osm.pbf"),
       // Override temp dir location
-      "tmp", tmpDir.toString(),
+      "tmpdir", tmpDir.toString(),
       // Override output location
       "output", dbPath.toString()
     ));

--- a/planetiler-examples/src/test/java/com/onthegomap/planetiler/examples/OsmQaTilesTest.java
+++ b/planetiler-examples/src/test/java/com/onthegomap/planetiler/examples/OsmQaTilesTest.java
@@ -91,7 +91,7 @@ class OsmQaTilesTest {
       // Override input source locations
       "osm_path", TestUtils.pathToResource("monaco-latest.osm.pbf"),
       // Override temp dir location
-      "tmp", tmpDir.toString(),
+      "tmpdir", tmpDir.toString(),
       // Override output location
       "output", dbPath.toString()
     ));

--- a/planetiler-examples/src/test/java/com/onthegomap/planetiler/examples/ToiletsProfileTest.java
+++ b/planetiler-examples/src/test/java/com/onthegomap/planetiler/examples/ToiletsProfileTest.java
@@ -56,7 +56,7 @@ class ToiletsProfileTest {
       // Override input source locations
       "osm_path", TestUtils.pathToResource("monaco-latest.osm.pbf"),
       // Override temp dir location
-      "tmp", tmpDir.toString(),
+      "tmpdir", tmpDir.toString(),
       // Override output location
       "output", dbPath.toString()
     ));

--- a/pom.xml
+++ b/pom.xml
@@ -236,11 +236,15 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.5.2</version>
-        <!-- by default surefire excludes tests on nested classes https://github.com/junit-team/junit5/issues/1377 -->
         <configuration>
+          <!-- by default surefire excludes tests on nested classes https://github.com/junit-team/junit5/issues/1377 -->
           <excludes>
             <exclude/>
           </excludes>
+          <!-- by default surefire only includes tests matching Test*.java *Test.java or *TestCase.java -->
+          <includes>
+            <include>**/*.java</include>
+          </includes>
         </configuration>
       </plugin>
       <plugin>
@@ -451,6 +455,7 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <groups>!slow</groups>
+              <forkCount>1C</forkCount>
             </configuration>
           </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -441,5 +441,20 @@
         </plugins>
       </build>
     </profile>
+    <!-- run with -Pfast to skip slow tests -->
+    <profile>
+      <id>fast</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <groups>!slow</groups>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>

--- a/scripts/fasttests.sh
+++ b/scripts/fasttests.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+./mvnw -Pfast clean test

--- a/scripts/fasttests.sh
+++ b/scripts/fasttests.sh
@@ -4,4 +4,4 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-./mvnw -Pfast clean test
+./mvnw -T 1C -Pfast clean test


### PR DESCRIPTION
The tests can take a while to run, so add a `scripts/fasttests.sh` script that runs `mvn -Pfast clean test` where the "fast" maven profile skips tests annotated with `@Slow` (integration tests, etc.) Also make the fast profile run tests in parallel, to get it down to around 30 seconds.