### PR TITLE
Add more flexibility to "languages" flag

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
@@ -48,6 +48,7 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -103,7 +104,7 @@ public class Planetiler {
   private boolean overwrite = false;
   private boolean ran = false;
   // most common OSM languages
-  private List<String> languages = List.of(
+  private List<String> defaultLanguages = List.of(
     "en", "ru", "ar", "zh", "ja", "ko", "fr",
     "de", "fi", "pl", "es", "be", "br", "he"
   );
@@ -547,7 +548,7 @@ public class Planetiler {
    * @return this runner instance for chaining
    */
   public Planetiler setDefaultLanguages(List<String> languages) {
-    this.languages = languages;
+    this.defaultLanguages = languages;
     return this;
   }
 
@@ -587,7 +588,13 @@ public class Planetiler {
   public Translations translations() {
     if (translations == null) {
       boolean transliterate = arguments.getBoolean("transliterate", "attempt to transliterate latin names", true);
-      List<String> languages = arguments.getList("languages", "languages to use", this.languages);
+      List<String> languages = arguments.getList("languages", "Languages to include labels for. \"default\" expands to the default set of languages configured by the profile. \"-lang\" excludes \"lang\". \"*\" includes every language not listed.", this.defaultLanguages);
+      if (languages.contains("default")) {
+        languages = Stream.concat(
+          languages.stream().filter(language -> !language.equals("default")),
+          this.defaultLanguages.stream()
+        ).toList();
+      }
       translations = Translations.defaultProvider(languages).setShouldTransliterate(transliterate);
     }
     return translations;

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
@@ -2714,6 +2714,17 @@ class PlanetilerTests {
     assertTrue(polyResultz8.tiles.containsKey(TileCoord.ofXYZ(z8tiles * 3 / 4, z8tiles * 7 / 8, 8)));
   }
 
+  @Test
+  void testDefaultLanguages() {
+    var planetiler = Planetiler.create(Arguments.of("languages", "default,en"))
+      .setDefaultLanguages(List.of("jbo", "tlh"));
+    var translations = planetiler.translations();
+    assertTrue(translations.careAboutLanguage("jbo"));
+    assertTrue(translations.careAboutLanguage("tlh"));
+    assertTrue(translations.careAboutLanguage("en"));
+    assertFalse(translations.careAboutLanguage("fr"));
+  }
+
   @FunctionalInterface
   private interface ReadableTileArchiveFactory {
     ReadableTileArchive create(Path p) throws IOException;

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/util/TranslationsTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/util/TranslationsTest.java
@@ -1,10 +1,16 @@
 package com.onthegomap.planetiler.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class TranslationsTest {
 
@@ -32,5 +38,26 @@ class TranslationsTest {
   @Test
   void testTransliterate() {
     assertEquals("rì běn", Translations.transliterate("日本"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("includeExcludeCases")
+  void testIncludeExclude(List<String> languages, List<String> shouldCare, List<String> shouldNotCare) {
+    var translations = Translations.nullProvider(languages);
+    for (var lang : shouldCare) {
+      assertTrue(translations.careAboutLanguage(lang));
+    }
+    for (var lang : shouldNotCare) {
+      assertFalse(translations.careAboutLanguage(lang));
+    }
+  }
+
+  private static Stream<Arguments> includeExcludeCases() {
+    return Stream.of(
+      Arguments.of(List.of("jbo", "tlh"), List.of("jbo", "tlh"), List.of("en", "fr")),
+      Arguments.of(List.of("*"), List.of("jbo", "tlh", "en", "fr"), List.of()),
+      Arguments.of(List.of("*", "-tlh"), List.of("jbo", "fr"), List.of("tlh")),
+      Arguments.of(List.of("tlh", "-tlh"), List.of(), List.of("tlh", "en"))
+    );
   }
 }


### PR DESCRIPTION
With this, the flag supports:

- "default" to append the default set of languages, instead of overriding it entirely, e.g. --languages=default,tlh means all default languages *plus* Klingon.
- "-lang" to exclude languages, e.g. --languages=default,-en means all default languages *except* English.
- "*" to include all languages not specified. This can be combined with "-lang". e.g. --languages=*,-jbo means all languages *except* Lojban.