### PR TITLE
GeometryPipeline

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureCollector.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureCollector.java
@@ -749,7 +749,7 @@ public class FeatureCollector implements Iterable<FeatureCollector.Feature> {
      * features. This function gets run instead of simplification, so should include any simplification if you want
      * that.
      */
-    public Feature setGeometryPipeline(GeometryPipeline pipeline) {
+    public Feature transformScaledGeometry(GeometryPipeline pipeline) {
       this.defaultGeometryPipeline = pipeline;
       return this;
     }
@@ -759,7 +759,7 @@ public class FeatureCollector implements Iterable<FeatureCollector.Feature> {
      * vector tile features. These functions get run instead of simplification, so should include any simplification if
      * you want that.
      */
-    public Feature setGeometryPipelineByZoom(ZoomFunction<GeometryPipeline> overrides) {
+    public Feature transformScaledGeometryByZoom(ZoomFunction<GeometryPipeline> overrides) {
       this.geometryPipelineByZoom = overrides;
       return this;
     }
@@ -768,7 +768,7 @@ public class FeatureCollector implements Iterable<FeatureCollector.Feature> {
      * Returns the geometry transform function to apply to scaled geometries at {@code zoom}, or null to not update them
      * at all.
      */
-    public GeometryPipeline getGeometryPipelineAtZoom(int zoom) {
+    public GeometryPipeline getScaledGeometryTransformAtZoom(int zoom) {
       return ZoomFunction.applyOrElse(geometryPipelineByZoom, zoom, defaultGeometryPipeline);
     }
 

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureCollector.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureCollector.java
@@ -507,8 +507,8 @@ public class FeatureCollector implements Iterable<FeatureCollector.Feature> {
     private SimplifyMethod defaultSimplifyMethod = SimplifyMethod.DOUGLAS_PEUCKER;
     private ZoomFunction<SimplifyMethod> simplifyMethod = null;
 
-    private GeometryPipeline defaultGeometryTransform = null;
-    private ZoomFunction<GeometryPipeline> geometryTransformByZoom = null;
+    private GeometryPipeline defaultGeometryPipeline = null;
+    private ZoomFunction<GeometryPipeline> geometryPipelineByZoom = null;
 
     private String numPointsAttr = null;
     private List<OverrideCommand> partialOverrides = null;
@@ -744,18 +744,32 @@ public class FeatureCollector implements Iterable<FeatureCollector.Feature> {
       return ZoomFunction.applyOrElse(simplifyMethod, zoom, defaultSimplifyMethod);
     }
 
-    public Feature setGeometryTransform(GeometryPipeline pipeline) {
-      this.defaultGeometryTransform = pipeline;
+    /**
+     * Sets the default pipeline to apply to geometries scaled to tile coordinates right before emitting vector tile
+     * features. This function gets run instead of simplification, so should include any simplification if you want
+     * that.
+     */
+    public Feature setGeometryPipeline(GeometryPipeline pipeline) {
+      this.defaultGeometryPipeline = pipeline;
       return this;
     }
 
-    public Feature setGeometryTransformByZoom(ZoomFunction<GeometryPipeline> overrides) {
-      this.geometryTransformByZoom = overrides;
+    /**
+     * Sets the per-zoom geometry pipeline to apply to geometries scaled to tile coordinates right before emitting
+     * vector tile features. These functions get run instead of simplification, so should include any simplification if
+     * you want that.
+     */
+    public Feature setGeometryPipelineByZoom(ZoomFunction<GeometryPipeline> overrides) {
+      this.geometryPipelineByZoom = overrides;
       return this;
     }
 
-    public GeometryPipeline getGeometryTransformAtZoom(int zoom) {
-      return ZoomFunction.applyOrElse(geometryTransformByZoom, zoom, defaultGeometryTransform);
+    /**
+     * Returns the geometry transform function to apply to scaled geometries at {@code zoom}, or null to not update them
+     * at all.
+     */
+    public GeometryPipeline getGeometryPipelineAtZoom(int zoom) {
+      return ZoomFunction.applyOrElse(geometryPipelineByZoom, zoom, defaultGeometryPipeline);
     }
 
     /**

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureCollector.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureCollector.java
@@ -5,6 +5,7 @@ import com.onthegomap.planetiler.collection.FeatureGroup;
 import com.onthegomap.planetiler.config.PlanetilerConfig;
 import com.onthegomap.planetiler.geo.GeoUtils;
 import com.onthegomap.planetiler.geo.GeometryException;
+import com.onthegomap.planetiler.geo.GeometryPipeline;
 import com.onthegomap.planetiler.geo.GeometryType;
 import com.onthegomap.planetiler.geo.SimplifyMethod;
 import com.onthegomap.planetiler.reader.SourceFeature;
@@ -506,6 +507,9 @@ public class FeatureCollector implements Iterable<FeatureCollector.Feature> {
     private SimplifyMethod defaultSimplifyMethod = SimplifyMethod.DOUGLAS_PEUCKER;
     private ZoomFunction<SimplifyMethod> simplifyMethod = null;
 
+    private GeometryPipeline defaultGeometryTransform = null;
+    private ZoomFunction<GeometryPipeline> geometryTransformByZoom = null;
+
     private String numPointsAttr = null;
     private List<OverrideCommand> partialOverrides = null;
 
@@ -738,6 +742,20 @@ public class FeatureCollector implements Iterable<FeatureCollector.Feature> {
      */
     public SimplifyMethod getSimplifyMethodAtZoom(int zoom) {
       return ZoomFunction.applyOrElse(simplifyMethod, zoom, defaultSimplifyMethod);
+    }
+
+    public Feature setGeometryTransform(GeometryPipeline pipeline) {
+      this.defaultGeometryTransform = pipeline;
+      return this;
+    }
+
+    public Feature setGeometryTransformByZoom(ZoomFunction<GeometryPipeline> overrides) {
+      this.geometryTransformByZoom = overrides;
+      return this;
+    }
+
+    public GeometryPipeline getGeometryTransformAtZoom(int zoom) {
+      return ZoomFunction.applyOrElse(geometryTransformByZoom, zoom, defaultGeometryTransform);
     }
 
     /**

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureCollector.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureCollector.java
@@ -1123,6 +1123,10 @@ public class FeatureCollector implements Iterable<FeatureCollector.Feature> {
       return rangesWithGeometries;
     }
 
+    public SourceFeature source() {
+      return source;
+    }
+
 
     /**
      * A builder that can be used to configure linear-scoped attributes for a partial segment of a line feature.

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureCollector.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureCollector.java
@@ -748,6 +748,9 @@ public class FeatureCollector implements Iterable<FeatureCollector.Feature> {
      * Sets the default pipeline to apply to geometries scaled to tile coordinates right before emitting vector tile
      * features. This function gets run instead of simplification, so should include any simplification if you want
      * that.
+     * <p>
+     * Geometries will be in scaled tile coordinates, so {@code 0,0} is the northwest corner and {@code 2^z, 2^z} is the
+     * southeast corner of the world scaled to web mercator coordinates.
      */
     public Feature transformScaledGeometry(GeometryPipeline pipeline) {
       this.defaultGeometryPipeline = pipeline;
@@ -755,9 +758,12 @@ public class FeatureCollector implements Iterable<FeatureCollector.Feature> {
     }
 
     /**
-     * Sets the per-zoom geometry pipeline to apply to geometries scaled to tile coordinates right before emitting
-     * vector tile features. These functions get run instead of simplification, so should include any simplification if
-     * you want that.
+     * Dynamically change the geometry pipeline to apply to geometries scaled to tile coordinates right before emitting
+     * vector tile features at each zoom level. These functions get run instead of simplification, so should include any
+     * simplification if you want that.
+     * <p>
+     * Geometries will be in scaled tile coordinates, so {@code 0,0} is the northwest corner and {@code 2^z, 2^z} is the
+     * southeast corner of the world scaled to web mercator coordinates.
      */
     public Feature transformScaledGeometryByZoom(ZoomFunction<GeometryPipeline> overrides) {
       this.geometryPipelineByZoom = overrides;

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureMerge.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureMerge.java
@@ -291,7 +291,8 @@ public class FeatureMerge {
    * @param buffer      the amount (in tile pixels) to expand then contract polygons by in order to combine
    *                    almost-touching polygons
    * @param stats       for counting data errors
-   * @param pipeline    a transform that should be applied to each merged polygon
+   * @param pipeline    a transform that should be applied to each merged polygon in tile pixel coordinates where
+   *                    {@code 0,0} is the top-left and {@code 256,256} is the bottom-right corner of the tile
    * @return a new list containing all unaltered features in their original order, then each of the merged groups
    *         ordered by the index of the first element in that group from the input list.
    * @throws GeometryException if an error occurs encoding the combined geometry
@@ -349,7 +350,7 @@ public class FeatureMerge {
             if (!(after instanceof Polygonal)) {
               continue;
             } else if (after != merged) {
-              merged = GeoUtils.snapAndFixPolygon(after, stats, "merge").reverse();
+              merged = GeoUtils.snapAndFixPolygon(after, stats, "merge_after_pipeline").reverse();
             }
           }
         }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureMerge.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureMerge.java
@@ -6,6 +6,7 @@ import com.carrotsearch.hppc.IntStack;
 import com.onthegomap.planetiler.collection.Hppc;
 import com.onthegomap.planetiler.geo.GeoUtils;
 import com.onthegomap.planetiler.geo.GeometryException;
+import com.onthegomap.planetiler.geo.GeometryPipeline;
 import com.onthegomap.planetiler.geo.GeometryType;
 import com.onthegomap.planetiler.geo.MutableCoordinateSequence;
 import com.onthegomap.planetiler.stats.DefaultStats;
@@ -81,7 +82,7 @@ public class FeatureMerge {
    */
   public static List<VectorTile.Feature> mergeLineStrings(List<VectorTile.Feature> features,
     double minLength, double tolerance, double buffer, boolean resimplify) {
-    return mergeLineStrings(features, attrs -> minLength, tolerance, buffer, resimplify);
+    return mergeLineStrings(features, attrs -> minLength, tolerance, buffer, resimplify, null);
   }
 
   /**
@@ -143,12 +144,13 @@ public class FeatureMerge {
   }
 
   /**
-   * Merges linestrings with the same attributes as {@link #mergeLineStrings(List, Function, double, double, boolean)}
-   * except sets {@code resimplify=false} by default.
+   * Merges linestrings with the same attributes as
+   * {@link #mergeLineStrings(List, Function, double, double, boolean, GeometryPipeline)} except sets
+   * {@code resimplify=false} by default.
    */
   public static List<VectorTile.Feature> mergeLineStrings(List<VectorTile.Feature> features,
     Function<Map<String, Object>, Double> lengthLimitCalculator, double tolerance, double buffer) {
-    return mergeLineStrings(features, lengthLimitCalculator, tolerance, buffer, false);
+    return mergeLineStrings(features, lengthLimitCalculator, tolerance, buffer, false, null);
   }
 
   /**
@@ -156,7 +158,8 @@ public class FeatureMerge {
    * except with a dynamic length limit computed by {@code lengthLimitCalculator} for the attributes of each group.
    */
   public static List<VectorTile.Feature> mergeLineStrings(List<VectorTile.Feature> features,
-    Function<Map<String, Object>, Double> lengthLimitCalculator, double tolerance, double buffer, boolean resimplify) {
+    Function<Map<String, Object>, Double> lengthLimitCalculator, double tolerance, double buffer, boolean resimplify,
+    GeometryPipeline pipeline) {
     List<VectorTile.Feature> result = new ArrayList<>(features.size());
     var groupedByAttrs = groupByAttrs(features, result, GeometryType.LINE);
     for (List<VectorTile.Feature> groupedFeatures : groupedByAttrs) {
@@ -176,7 +179,8 @@ public class FeatureMerge {
           .setMergeStrokes(true)
           .setMinLength(lengthLimit)
           .setLoopMinLength(lengthLimit)
-          .setStubMinLength(0.5);
+          .setStubMinLength(0.5)
+          .setSegmentTransform(pipeline);
         for (VectorTile.Feature feature : groupedFeatures) {
           try {
             merger.add(feature.geometry().decode());
@@ -287,12 +291,14 @@ public class FeatureMerge {
    * @param buffer      the amount (in tile pixels) to expand then contract polygons by in order to combine
    *                    almost-touching polygons
    * @param stats       for counting data errors
+   * @param pipeline    a transform that should be applied to each merged polygon
    * @return a new list containing all unaltered features in their original order, then each of the merged groups
    *         ordered by the index of the first element in that group from the input list.
    * @throws GeometryException if an error occurs encoding the combined geometry
    */
   public static List<VectorTile.Feature> mergeNearbyPolygons(List<VectorTile.Feature> features, double minArea,
-    double minHoleArea, double minDist, double buffer, Stats stats) throws GeometryException {
+    double minHoleArea, double minDist, double buffer, Stats stats, GeometryPipeline pipeline)
+    throws GeometryException {
     List<VectorTile.Feature> result = new ArrayList<>(features.size());
     Collection<List<VectorTile.Feature>> groupedByAttrs = groupByAttrs(features, result, GeometryType.POLYGON);
     for (List<VectorTile.Feature> groupedFeatures : groupedByAttrs) {
@@ -326,11 +332,25 @@ public class FeatureMerge {
           if (!(merged instanceof Polygonal) || merged.getEnvelopeInternal().getArea() < minArea) {
             continue;
           }
+          if (pipeline != null) {
+            merged = pipeline.apply(merged);
+            if (!(merged instanceof Polygonal)) {
+              continue;
+            }
+          }
           merged = GeoUtils.snapAndFixPolygon(merged, stats, "merge").reverse();
         } else {
           merged = polygonGroup.getFirst();
           if (!(merged instanceof Polygonal) || merged.getEnvelopeInternal().getArea() < minArea) {
             continue;
+          }
+          if (pipeline != null) {
+            Geometry after = pipeline.apply(merged);
+            if (!(after instanceof Polygonal)) {
+              continue;
+            } else if (after != merged) {
+              merged = GeoUtils.snapAndFixPolygon(after, stats, "merge").reverse();
+            }
           }
         }
         extractPolygons(merged, outPolygons, minArea, minHoleArea);
@@ -354,7 +374,7 @@ public class FeatureMerge {
 
   public static List<VectorTile.Feature> mergeNearbyPolygons(List<VectorTile.Feature> features, double minArea,
     double minHoleArea, double minDist, double buffer) throws GeometryException {
-    return mergeNearbyPolygons(features, minArea, minHoleArea, minDist, buffer, DefaultStats.get());
+    return mergeNearbyPolygons(features, minArea, minHoleArea, minDist, buffer, DefaultStats.get(), null);
   }
 
 

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/DouglasPeuckerSimplifier.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/DouglasPeuckerSimplifier.java
@@ -189,7 +189,8 @@ public class DouglasPeuckerSimplifier extends GeometryTransformer implements Geo
   }
 
   protected List<Coordinate> transformCoordinateList(List<Coordinate> coords, boolean area) {
-    if (coords.isEmpty()) {
+    int minPoints = area ? 4 : 2;
+    if (coords.size() <= minPoints) {
       return coords;
     }
     // make sure we include the first and last points even if they are closer than the simplification threshold
@@ -197,7 +198,7 @@ public class DouglasPeuckerSimplifier extends GeometryTransformer implements Geo
     result.add(coords.getFirst());
     // for polygons, additionally keep at least 2 intermediate points even if they are below simplification threshold
     // to avoid collapse.
-    subsimplify(coords, result, 0, coords.size() - 1, area ? 2 : 0);
+    subsimplify(coords, result, 0, coords.size() - 1, minPoints - 2);
     result.add(coords.getLast());
     return result;
   }
@@ -205,7 +206,8 @@ public class DouglasPeuckerSimplifier extends GeometryTransformer implements Geo
   @Override
   protected CoordinateSequence transformCoordinates(CoordinateSequence coords, Geometry parent) {
     boolean area = parent instanceof LinearRing;
-    if (coords.size() == 0) {
+    int minPoints = area ? 4 : 2;
+    if (coords.size() <= minPoints) {
       return coords;
     }
     // make sure we include the first and last points even if they are closer than the simplification threshold
@@ -213,7 +215,7 @@ public class DouglasPeuckerSimplifier extends GeometryTransformer implements Geo
     result.forceAddPoint(coords.getX(0), coords.getY(0));
     // for polygons, additionally keep at least 2 intermediate points even if they are below simplification threshold
     // to avoid collapse.
-    subsimplify(coords, result, 0, coords.size() - 1, area ? 2 : 0);
+    subsimplify(coords, result, 0, coords.size() - 1, minPoints - 2);
     result.forceAddPoint(coords.getX(coords.size() - 1), coords.getY(coords.size() - 1));
     return result;
   }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/DouglasPeuckerSimplifier.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/DouglasPeuckerSimplifier.java
@@ -92,7 +92,7 @@ public class DouglasPeuckerSimplifier extends GeometryTransformer implements Geo
    * Returns the square of the number of units that (px, p1) is away from the line segment from (p1x, py1) to (p2x,
    * p2y).
    */
-  private static double getSqSegDist(double px, double py, double p1x, double p1y, double p2x, double p2y) {
+  public static double getSqSegDist(double px, double py, double p1x, double p1y, double p2x, double p2y) {
 
     double x = p1x,
       y = p1y,

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/DouglasPeuckerSimplifier.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/DouglasPeuckerSimplifier.java
@@ -30,7 +30,31 @@ import org.locationtech.jts.geom.util.GeometryTransformer;
  * accurately and performance improvement to put the results in a {@link MutableCoordinateSequence} which uses a
  * primitive double array instead of allocating lots of {@link Coordinate} objects.
  */
-public class DouglasPeuckerSimplifier {
+public class DouglasPeuckerSimplifier extends GeometryTransformer implements GeometryPipeline {
+
+  private final double sqTolerance;
+
+  public DouglasPeuckerSimplifier(double distanceTolerance) {
+    this.sqTolerance = distanceTolerance * Math.abs(distanceTolerance);
+  }
+
+  @Override
+  public Geometry apply(Geometry input) {
+    return simplify(input);
+  }
+
+  /**
+   * Returns a copy of {@code geom}, simplified using Douglas Peucker Algorithm.
+   *
+   * @param geom the geometry to simplify (will not be modified)
+   * @return the simplified geometry
+   */
+  public Geometry simplify(Geometry geom) {
+    if (geom.isEmpty() || (sqTolerance < 0.0)) {
+      return geom.copy();
+    }
+    return transform(geom);
+  }
 
   /**
    * Returns a copy of {@code geom}, simplified using Douglas Peucker Algorithm.
@@ -44,7 +68,7 @@ public class DouglasPeuckerSimplifier {
       return geom.copy();
     }
 
-    return (new DPTransformer(distanceTolerance)).transform(geom);
+    return (new DouglasPeuckerSimplifier(distanceTolerance)).simplify(geom);
   }
 
   /**
@@ -60,160 +84,152 @@ public class DouglasPeuckerSimplifier {
       return List.of();
     }
 
-    return (new DPTransformer(distanceTolerance)).transformCoordinateList(coords, area);
+    return (new DouglasPeuckerSimplifier(distanceTolerance)).transformCoordinateList(coords, area);
   }
 
-  private static class DPTransformer extends GeometryTransformer {
 
-    private final double sqTolerance;
+  /**
+   * Returns the square of the number of units that (px, p1) is away from the line segment from (p1x, py1) to (p2x,
+   * p2y).
+   */
+  private static double getSqSegDist(double px, double py, double p1x, double p1y, double p2x, double p2y) {
 
-    private DPTransformer(double distanceTolerance) {
-      this.sqTolerance = distanceTolerance * distanceTolerance;
-    }
+    double x = p1x,
+      y = p1y,
+      dx = p2x - x,
+      dy = p2y - y;
 
-    /**
-     * Returns the square of the number of units that (px, p1) is away from the line segment from (p1x, py1) to (p2x,
-     * p2y).
-     */
-    private static double getSqSegDist(double px, double py, double p1x, double p1y, double p2x, double p2y) {
+    if (dx != 0d || dy != 0d) {
 
-      double x = p1x,
-        y = p1y,
-        dx = p2x - x,
-        dy = p2y - y;
+      double t = ((px - x) * dx + (py - y) * dy) / (dx * dx + dy * dy);
 
-      if (dx != 0d || dy != 0d) {
+      if (t > 1) {
+        x = p2x;
+        y = p2y;
 
-        double t = ((px - x) * dx + (py - y) * dy) / (dx * dx + dy * dy);
-
-        if (t > 1) {
-          x = p2x;
-          y = p2y;
-
-        } else if (t > 0) {
-          x += dx * t;
-          y += dy * t;
-        }
-      }
-
-      dx = px - x;
-      dy = py - y;
-
-      return dx * dx + dy * dy;
-    }
-
-    private void subsimplify(List<Coordinate> in, List<Coordinate> out, int first, int last, int numForcedPoints) {
-      // numForcePoints lets us keep some points even if they are below simplification threshold
-      boolean force = numForcedPoints > 0;
-      double maxSqDist = force ? -1 : sqTolerance;
-      int index = -1;
-      Coordinate p1 = in.get(first);
-      Coordinate p2 = in.get(last);
-      double p1x = p1.x;
-      double p1y = p1.y;
-      double p2x = p2.x;
-      double p2y = p2.y;
-
-      int i = first + 1;
-      Coordinate furthest = null;
-      for (Coordinate coord : in.subList(first + 1, last)) {
-        double sqDist = getSqSegDist(coord.x, coord.y, p1x, p1y, p2x, p2y);
-
-        if (sqDist > maxSqDist) {
-          index = i;
-          furthest = coord;
-          maxSqDist = sqDist;
-        }
-        i++;
-      }
-
-      if (force || maxSqDist > sqTolerance) {
-        if (index - first > 1) {
-          subsimplify(in, out, first, index, numForcedPoints - 1);
-        }
-        out.add(furthest);
-        if (last - index > 1) {
-          subsimplify(in, out, index, last, numForcedPoints - 2);
-        }
+      } else if (t > 0) {
+        x += dx * t;
+        y += dy * t;
       }
     }
 
-    private void subsimplify(CoordinateSequence in, MutableCoordinateSequence out, int first, int last,
-      int numForcedPoints) {
-      // numForcePoints lets us keep some points even if they are below simplification threshold
-      boolean force = numForcedPoints > 0;
-      double maxSqDist = force ? -1 : sqTolerance;
-      int index = -1;
-      double p1x = in.getX(first);
-      double p1y = in.getY(first);
-      double p2x = in.getX(last);
-      double p2y = in.getY(last);
+    dx = px - x;
+    dy = py - y;
 
-      for (int i = first + 1; i < last; i++) {
-        double px = in.getX(i);
-        double py = in.getY(i);
-        double sqDist = getSqSegDist(px, py, p1x, p1y, p2x, p2y);
+    return dx * dx + dy * dy;
+  }
 
-        if (sqDist > maxSqDist) {
-          index = i;
-          maxSqDist = sqDist;
-        }
+  private void subsimplify(List<Coordinate> in, List<Coordinate> out, int first, int last, int numForcedPoints) {
+    // numForcePoints lets us keep some points even if they are below simplification threshold
+    boolean force = numForcedPoints > 0;
+    double maxSqDist = force ? -1 : sqTolerance;
+    int index = -1;
+    Coordinate p1 = in.get(first);
+    Coordinate p2 = in.get(last);
+    double p1x = p1.x;
+    double p1y = p1.y;
+    double p2x = p2.x;
+    double p2y = p2.y;
+
+    int i = first + 1;
+    Coordinate furthest = null;
+    for (Coordinate coord : in.subList(first + 1, last)) {
+      double sqDist = getSqSegDist(coord.x, coord.y, p1x, p1y, p2x, p2y);
+
+      if (sqDist > maxSqDist) {
+        index = i;
+        furthest = coord;
+        maxSqDist = sqDist;
       }
+      i++;
+    }
 
-      if (force || maxSqDist > sqTolerance) {
-        if (index - first > 1) {
-          subsimplify(in, out, first, index, numForcedPoints - 1);
-        }
-        out.forceAddPoint(in.getX(index), in.getY(index));
-        if (last - index > 1) {
-          subsimplify(in, out, index, last, numForcedPoints - 2);
-        }
+    if (force || maxSqDist > sqTolerance) {
+      if (index - first > 1) {
+        subsimplify(in, out, first, index, numForcedPoints - 1);
+      }
+      out.add(furthest);
+      if (last - index > 1) {
+        subsimplify(in, out, index, last, numForcedPoints - 2);
+      }
+    }
+  }
+
+  private void subsimplify(CoordinateSequence in, MutableCoordinateSequence out, int first, int last,
+    int numForcedPoints) {
+    // numForcePoints lets us keep some points even if they are below simplification threshold
+    boolean force = numForcedPoints > 0;
+    double maxSqDist = force ? -1 : sqTolerance;
+    int index = -1;
+    double p1x = in.getX(first);
+    double p1y = in.getY(first);
+    double p2x = in.getX(last);
+    double p2y = in.getY(last);
+
+    for (int i = first + 1; i < last; i++) {
+      double px = in.getX(i);
+      double py = in.getY(i);
+      double sqDist = getSqSegDist(px, py, p1x, p1y, p2x, p2y);
+
+      if (sqDist > maxSqDist) {
+        index = i;
+        maxSqDist = sqDist;
       }
     }
 
-    protected List<Coordinate> transformCoordinateList(List<Coordinate> coords, boolean area) {
-      if (coords.isEmpty()) {
-        return coords;
+    if (force || maxSqDist > sqTolerance) {
+      if (index - first > 1) {
+        subsimplify(in, out, first, index, numForcedPoints - 1);
       }
-      // make sure we include the first and last points even if they are closer than the simplification threshold
-      List<Coordinate> result = new ArrayList<>();
-      result.add(coords.getFirst());
-      // for polygons, additionally keep at least 2 intermediate points even if they are below simplification threshold
-      // to avoid collapse.
-      subsimplify(coords, result, 0, coords.size() - 1, area ? 2 : 0);
-      result.add(coords.getLast());
-      return result;
-    }
-
-    @Override
-    protected CoordinateSequence transformCoordinates(CoordinateSequence coords, Geometry parent) {
-      boolean area = parent instanceof LinearRing;
-      if (coords.size() == 0) {
-        return coords;
+      out.forceAddPoint(in.getX(index), in.getY(index));
+      if (last - index > 1) {
+        subsimplify(in, out, index, last, numForcedPoints - 2);
       }
-      // make sure we include the first and last points even if they are closer than the simplification threshold
-      MutableCoordinateSequence result = new MutableCoordinateSequence();
-      result.forceAddPoint(coords.getX(0), coords.getY(0));
-      // for polygons, additionally keep at least 2 intermediate points even if they are below simplification threshold
-      // to avoid collapse.
-      subsimplify(coords, result, 0, coords.size() - 1, area ? 2 : 0);
-      result.forceAddPoint(coords.getX(coords.size() - 1), coords.getY(coords.size() - 1));
-      return result;
     }
+  }
 
-    @Override
-    protected Geometry transformPolygon(Polygon geom, Geometry parent) {
-      return geom.isEmpty() ? null : super.transformPolygon(geom, parent);
+  protected List<Coordinate> transformCoordinateList(List<Coordinate> coords, boolean area) {
+    if (coords.isEmpty()) {
+      return coords;
     }
+    // make sure we include the first and last points even if they are closer than the simplification threshold
+    List<Coordinate> result = new ArrayList<>();
+    result.add(coords.getFirst());
+    // for polygons, additionally keep at least 2 intermediate points even if they are below simplification threshold
+    // to avoid collapse.
+    subsimplify(coords, result, 0, coords.size() - 1, area ? 2 : 0);
+    result.add(coords.getLast());
+    return result;
+  }
 
-    @Override
-    protected Geometry transformLinearRing(LinearRing geom, Geometry parent) {
-      boolean removeDegenerateRings = parent instanceof Polygon;
-      Geometry simpResult = super.transformLinearRing(geom, parent);
-      if (removeDegenerateRings && !(simpResult instanceof LinearRing)) {
-        return null;
-      }
-      return simpResult;
+  @Override
+  protected CoordinateSequence transformCoordinates(CoordinateSequence coords, Geometry parent) {
+    boolean area = parent instanceof LinearRing;
+    if (coords.size() == 0) {
+      return coords;
     }
+    // make sure we include the first and last points even if they are closer than the simplification threshold
+    MutableCoordinateSequence result = new MutableCoordinateSequence();
+    result.forceAddPoint(coords.getX(0), coords.getY(0));
+    // for polygons, additionally keep at least 2 intermediate points even if they are below simplification threshold
+    // to avoid collapse.
+    subsimplify(coords, result, 0, coords.size() - 1, area ? 2 : 0);
+    result.forceAddPoint(coords.getX(coords.size() - 1), coords.getY(coords.size() - 1));
+    return result;
+  }
+
+  @Override
+  protected Geometry transformPolygon(Polygon geom, Geometry parent) {
+    return geom.isEmpty() ? null : super.transformPolygon(geom, parent);
+  }
+
+  @Override
+  protected Geometry transformLinearRing(LinearRing geom, Geometry parent) {
+    boolean removeDegenerateRings = parent instanceof Polygon;
+    Geometry simpResult = super.transformLinearRing(geom, parent);
+    if (removeDegenerateRings && !(simpResult instanceof LinearRing)) {
+      return null;
+    }
+    return simpResult;
   }
 }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/DualMidpointSmoother.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/DualMidpointSmoother.java
@@ -117,6 +117,7 @@ public class DualMidpointSmoother extends GeometryTransformer implements Geometr
       return coords.copy();
     }
     for (int iter = 0; iter < iters; iter++) {
+      assert iter < iters - 1 || (minSquaredVertexTolerance == 0 && minVertexArea == 0) : "reached max iterations";
       MutableCoordinateSequence result = new MutableCoordinateSequence();
       int last = coords.size() - 1;
       double x1, y1;
@@ -180,7 +181,9 @@ public class DualMidpointSmoother extends GeometryTransformer implements Geometr
       double maxDistSquared = Double.POSITIVE_INFINITY;
       if (maxArea > 0) {
         double sin = den <= 0 ? 0 : Math.abs(((x1 - x2) * (y3 - y2)) - ((y1 - y2) * (x3 - x2))) / den;
-        maxDistSquared = 2 * maxArea / sin;
+        if (sin != 0) {
+          maxDistSquared = 2 * maxArea / sin;
+        }
       }
       if (maxSquaredOffset > 0) {
         double cos = den <= 0 ? 0 : Math.clamp(((x1 - x2) * (x3 - x2) + (y1 - y2) * (y3 - y2)) / den, -1, 1);
@@ -194,7 +197,7 @@ public class DualMidpointSmoother extends GeometryTransformer implements Geometr
         if (Double.isNaN(maxDist)) {
           maxDist = Math.sqrt(maxDistSquared);
         }
-        nextA = maxDist / magA;
+        nextA = maxDist / magB;
       }
     }
 

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/DualMidpointSmoother.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/DualMidpointSmoother.java
@@ -7,7 +7,7 @@ import org.locationtech.jts.geom.util.GeometryTransformer;
 
 /**
  * Smooths an input geometry by interpolating 2 points at certain ratios along each edge and repeating for a set number
- * of iterations. This can be thought of as slicing off of each vertex until the segments are so short it appears round.
+ * of iterations. This can be thought of as slicing off each vertex until the segments are so short it appears round.
  * <p>
  * Instead of iterating a fixed number of iterations, you can set {@link #setMinVertexArea(double)} or
  * {@link #setMinVertexOffset(double)} to stop smoothing corners when the triangle formed by 3 consecutive vertices gets
@@ -107,7 +107,7 @@ public class DualMidpointSmoother extends GeometryTransformer implements Geometr
     return this;
   }
 
-  /** Sets the number of times that smoothing runs. */
+  /** Sets the maximum number of times that smoothing runs. */
   public DualMidpointSmoother setIters(int iters) {
     this.iters = iters;
     return this;

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/DualMidpointSmoother.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/DualMidpointSmoother.java
@@ -9,6 +9,14 @@ import org.locationtech.jts.geom.util.GeometryTransformer;
  * Smooths an input geometry by interpolating 2 points at certain ratios along each edge and repeating for a set number
  * of iterations. This can be thought of as slicing off of each vertex until the segments are so short it appears round.
  * <p>
+ * Instead of iterating a fixed number of iterations, you can set {@link #setMinVertexArea(double)} or
+ * {@link #setMinVertexTolerance(double)} to stop smoothing corners when the triangle formed by 3 consecutive vertices
+ * gets to small.
+ * <p>
+ * In order to avoid introducing too much error from the original shape when rounding corners between very long edges,
+ * you can set {@link #setMaxArea(double)} or {@link #setMaxOffset(double)} to move the new points closer to a vertex to
+ * limit the amount of error that is introduced.
+ * <p>
  * When the points are {@code [0.25, 0.75]} this is equivalent to
  * <a href="https://observablehq.com/@pamacha/chaikins-algorithm">Chaikin Smoothing</a>.
  */

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/DualMidpointSmoother.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/DualMidpointSmoother.java
@@ -1,0 +1,218 @@
+package com.onthegomap.planetiler.geo;
+
+import org.locationtech.jts.geom.CoordinateSequence;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.LinearRing;
+import org.locationtech.jts.geom.util.GeometryTransformer;
+
+/**
+ * Smooths an input geometry by interpolating 2 points at certain ratios along each edge and repeating for a set number
+ * of iterations. This can be thought of as slicing off of each vertex until the segments are so short it appears round.
+ * <p>
+ * When the points are {@code [0.25, 0.75]} this is equivalent to
+ * <a href="https://observablehq.com/@pamacha/chaikins-algorithm">Chaikin Smoothing</a>.
+ */
+public class DualMidpointSmoother extends GeometryTransformer implements GeometryPipeline {
+
+  private final double a;
+  private final double b;
+  private int iters = 1;
+  private double minSquaredVertexTolerance = 0;
+  private double minVertexArea = 0;
+  private double maxArea = 0;
+  private double maxSquaredOffset = 0;
+
+  public DualMidpointSmoother(double a, double b) {
+    this.a = a;
+    this.b = b;
+  }
+
+  /**
+   * Returns a new smoother that does <a href="https://observablehq.com/@pamacha/chaikins-algorithm">Chaikin
+   * Smoothing</a> {@code iters} times on the input line.
+   */
+  public static DualMidpointSmoother chaikin(int iters) {
+    return new DualMidpointSmoother(0.25, 0.75).setIters(iters);
+  }
+
+  /**
+   * Returns a new smoother that does <a href="https://observablehq.com/@pamacha/chaikins-algorithm">Chaikin
+   * Smoothing</a> but instead of stopping after a fixed number of iterations, it stops when the added points would get
+   * dropped with {@link DouglasPeuckerSimplifier Douglas-Peucker simplification} with {@code tolerance} threshold.
+   */
+  public static DualMidpointSmoother chaikinToTolerance(double tolerance) {
+    return chaikin(10).setMinVertexTolerance(tolerance);
+  }
+
+  /**
+   * Returns a new smoother that does <a href="https://observablehq.com/@pamacha/chaikins-algorithm">Chaikin
+   * Smoothing</a> but instead of stopping after a fixed number of iterations, it stops when the added points would get
+   * dropped with {@link VWSimplifier Visvalingam-Whyatt simplification} with {@code minArea} threshold.
+   */
+  public static DualMidpointSmoother chaikinToMinArea(double minArea) {
+    return chaikin(10).setMinVertexArea(minArea);
+  }
+
+  /**
+   * Sets the min distance between a vertex and the line between its neighbors below which a vertex will not be
+   * squashed.
+   * <p>
+   * If all points are below this threshold for an entire iteration then smoothing will stop before the maximum number
+   * of iterations is reached.
+   */
+  public DualMidpointSmoother setMinVertexTolerance(double minVertexTolerance) {
+    this.minSquaredVertexTolerance = minVertexTolerance * minVertexTolerance;
+    return this;
+  }
+
+  /**
+   * Sets the min area of the triangle created by a point and its 2 neighbors below which a vertex will not be squashed.
+   * <p>
+   * If all points are below this threshold for an entire iteration then smoothing will stop before the maximum number
+   * of iterations is reached.
+   */
+  public DualMidpointSmoother setMinVertexArea(double minVertexArea) {
+    this.minVertexArea = minVertexArea;
+    return this;
+  }
+
+  /**
+   * Sets a limit on the maximum area that can be removed when removing a vertex. When the area is larger than this, the
+   * new points are moved closer to the vertex in order to bring the removed area down to this threshold.
+   * <p>
+   * This prevents smoothing 2 long adjacent edges from introducing a large deviation from the original shape.
+   */
+  public DualMidpointSmoother setMaxArea(double maxArea) {
+    this.maxArea = maxArea;
+    return this;
+  }
+
+  /**
+   * Sets a limit on the maximum distance from the original shape that can be introduced by smoothing. When the error
+   * introduced by squashing a vertex will be above this threshold, the new points are moved closer to the vertex in
+   * order to bring the distance down to this threshold.
+   * <p>
+   * This prevents smoothing 2 long adjacent edges from introducing a large deviation from the original shape.
+   */
+  public DualMidpointSmoother setMaxOffset(double maxOffset) {
+    this.maxSquaredOffset = maxOffset * maxOffset;
+    return this;
+  }
+
+  /** Sets the number of times that smoothing runs. */
+  public DualMidpointSmoother setIters(int iters) {
+    this.iters = iters;
+    return this;
+  }
+
+  @Override
+  public Geometry apply(Geometry input) {
+    return transform(input);
+  }
+
+  @Override
+  protected CoordinateSequence transformCoordinates(CoordinateSequence coords, Geometry parent) {
+    boolean area = parent instanceof LinearRing;
+    if (coords.size() <= 2) {
+      return coords.copy();
+    }
+    boolean checkVertices = minSquaredVertexTolerance > 0 || minVertexArea > 0 || maxSquaredOffset > 0 || maxArea > 0;
+    for (int iter = 0; iter < iters; iter++) {
+      MutableCoordinateSequence result = new MutableCoordinateSequence();
+      if (!area) {
+        result.addPoint(coords.getX(0), coords.getY(0));
+      }
+      int last = coords.size() - 1;
+      double x2 = coords.getX(0);
+      double y2 = coords.getY(0);
+      double nextA = a;
+      boolean skippedLastVertex = false;
+      double x1, y1;
+      for (int i = 0; i < last; i++) {
+        x1 = x2;
+        y1 = y2;
+        x2 = coords.getX(i + 1);
+        y2 = coords.getY(i + 1);
+        double dx = x2 - x1;
+        double dy = y2 - y1;
+
+        if ((area || i > 0) && !skippedLastVertex) {
+          result.addPoint(x1 + dx * nextA, y1 + dy * nextA);
+        }
+        nextA = a;
+
+        if (area || i < last - 1) {
+          double nextB = b;
+          if (checkVertices) {
+            int next = i < last - 1 ? (i + 2) : 1;
+            double x3 = coords.getX(next);
+            double y3 = coords.getY(next);
+            if (skipVertex(x1, y1, x2, y2, x3, y3)) {
+              result.addPoint(x2, y2);
+              skippedLastVertex = true;
+              continue;
+            }
+            skippedLastVertex = false;
+
+            // check the amount of error introduced by removing this vertex (either by offset or area)
+            // and if it is too large, then move nextA/nextB ratios closer to the vertex to limit the error
+            if (maxArea > 0 || maxSquaredOffset > 0) {
+              double magA = Math.hypot(x2 - x1, y2 - y1);
+              double magB = Math.hypot(x3 - x2, y3 - y2);
+              double den = magA * magB;
+              double aDist = magA * (1 - b);
+              double bDist = magB * a;
+              double maxDistSquared = Double.POSITIVE_INFINITY;
+              if (maxArea > 0) {
+                double sin = den <= 0 ? 0 : Math.abs(((x1 - x2) * (y3 - y2)) - ((y1 - y2) * (x3 - x2))) / den;
+                maxDistSquared = 2 * maxArea / sin;
+              }
+              if (maxSquaredOffset > 0) {
+                double cos = den <= 0 ? 0 : Math.clamp(((x1 - x2) * (x3 - x2) + (y1 - y2) * (y3 - y2)) / den, -1, 1);
+                maxDistSquared = Math.min(maxDistSquared, 2 * maxSquaredOffset / (1 + cos));
+              }
+              double maxDist = Double.NaN;
+              if (aDist * aDist > maxDistSquared) {
+                nextB = 1 - (maxDist = Math.sqrt(maxDistSquared)) / magA;
+              }
+              if (bDist * bDist > maxDistSquared) {
+                if (Double.isNaN(maxDist)) {
+                  maxDist = Math.sqrt(maxDistSquared);
+                }
+                nextA = maxDist / magA;
+              }
+            }
+          }
+
+          result.addPoint(x1 + dx * nextB, y1 + dy * nextB);
+        }
+      }
+      if (area) {
+        if (skippedLastVertex) {
+          result.setX(0, result.getX(result.size() - 1));
+          result.setY(0, result.getY(result.size() - 1));
+        } else {
+          if (nextA != a) {
+            result.setX(0, (coords.getX(1) - coords.getX(0)) * nextA);
+            result.setY(0, (coords.getY(1) - coords.getY(0)) * nextA);
+          }
+          result.closeRing();
+        }
+      } else {
+        result.addPoint(coords.getX(last), coords.getY(last));
+      }
+      // early exit case: if no vertices were collapsed then we are done smoothing
+      if (coords.size() == result.size()) {
+        return result;
+      }
+      coords = result;
+    }
+    return coords;
+  }
+
+  private boolean skipVertex(double x1, double y1, double x2, double y2, double x3, double y3) {
+    return (minVertexArea > 0 && VWSimplifier.triangleArea(x1, y1, x2, y2, x3, y3) < minVertexArea) ||
+      (minSquaredVertexTolerance > 0 &&
+        DouglasPeuckerSimplifier.getSqSegDist(x2, y2, x1, y1, x3, y3) < minSquaredVertexTolerance);
+  }
+}

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/GeometryPipeline.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/GeometryPipeline.java
@@ -1,0 +1,12 @@
+package com.onthegomap.planetiler.geo;
+
+import org.locationtech.jts.geom.Geometry;
+
+@FunctionalInterface
+public interface GeometryPipeline {
+  Geometry apply(Geometry input);
+
+  default GeometryPipeline andThen(GeometryPipeline other) {
+    return input -> other.apply(apply(input));
+  }
+}

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/GeometryPipeline.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/GeometryPipeline.java
@@ -1,13 +1,83 @@
 package com.onthegomap.planetiler.geo;
 
+import com.onthegomap.planetiler.FeatureCollector;
+import com.onthegomap.planetiler.util.ZoomFunction;
 import org.locationtech.jts.geom.Geometry;
 
 @FunctionalInterface
-public interface GeometryPipeline {
+public interface GeometryPipeline extends ZoomFunction<GeometryPipeline> {
+  GeometryPipeline NOOP = g -> g;
+
   Geometry apply(Geometry input);
+
+  @Override
+  default GeometryPipeline apply(int zoom) {
+    // allow GeometryPipeline to be used where ZoomFunction<GeometryPipeline> is expected
+    return this;
+  }
 
   default GeometryPipeline andThen(GeometryPipeline other) {
     return input -> other.apply(apply(input));
+  }
+
+  /** Returns a function equivalent to {@code b(a(geom))} at each zoom. */
+  static ZoomFunction<GeometryPipeline> compose(ZoomFunction<GeometryPipeline> a, ZoomFunction<GeometryPipeline> b) {
+    return zoom -> ZoomFunction.applyOrElse(a, zoom, NOOP).andThen(ZoomFunction.applyOrElse(b, zoom, NOOP));
+  }
+
+  /** Returns a function that applies each argument sequentially to the input geometry at each zoom. */
+  @SafeVarargs
+  static ZoomFunction<GeometryPipeline> compose(
+    ZoomFunction<GeometryPipeline> a,
+    ZoomFunction<GeometryPipeline> b,
+    ZoomFunction<GeometryPipeline> c,
+    ZoomFunction<GeometryPipeline>... rest) {
+    return zoom -> geom -> {
+      geom = ZoomFunction.applyOrElse(a, zoom, NOOP).apply(geom);
+      geom = ZoomFunction.applyOrElse(b, zoom, NOOP).apply(geom);
+      geom = ZoomFunction.applyOrElse(c, zoom, NOOP).apply(geom);
+      if (rest != null) {
+        for (var fn : rest) {
+          geom = ZoomFunction.applyOrElse(fn, zoom, NOOP).apply(geom);
+        }
+      }
+      return geom;
+    };
+  }
+
+  /** Returns a function equivalent to {@code b(a(geom))} at each zoom. */
+  static ZoomFunction<GeometryPipeline> compose(ZoomFunction<GeometryPipeline> a, GeometryPipeline b) {
+    return zoom -> ZoomFunction.applyOrElse(a, zoom, NOOP).andThen(b);
+  }
+
+  /** Returns a function equivalent to {@code b(a(geom))} at each zoom. */
+  static ZoomFunction<GeometryPipeline> compose(GeometryPipeline a, ZoomFunction<GeometryPipeline> b) {
+    return zoom -> a.andThen(ZoomFunction.applyOrElse(b, zoom, NOOP));
+  }
+
+  /** Returns a function equivalent to {@code b(a(geom))} at each zoom. */
+  static GeometryPipeline compose(GeometryPipeline a, GeometryPipeline b) {
+    return a.andThen(b);
+  }
+
+
+  /**
+   * Returns a geometry pipeline that applies the normal geometry simplification to {@code feature} that would happen
+   * without any geometry pipeline.
+   */
+  static ZoomFunction<GeometryPipeline> defaultSimplify(FeatureCollector.Feature feature) {
+    return zoom -> {
+      double tolerance = feature.getPixelToleranceAtZoom(zoom) / 256d;
+      SimplifyMethod simplifyMethod = feature.getSimplifyMethodAtZoom(zoom);
+      return geom -> switch (simplifyMethod) {
+        case RETAIN_IMPORTANT_POINTS -> DouglasPeuckerSimplifier.simplify(geom, tolerance);
+        // DP tolerance is displacement, and VW tolerance is area, so square what the user entered to convert from
+        // DP to VW tolerance
+        case RETAIN_EFFECTIVE_AREAS -> new VWSimplifier().setTolerance(tolerance * tolerance).transform(geom);
+        case RETAIN_WEIGHTED_EFFECTIVE_AREAS ->
+          new VWSimplifier().setWeight(0.7).setTolerance(tolerance * tolerance).transform(geom);
+      };
+    };
   }
 
   /**

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/GeometryPipeline.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/GeometryPipeline.java
@@ -9,4 +9,19 @@ public interface GeometryPipeline {
   default GeometryPipeline andThen(GeometryPipeline other) {
     return input -> other.apply(apply(input));
   }
+
+  /**
+   * Returns a pipeline that simplifies input geometries using the {@link VWSimplifier Visvalingam Whyatt algorithm}.
+   */
+  static VWSimplifier simplifyVW(double tolerance) {
+    return new VWSimplifier().setTolerance(tolerance);
+  }
+
+  /**
+   * Returns a pipeline that simplifies input geometries using the {@link DouglasPeuckerSimplifier Douglas Peucker
+   * algorithm}.
+   */
+  static DouglasPeuckerSimplifier simplifyDP(double tolerance) {
+    return new DouglasPeuckerSimplifier(tolerance);
+  }
 }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/GeometryPipeline.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/GeometryPipeline.java
@@ -103,7 +103,7 @@ public interface GeometryPipeline extends ZoomFunction<GeometryPipeline> {
   }
 
   /**
-   * Returns a pipeline that smoothes an input geometry by joining the midpoint of each edge of lines or polygons in the
+   * Returns a pipeline that smooths an input geometry by joining the midpoint of each edge of lines or polygons in the
    * order in which they are encountered.
    */
   static MidpointSmoother smoothMidpoint() {
@@ -111,10 +111,18 @@ public interface GeometryPipeline extends ZoomFunction<GeometryPipeline> {
   }
 
   /**
-   * Returns a pipeline that smoothes an input geometry by slicing off each corner {@code iters} times until you get a
+   * Returns a pipeline that smooths an input geometry by slicing off each corner {@code iters} times until you get a
    * sufficiently smooth curve.
    */
   static MidpointSmoother smoothChaikin(int iters) {
     return MidpointSmoother.chaikin(iters);
+  }
+
+  static MidpointSmoother smoothChaikinToTolerance(double tolerance) {
+    return MidpointSmoother.chaikinToTolerance(tolerance);
+  }
+
+  static MidpointSmoother smoothChaikinToMinArea(double minArea) {
+    return MidpointSmoother.chaikinToMinArea(minArea);
   }
 }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/GeometryPipeline.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/GeometryPipeline.java
@@ -4,6 +4,12 @@ import com.onthegomap.planetiler.FeatureCollector;
 import com.onthegomap.planetiler.util.ZoomFunction;
 import org.locationtech.jts.geom.Geometry;
 
+/**
+ * A function that transforms a {@link Geometry}.
+ * <p>
+ * This can be chained and used in {@link FeatureCollector.Feature#transformScaledGeometry(GeometryPipeline)} to
+ * transform geometries before slicing them into tiles.
+ */
 @FunctionalInterface
 public interface GeometryPipeline extends ZoomFunction<GeometryPipeline> {
   GeometryPipeline NOOP = g -> g;
@@ -16,6 +22,7 @@ public interface GeometryPipeline extends ZoomFunction<GeometryPipeline> {
     return this;
   }
 
+  /** Returns a function equivalent to {@code other(this(geom))}. */
   default GeometryPipeline andThen(GeometryPipeline other) {
     return input -> other.apply(apply(input));
   }
@@ -93,5 +100,21 @@ public interface GeometryPipeline extends ZoomFunction<GeometryPipeline> {
    */
   static DouglasPeuckerSimplifier simplifyDP(double tolerance) {
     return new DouglasPeuckerSimplifier(tolerance);
+  }
+
+  /**
+   * Returns a pipeline that smoothes an input geometry by joining the midpoint of each edge of lines or polygons in the
+   * order in which they are encountered.
+   */
+  static MidpointSmoother smoothMidpoint() {
+    return MidpointSmoother.midpoint();
+  }
+
+  /**
+   * Returns a pipeline that smoothes an input geometry by slicing off each corner {@code iters} times until you get a
+   * sufficiently smooth curve.
+   */
+  static MidpointSmoother smoothChaikin(int iters) {
+    return MidpointSmoother.chaikin(iters);
   }
 }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/GeometryPipeline.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/GeometryPipeline.java
@@ -106,23 +106,31 @@ public interface GeometryPipeline extends ZoomFunction<GeometryPipeline> {
    * Returns a pipeline that smooths an input geometry by joining the midpoint of each edge of lines or polygons in the
    * order in which they are encountered.
    */
-  static MidpointSmoother smoothMidpoint() {
-    return MidpointSmoother.midpoint();
+  static MidpointSmoother smoothMidpoint(int iters) {
+    return new MidpointSmoother().setIters(iters);
   }
 
   /**
    * Returns a pipeline that smooths an input geometry by slicing off each corner {@code iters} times until you get a
    * sufficiently smooth curve.
    */
-  static MidpointSmoother smoothChaikin(int iters) {
-    return MidpointSmoother.chaikin(iters);
+  static DualMidpointSmoother smoothChaikin(int iters) {
+    return DualMidpointSmoother.chaikin(iters);
   }
 
-  static MidpointSmoother smoothChaikinToTolerance(double tolerance) {
-    return MidpointSmoother.chaikinToTolerance(tolerance);
+  /**
+   * Returns a new smoother that slices off each corner, except instead of stopping at a fixed number of iterations, it
+   * stops when the distance between a vertex and its 2 adjacent neighbors is below {@code tolerance}.
+   */
+  static DualMidpointSmoother smoothChaikinToTolerance(double tolerance) {
+    return DualMidpointSmoother.chaikinToTolerance(tolerance);
   }
 
-  static MidpointSmoother smoothChaikinToMinArea(double minArea) {
-    return MidpointSmoother.chaikinToMinArea(minArea);
+  /**
+   * Returns a new smoother that slices off each corner, except instead of stopping at a fixed number of iterations, it
+   * stops when the area formed between a vertex and its 2 adjacent neighbors is below {@code minArea}.
+   */
+  static DualMidpointSmoother smoothChaikinToMinArea(double minArea) {
+    return DualMidpointSmoother.chaikinToMinArea(minArea);
   }
 }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/MidpointSmoother.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/MidpointSmoother.java
@@ -1,12 +1,13 @@
 package com.onthegomap.planetiler.geo;
 
+import java.util.Arrays;
 import org.locationtech.jts.geom.CoordinateSequence;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.LinearRing;
 import org.locationtech.jts.geom.util.GeometryTransformer;
 
 /**
- * Smoothes an input geometry by interpolating points along each edge and repeating for a set number of iterations.
+ * Smooths an input geometry by interpolating points along each edge and repeating for a set number of iterations.
  * <p>
  * When the points array is {@code [0.5]} this means midpoint smoothing, and when it is {@code [0.25, 0.75]} it means
  * <a href="https://observablehq.com/@pamacha/chaikins-algorithm">Chaikin Smoothing</a>.
@@ -17,8 +18,14 @@ public class MidpointSmoother extends GeometryTransformer implements GeometryPip
   private static final double[] MIDPOINT = new double[]{0.5};
   private final double[] points;
   private int iters = 1;
+  private double minSquaredVertexTolerance = 0;
+  private double minVertexArea = 0;
 
   public MidpointSmoother(double[] points) {
+    if (points.length < 1 || points.length > 2) {
+      throw new IllegalArgumentException("Smoothing only works with 1 or 2 points along each edge, got %s".formatted(
+        Arrays.toString(points)));
+    }
     this.points = points;
   }
 
@@ -30,7 +37,48 @@ public class MidpointSmoother extends GeometryTransformer implements GeometryPip
     return new MidpointSmoother(CHAIKIN).setIters(iters);
   }
 
-  /** Returns a new smoother that does midpoint smoothing. */
+  /**
+   * Returns a new smoother that does <a href="https://observablehq.com/@pamacha/chaikins-algorithm">Chaikin
+   * Smoothing</a> until the added points would get dropped with {@link DouglasPeuckerSimplifier Douglas-Peucker
+   * simplification} with {@code tolerance} threshold.
+   */
+  public static MidpointSmoother chaikinToTolerance(double tolerance) {
+    return new MidpointSmoother(CHAIKIN).setIters(10).setMinVertexTolerance(tolerance);
+  }
+
+  /**
+   * Returns a new smoother that does <a href="https://observablehq.com/@pamacha/chaikins-algorithm">Chaikin
+   * Smoothing</a> until the added points would get dropped with {@link VWSimplifier Visvalingam-Whyatt simplification}
+   * with {@code minArea} threshold.
+   */
+  public static MidpointSmoother chaikinToMinArea(double minArea) {
+    return new MidpointSmoother(CHAIKIN).setIters(10).setMinVertexArea(minArea);
+  }
+
+  /**
+   * Sets the min distance between a vertex and the line between its neighbors below which a vertex will not be
+   * squashed.
+   * <p>
+   * If all points are below this threshold for an entire iteration then smoothing will stop before the maximum number
+   * of iterations is reached.
+   */
+  public MidpointSmoother setMinVertexTolerance(double minVertexTolerance) {
+    this.minSquaredVertexTolerance = minVertexTolerance * minVertexTolerance;
+    return this;
+  }
+
+  /**
+   * Sets the min area of the triangle created by a point and its 2 neighbors below which a vertex will not be squashed.
+   * <p>
+   * If all points are below this threshold for an entire iteration then smoothing will stop before the maximum number
+   * of iterations is reached.
+   */
+  public MidpointSmoother setMinVertexArea(double minVertexArea) {
+    this.minVertexArea = minVertexArea;
+    return this;
+  }
+
+  /** Returns a new smoother that connects the points halfway along each edge. */
   public static MidpointSmoother midpoint() {
     return new MidpointSmoother(MIDPOINT);
   }
@@ -52,9 +100,17 @@ public class MidpointSmoother extends GeometryTransformer implements GeometryPip
     if (coords.size() <= 2) {
       return coords.copy();
     }
+    if (points.length == 1) {
+      return singlePointSmooth(coords, area, points[0]);
+    } else if (points.length >= 2) {
+      return dualPointSmooth(coords, area, points[0], points[1]);
+    }
+    return coords.copy();
+  }
+
+  private CoordinateSequence singlePointSmooth(CoordinateSequence coords, boolean area, double ratio) {
     for (int iter = 0; iter < iters; iter++) {
       MutableCoordinateSequence result = new MutableCoordinateSequence();
-      boolean skipFirstAndLastInterpolated = !area && points.length > 1;
       if (!area) {
         result.addPoint(coords.getX(0), coords.getY(0));
       }
@@ -67,16 +123,7 @@ public class MidpointSmoother extends GeometryTransformer implements GeometryPip
         y1 = y2;
         x2 = coords.getX(i + 1);
         y2 = coords.getY(i + 1);
-        double dx = x2 - x1;
-        double dy = y2 - y1;
-        for (int j = 0; j < points.length; j++) {
-          if (skipFirstAndLastInterpolated && ((i == 0 && j == 0) || (i == last - 1 && j == points.length - 1))) {
-            continue;
-          }
-
-          double value = points[j];
-          result.addPoint(x1 + dx * value, y1 + dy * value);
-        }
+        result.addPoint(x1 + (x2 - x1) * ratio, y1 + (y2 - y1) * ratio);
       }
       if (area) {
         result.closeRing();
@@ -86,5 +133,72 @@ public class MidpointSmoother extends GeometryTransformer implements GeometryPip
       coords = result;
     }
     return coords;
+  }
+
+  private CoordinateSequence dualPointSmooth(CoordinateSequence coords, boolean area, double a, double b) {
+    boolean checkVertices = minSquaredVertexTolerance > 0 || minVertexArea > 0;
+    for (int iter = 0; iter < iters; iter++) {
+      MutableCoordinateSequence result = new MutableCoordinateSequence();
+      if (!area) {
+        result.addPoint(coords.getX(0), coords.getY(0));
+      }
+      int last = coords.size() - 1;
+      double x2 = coords.getX(0);
+      double y2 = coords.getY(0);
+      boolean skippedLastVertex = false;
+      double x1, y1;
+      for (int i = 0; i < last; i++) {
+        x1 = x2;
+        y1 = y2;
+        x2 = coords.getX(i + 1);
+        y2 = coords.getY(i + 1);
+        double dx = x2 - x1;
+        double dy = y2 - y1;
+
+        if ((area || i > 0) && !skippedLastVertex) {
+          result.addPoint(x1 + dx * a, y1 + dy * a);
+        }
+
+
+        if (area || i < last - 1) {
+          if (checkVertices) {
+            int next = i < last - 1 ? (i + 2) : 1;
+            double x3 = coords.getX(next);
+            double y3 = coords.getY(next);
+            if (skipVertex(x1, y1, x2, y2, x3, y3)) {
+              result.addPoint(x2, y2);
+              skippedLastVertex = true;
+              continue;
+            } else {
+              skippedLastVertex = false;
+            }
+          }
+
+          result.addPoint(x1 + dx * b, y1 + dy * b);
+        }
+      }
+      if (area) {
+        if (skippedLastVertex) {
+          result.setX(0, result.getX(result.size() - 1));
+          result.setY(0, result.getY(result.size() - 1));
+        } else {
+          result.closeRing();
+        }
+      } else {
+        result.addPoint(coords.getX(last), coords.getY(last));
+      }
+      // early exit case: if no vertices were collapsed then we are done smoothing
+      if (coords.size() == result.size()) {
+        return result;
+      }
+      coords = result;
+    }
+    return coords;
+  }
+
+  private boolean skipVertex(double x1, double y1, double x2, double y2, double x3, double y3) {
+    return (minVertexArea > 0 && VWSimplifier.triangleArea(x1, y1, x2, y2, x3, y3) < minVertexArea) ||
+      (minSquaredVertexTolerance > 0 &&
+        DouglasPeuckerSimplifier.getSqSegDist(x2, y2, x1, y1, x3, y3) < minSquaredVertexTolerance);
   }
 }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/MidpointSmoother.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/MidpointSmoother.java
@@ -5,29 +5,45 @@ import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.LinearRing;
 import org.locationtech.jts.geom.util.GeometryTransformer;
 
+/**
+ * Smoothes an input geometry by interpolating points along each edge and repeating for a set number of iterations.
+ * <p>
+ * When the points array is {@code [0.5]} this means midpoint smoothing, and when it is {@code [0.25, 0.75]} it means
+ * <a href="https://observablehq.com/@pamacha/chaikins-algorithm">Chaikin Smoothing</a>.
+ */
 public class MidpointSmoother extends GeometryTransformer implements GeometryPipeline {
 
+  private static final double[] CHAIKIN = new double[]{0.25, 0.75};
+  private static final double[] MIDPOINT = new double[]{0.5};
   private final double[] points;
   private int iters = 1;
-  private boolean includeLineEndpoints = true;
 
   public MidpointSmoother(double[] points) {
     this.points = points;
   }
 
-  @Override
-  public Geometry apply(Geometry input) {
-    return transform(input);
+  /**
+   * Returns a new smoother that does <a href="https://observablehq.com/@pamacha/chaikins-algorithm">Chaikin
+   * Smoothing</a> {@code iters} times on the input line.
+   */
+  public static MidpointSmoother chaikin(int iters) {
+    return new MidpointSmoother(CHAIKIN).setIters(iters);
   }
 
+  /** Returns a new smoother that does midpoint smoothing. */
+  public static MidpointSmoother midpoint() {
+    return new MidpointSmoother(MIDPOINT);
+  }
+
+  /** Sets the number of times that smoothing runs. */
   public MidpointSmoother setIters(int iters) {
     this.iters = iters;
     return this;
   }
 
-  public MidpointSmoother includeLineEndpoints(boolean includeLineEndpoints) {
-    this.includeLineEndpoints = includeLineEndpoints;
-    return this;
+  @Override
+  public Geometry apply(Geometry input) {
+    return transform(input);
   }
 
   @Override
@@ -38,8 +54,8 @@ public class MidpointSmoother extends GeometryTransformer implements GeometryPip
     }
     for (int iter = 0; iter < iters; iter++) {
       MutableCoordinateSequence result = new MutableCoordinateSequence();
-      boolean skipFirstAndLastInterpolated = !area && includeLineEndpoints && points.length > 1;
-      if (!area && includeLineEndpoints) {
+      boolean skipFirstAndLastInterpolated = !area && points.length > 1;
+      if (!area) {
         result.addPoint(coords.getX(0), coords.getY(0));
       }
       int last = coords.size() - 1;
@@ -54,18 +70,17 @@ public class MidpointSmoother extends GeometryTransformer implements GeometryPip
         double dx = x2 - x1;
         double dy = y2 - y1;
         for (int j = 0; j < points.length; j++) {
-          if (skipFirstAndLastInterpolated) {
-            if ((i == 0 && j == 0) || (i == last - 1 && j == points.length - 1)) {
-              continue;
-            }
+          if (skipFirstAndLastInterpolated && ((i == 0 && j == 0) || (i == last - 1 && j == points.length - 1))) {
+            continue;
           }
+
           double value = points[j];
           result.addPoint(x1 + dx * value, y1 + dy * value);
         }
       }
       if (area) {
         result.closeRing();
-      } else if (includeLineEndpoints) {
+      } else {
         result.addPoint(coords.getX(last), coords.getY(last));
       }
       coords = result;

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/MidpointSmoother.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/MidpointSmoother.java
@@ -1,111 +1,27 @@
 package com.onthegomap.planetiler.geo;
 
-import java.util.Arrays;
 import org.locationtech.jts.geom.CoordinateSequence;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.LinearRing;
 import org.locationtech.jts.geom.util.GeometryTransformer;
 
 /**
- * Smooths an input geometry by interpolating points along each edge and repeating for a set number of iterations.
- * <p>
- * When the points array is {@code [0.5]} this means midpoint smoothing, and when it is {@code [0.25, 0.75]} it means
- * <a href="https://observablehq.com/@pamacha/chaikins-algorithm">Chaikin Smoothing</a>.
+ * Smooths an input geometry by iteratively joining the midpoint of each edge of lines or polygons in the order in which
+ * they are encountered.
+ *
+ * @see <a href="https://github.com/wipfli/midpoint-smoothing">github.com/wipfli/midpoint-smoothing</a>.
  */
 public class MidpointSmoother extends GeometryTransformer implements GeometryPipeline {
 
-  private static final double[] CHAIKIN = new double[]{0.25, 0.75};
-  private static final double[] MIDPOINT = new double[]{0.5};
-  private final double[] points;
+  private final double ratio;
   private int iters = 1;
-  private double minSquaredVertexTolerance = 0;
-  private double minVertexArea = 0;
-  private double maxArea = 0;
-  private double maxSquaredOffset = 0;
 
-  public MidpointSmoother(double[] points) {
-    if (points.length < 1 || points.length > 2) {
-      throw new IllegalArgumentException("Smoothing only works with 1 or 2 points along each edge, got %s".formatted(
-        Arrays.toString(points)));
-    }
-    this.points = points;
+  public MidpointSmoother(double ratio) {
+    this.ratio = ratio;
   }
 
-  /**
-   * Returns a new smoother that does <a href="https://observablehq.com/@pamacha/chaikins-algorithm">Chaikin
-   * Smoothing</a> {@code iters} times on the input line.
-   */
-  public static MidpointSmoother chaikin(int iters) {
-    return new MidpointSmoother(CHAIKIN).setIters(iters);
-  }
-
-  /**
-   * Returns a new smoother that does <a href="https://observablehq.com/@pamacha/chaikins-algorithm">Chaikin
-   * Smoothing</a> until the added points would get dropped with {@link DouglasPeuckerSimplifier Douglas-Peucker
-   * simplification} with {@code tolerance} threshold.
-   */
-  public static MidpointSmoother chaikinToTolerance(double tolerance) {
-    return new MidpointSmoother(CHAIKIN).setIters(10).setMinVertexTolerance(tolerance);
-  }
-
-  /**
-   * Returns a new smoother that does <a href="https://observablehq.com/@pamacha/chaikins-algorithm">Chaikin
-   * Smoothing</a> until the added points would get dropped with {@link VWSimplifier Visvalingam-Whyatt simplification}
-   * with {@code minArea} threshold.
-   */
-  public static MidpointSmoother chaikinToMinArea(double minArea) {
-    return new MidpointSmoother(CHAIKIN).setIters(10).setMinVertexArea(minArea);
-  }
-
-  /**
-   * Sets the min distance between a vertex and the line between its neighbors below which a vertex will not be
-   * squashed.
-   * <p>
-   * If all points are below this threshold for an entire iteration then smoothing will stop before the maximum number
-   * of iterations is reached.
-   */
-  public MidpointSmoother setMinVertexTolerance(double minVertexTolerance) {
-    this.minSquaredVertexTolerance = minVertexTolerance * minVertexTolerance;
-    return this;
-  }
-
-  /**
-   * Sets the min area of the triangle created by a point and its 2 neighbors below which a vertex will not be squashed.
-   * <p>
-   * If all points are below this threshold for an entire iteration then smoothing will stop before the maximum number
-   * of iterations is reached.
-   */
-  public MidpointSmoother setMinVertexArea(double minVertexArea) {
-    this.minVertexArea = minVertexArea;
-    return this;
-  }
-
-  /**
-   * Sets a limit on the maximum area that can be removed when removing a vertex. When the area is larger than this, the
-   * new points are moved closer to the vertex in order to bring the removed area to this threshold.
-   * <p>
-   * This prevents smoothing 2 long adjacent edges from introducing a large deviation from the original shape.
-   */
-  public MidpointSmoother setMaxArea(double maxArea) {
-    this.maxArea = maxArea;
-    return this;
-  }
-
-  /**
-   * Sets a limit on the maximum distance from the original shape that can be introduced by smoothing. When the error
-   * introduced by squashing a vertex will be above this threshold, the new points are moved closer to the vertex in
-   * order to bring the removed area to this threshold.
-   * <p>
-   * This prevents smoothing 2 long adjacent edges from introducing a large deviation from the original shape.
-   */
-  public MidpointSmoother setMaxOffset(double maxOffset) {
-    this.maxSquaredOffset = maxOffset * maxOffset;
-    return this;
-  }
-
-  /** Returns a new smoother that connects the points halfway along each edge. */
-  public static MidpointSmoother midpoint() {
-    return new MidpointSmoother(MIDPOINT);
+  public MidpointSmoother() {
+    this(0.5);
   }
 
   /** Sets the number of times that smoothing runs. */
@@ -125,15 +41,6 @@ public class MidpointSmoother extends GeometryTransformer implements GeometryPip
     if (coords.size() <= 2) {
       return coords.copy();
     }
-    if (points.length == 1) {
-      return singlePointSmooth(coords, area, points[0]);
-    } else if (points.length >= 2) {
-      return dualPointSmooth(coords, area, points[0], points[1]);
-    }
-    return coords.copy();
-  }
-
-  private CoordinateSequence singlePointSmooth(CoordinateSequence coords, boolean area, double ratio) {
     for (int iter = 0; iter < iters; iter++) {
       MutableCoordinateSequence result = new MutableCoordinateSequence();
       if (!area) {
@@ -158,105 +65,5 @@ public class MidpointSmoother extends GeometryTransformer implements GeometryPip
       coords = result;
     }
     return coords;
-  }
-
-  private CoordinateSequence dualPointSmooth(CoordinateSequence coords, boolean area, double a, double b) {
-    boolean checkVertices = minSquaredVertexTolerance > 0 || minVertexArea > 0 || maxSquaredOffset > 0 || maxArea > 0;
-    for (int iter = 0; iter < iters; iter++) {
-      MutableCoordinateSequence result = new MutableCoordinateSequence();
-      if (!area) {
-        result.addPoint(coords.getX(0), coords.getY(0));
-      }
-      int last = coords.size() - 1;
-      double x2 = coords.getX(0);
-      double y2 = coords.getY(0);
-      double nextA = a;
-      boolean skippedLastVertex = false;
-      double x1, y1;
-      for (int i = 0; i < last; i++) {
-        x1 = x2;
-        y1 = y2;
-        x2 = coords.getX(i + 1);
-        y2 = coords.getY(i + 1);
-        double dx = x2 - x1;
-        double dy = y2 - y1;
-
-        if ((area || i > 0) && !skippedLastVertex) {
-          result.addPoint(x1 + dx * nextA, y1 + dy * nextA);
-        }
-        nextA = a;
-
-
-        if (area || i < last - 1) {
-          double nextB = b;
-          if (checkVertices) {
-            int next = i < last - 1 ? (i + 2) : 1;
-            double x3 = coords.getX(next);
-            double y3 = coords.getY(next);
-            if (skipVertex(x1, y1, x2, y2, x3, y3)) {
-              result.addPoint(x2, y2);
-              skippedLastVertex = true;
-              continue;
-            }
-            skippedLastVertex = false;
-
-            if (maxArea > 0 || maxSquaredOffset > 0) {
-              double magA = Math.hypot(x2 - x1, y2 - y1);
-              double magB = Math.hypot(x3 - x2, y3 - y2);
-              double den = magA * magB;
-              double aDist = magA * (1 - b);
-              double bDist = magB * a;
-              double maxDistSquared = Double.POSITIVE_INFINITY;
-              if (maxArea > 0) {
-                double sin = den <= 0 ? 0 : Math.abs(((x1 - x2) * (y3 - y2)) - ((y1 - y2) * (x3 - x2))) / den;
-                maxDistSquared = 2 * maxArea / sin;
-              }
-              if (maxSquaredOffset > 0) {
-                double cos = den <= 0 ? 0 : Math.clamp(((x1 - x2) * (x3 - x2) + (y1 - y2) * (y3 - y2)) / den, -1, 1);
-                maxDistSquared = Math.min(maxDistSquared, 2 * maxSquaredOffset / (1 + cos));
-              }
-              double maxDist = Double.NaN;
-              if (aDist * aDist > maxDistSquared) {
-                nextB = 1 - (maxDist = Math.sqrt(maxDistSquared)) / magA;
-              }
-              if (bDist * bDist > maxDistSquared) {
-                if (Double.isNaN(maxDist)) {
-                  maxDist = Math.sqrt(maxDistSquared);
-                }
-                nextA = maxDist / magA;
-              }
-            }
-          }
-
-          result.addPoint(x1 + dx * nextB, y1 + dy * nextB);
-        }
-      }
-      if (area) {
-        if (skippedLastVertex) {
-          result.setX(0, result.getX(result.size() - 1));
-          result.setY(0, result.getY(result.size() - 1));
-        } else {
-          if (nextA != a) {
-            result.setX(0, (coords.getX(1) - coords.getX(0)) * nextA);
-            result.setY(0, (coords.getY(1) - coords.getY(0)) * nextA);
-          }
-          result.closeRing();
-        }
-      } else {
-        result.addPoint(coords.getX(last), coords.getY(last));
-      }
-      // early exit case: if no vertices were collapsed then we are done smoothing
-      if (coords.size() == result.size()) {
-        return result;
-      }
-      coords = result;
-    }
-    return coords;
-  }
-
-  private boolean skipVertex(double x1, double y1, double x2, double y2, double x3, double y3) {
-    return (minVertexArea > 0 && VWSimplifier.triangleArea(x1, y1, x2, y2, x3, y3) < minVertexArea) ||
-      (minSquaredVertexTolerance > 0 &&
-        DouglasPeuckerSimplifier.getSqSegDist(x2, y2, x1, y1, x3, y3) < minSquaredVertexTolerance);
   }
 }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/MidpointSmoother.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/MidpointSmoother.java
@@ -1,0 +1,75 @@
+package com.onthegomap.planetiler.geo;
+
+import org.locationtech.jts.geom.CoordinateSequence;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.LinearRing;
+import org.locationtech.jts.geom.util.GeometryTransformer;
+
+public class MidpointSmoother extends GeometryTransformer implements GeometryPipeline {
+
+  private final double[] points;
+  private int iters = 1;
+  private boolean includeLineEndpoints = true;
+
+  public MidpointSmoother(double[] points) {
+    this.points = points;
+  }
+
+  @Override
+  public Geometry apply(Geometry input) {
+    return transform(input);
+  }
+
+  public MidpointSmoother setIters(int iters) {
+    this.iters = iters;
+    return this;
+  }
+
+  public MidpointSmoother includeLineEndpoints(boolean includeLineEndpoints) {
+    this.includeLineEndpoints = includeLineEndpoints;
+    return this;
+  }
+
+  @Override
+  protected CoordinateSequence transformCoordinates(CoordinateSequence coords, Geometry parent) {
+    boolean area = parent instanceof LinearRing;
+    if (coords.size() <= 2) {
+      return coords.copy();
+    }
+    for (int iter = 0; iter < iters; iter++) {
+      MutableCoordinateSequence result = new MutableCoordinateSequence();
+      boolean skipFirstAndLastInterpolated = !area && includeLineEndpoints && points.length > 1;
+      if (!area && includeLineEndpoints) {
+        result.addPoint(coords.getX(0), coords.getY(0));
+      }
+      int last = coords.size() - 1;
+      double x2 = coords.getX(0);
+      double y2 = coords.getY(0);
+      double x1, y1;
+      for (int i = 0; i < last; i++) {
+        x1 = x2;
+        y1 = y2;
+        x2 = coords.getX(i + 1);
+        y2 = coords.getY(i + 1);
+        double dx = x2 - x1;
+        double dy = y2 - y1;
+        for (int j = 0; j < points.length; j++) {
+          if (skipFirstAndLastInterpolated) {
+            if ((i == 0 && j == 0) || (i == last - 1 && j == points.length - 1)) {
+              continue;
+            }
+          }
+          double value = points[j];
+          result.addPoint(x1 + dx * value, y1 + dy * value);
+        }
+      }
+      if (area) {
+        result.closeRing();
+      } else if (includeLineEndpoints) {
+        result.addPoint(coords.getX(last), coords.getY(last));
+      }
+      coords = result;
+    }
+    return coords;
+  }
+}

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/VWSimplifier.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/VWSimplifier.java
@@ -15,10 +15,17 @@ public class VWSimplifier extends GeometryTransformer implements GeometryPipelin
 
   private double tolerance;
   private double k;
+  private boolean keepCollapsed = false;
 
   /** Sets the minimum effective triangle area created by 3 consecutive vertices in order to retain that vertex. */
   public VWSimplifier setTolerance(double tolerance) {
     this.tolerance = tolerance;
+    return this;
+  }
+
+  /** Set to {@code true} to keep polygons with area smaller than {@code tolerance}. */
+  public VWSimplifier setKeepCollapsed(boolean keepCollapsed) {
+    this.keepCollapsed = keepCollapsed;
     return this;
   }
 
@@ -72,7 +79,7 @@ public class VWSimplifier extends GeometryTransformer implements GeometryPipelin
   @Override
   protected CoordinateSequence transformCoordinates(CoordinateSequence coords, Geometry parent) {
     boolean area = parent instanceof LinearRing;
-    int minPoints = area ? 4 : 2;
+    int minPoints = keepCollapsed && area ? 4 : 2;
     int num = coords.size();
     if (num <= minPoints) {
       return coords;

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/VWSimplifier.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/VWSimplifier.java
@@ -1,7 +1,6 @@
 package com.onthegomap.planetiler.geo;
 
 import com.onthegomap.planetiler.collection.DoubleMinHeap;
-import java.util.function.Function;
 import org.locationtech.jts.geom.CoordinateSequence;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.LinearRing;
@@ -12,7 +11,7 @@ import org.locationtech.jts.geom.util.GeometryTransformer;
  * A utility to simplify geometries using Visvalingam Whyatt simplification algorithm without any attempt to repair
  * geometries that become invalid due to simplification.
  */
-public class VWSimplifier extends GeometryTransformer implements Function<Geometry, Geometry> {
+public class VWSimplifier extends GeometryTransformer implements GeometryPipeline {
 
   private double tolerance;
   private double k;

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/VWSimplifier.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/VWSimplifier.java
@@ -146,7 +146,7 @@ public class VWSimplifier extends GeometryTransformer implements GeometryPipelin
     return simpResult;
   }
 
-  private static double triangleArea(double ax, double ay, double bx, double by, double cx, double cy) {
+  public static double triangleArea(double ax, double ay, double bx, double by, double cx, double cy) {
     return Math.abs(((ay - cy) * (bx - cx) + (by - cy) * (cx - ax)) / 2);
   }
 

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/VWSimplifier.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/VWSimplifier.java
@@ -72,8 +72,9 @@ public class VWSimplifier extends GeometryTransformer implements GeometryPipelin
   @Override
   protected CoordinateSequence transformCoordinates(CoordinateSequence coords, Geometry parent) {
     boolean area = parent instanceof LinearRing;
+    int minPoints = area ? 4 : 2;
     int num = coords.size();
-    if (num == 0) {
+    if (num <= minPoints) {
       return coords;
     }
 
@@ -95,13 +96,12 @@ public class VWSimplifier extends GeometryTransformer implements GeometryPipelin
     heap.push(prev.idx, prev.updateArea());
 
     int left = num;
-    int min = area ? 4 : 2;
 
     while (!heap.isEmpty()) {
       var id = heap.poll();
       Vertex point = points[id];
 
-      if (point.area > tolerance || left <= min) {
+      if (point.area > tolerance || left <= minPoints) {
         break;
       }
       // TODO

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/render/FeatureRenderer.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/render/FeatureRenderer.java
@@ -104,7 +104,7 @@ public class FeatureRenderer implements Consumer<FeatureCollector.Feature>, Clos
     if (pipeline != null) {
       geom = pipeline.apply(geom);
     } else if (!(geom instanceof Puntal)) {
-      GeometryPipeline.defaultSimplify(feature).apply(zoom).apply(geom);
+      geom = GeometryPipeline.defaultSimplify(feature).apply(zoom).apply(geom);
     }
 
     renderGeometry(zoom, geom, attrs, feature);

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/render/FeatureRenderer.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/render/FeatureRenderer.java
@@ -86,10 +86,12 @@ public class FeatureRenderer implements Consumer<FeatureCollector.Feature>, Clos
       } else {
         if (minSize > 0) {
           if (geometry instanceof Puntal) {
-            double size = feature.getSourceFeaturePixelSizeAtZoom(zoom);
-            if (size > 0 && size < minSize) {
-              // don't emit points if the source feature it came from was too small
-              continue;
+            if (!feature.source().isPoint()) {
+              double size = feature.getSourceFeaturePixelSizeAtZoom(zoom);
+              if (size < minSize) {
+                // don't emit points if the source feature it came from was too small
+                continue;
+              }
             }
           } else if (simpleLineLength >= 0 && simpleLineLength * scale * 256 < minSize) {
             // skip processing lines that are too short

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/render/FeatureRenderer.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/render/FeatureRenderer.java
@@ -100,7 +100,7 @@ public class FeatureRenderer implements Consumer<FeatureCollector.Feature>, Clos
   private void accept(int zoom, Geometry geom, Map<String, Object> attrs, FeatureCollector.Feature feature) {
     double scale = 1 << zoom;
     geom = AffineTransformation.scaleInstance(scale, scale).transform(geom);
-    GeometryPipeline pipeline = feature.getGeometryPipelineAtZoom(zoom);
+    GeometryPipeline pipeline = feature.getScaledGeometryTransformAtZoom(zoom);
     if (pipeline != null) {
       geom = pipeline.apply(geom);
     } else if (!(geom instanceof Puntal)) {

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/render/FeatureRenderer.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/render/FeatureRenderer.java
@@ -104,7 +104,7 @@ public class FeatureRenderer implements Consumer<FeatureCollector.Feature>, Clos
   private void accept(int zoom, Geometry geom, Map<String, Object> attrs, FeatureCollector.Feature feature) {
     double scale = 1 << zoom;
     geom = AffineTransformation.scaleInstance(scale, scale).transform(geom);
-    GeometryPipeline pipeline = feature.getGeometryTransformAtZoom(zoom);
+    GeometryPipeline pipeline = feature.getGeometryPipelineAtZoom(zoom);
     if (pipeline != null) {
       geom = pipeline.apply(geom);
     } else if (!(geom instanceof Puntal)) {

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/render/FeatureRenderer.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/render/FeatureRenderer.java
@@ -86,12 +86,9 @@ public class FeatureRenderer implements Consumer<FeatureCollector.Feature>, Clos
       } else {
         if (minSize > 0) {
           if (geometry instanceof Puntal) {
-            if (!feature.source().isPoint()) {
-              double size = feature.getSourceFeaturePixelSizeAtZoom(zoom);
-              if (size < minSize) {
-                // don't emit points if the source feature it came from was too small
-                continue;
-              }
+            if (!feature.source().isPoint() && feature.getSourceFeaturePixelSizeAtZoom(zoom) < minSize) {
+              // don't emit points if the line or polygon feature it came from was too small
+              continue;
             }
           } else if (simpleLineLength >= 0 && simpleLineLength * scale * 256 < minSize) {
             // skip processing lines that are too short

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/stats/PrometheusStats.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/stats/PrometheusStats.java
@@ -114,12 +114,12 @@ class PrometheusStats implements Stats {
 
   private final io.prometheus.client.Counter processedElements = io.prometheus.client.Counter
     .build(BASE + "renderer_elements_processed", "Number of source elements processed")
-    .labelNames("type", "layer")
+    .labelNames("type", "layer", "zoom")
     .register(registry);
 
   @Override
-  public void processedElement(String elemType, String layer) {
-    processedElements.labels(elemType, layer).inc();
+  public void processedElement(String elemType, String layer, int zoom) {
+    processedElements.labels(elemType, layer, String.valueOf(zoom)).inc();
   }
 
   private final io.prometheus.client.Counter dataErrors = io.prometheus.client.Counter

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/stats/Stats.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/stats/Stats.java
@@ -114,7 +114,7 @@ public interface Stats extends AutoCloseable {
   void emittedFeatures(int z, String layer, int numFeatures);
 
   /** Records that an input element was processed and emitted some output features in {@code layer}. */
-  void processedElement(String elemType, String layer);
+  void processedElement(String elemType, String layer, int zoom);
 
   /** Records that a tile has been written to the archive output where compressed size is {@code bytes}. */
   void wroteTile(int zoom, int bytes);
@@ -239,7 +239,7 @@ public interface Stats extends AutoCloseable {
     }
 
     @Override
-    public void processedElement(String elemType, String layer) {}
+    public void processedElement(String elemType, String layer, int zoom) {}
 
     @Override
     public void gauge(String name, Supplier<Number> value) {}

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/DouglasPeuckerSimplifierTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/DouglasPeuckerSimplifierTest.java
@@ -1,9 +1,6 @@
 package com.onthegomap.planetiler.geo;
 
-import static com.onthegomap.planetiler.TestUtils.assertSameNormalizedFeature;
-import static com.onthegomap.planetiler.TestUtils.newLineString;
-import static com.onthegomap.planetiler.TestUtils.newPolygon;
-import static com.onthegomap.planetiler.TestUtils.rectangle;
+import static com.onthegomap.planetiler.TestUtils.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
@@ -33,6 +30,11 @@ class DouglasPeuckerSimplifierTest {
       List<Coordinate> actual = DouglasPeuckerSimplifier.simplify(inList, amount, in instanceof Polygonal);
       assertEquals(expList, actual);
     }
+  }
+
+  @Test
+  void testDontModifyPoint() {
+    testSimplify(newPoint(1, 1), newPoint(1, 1), 1);
   }
 
   @Test

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/DualMidpointSmootherTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/DualMidpointSmootherTest.java
@@ -1,0 +1,119 @@
+package com.onthegomap.planetiler.geo;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.onthegomap.planetiler.TestUtils;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
+
+class DualDualMidpointSmootherTest {
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "POINT(1 1); POINT(1 1)",
+    "LINESTRING(0 0, 10 10); LINESTRING(0 0, 10 10)",
+    "LINESTRING(0 0, 10 0, 10 10); LINESTRING(0 0, 8 0, 10 2, 10 10)",
+    "LINESTRING(0 0, 10 0, 10 10, 0 10); LINESTRING(0 0, 8 0, 10 2, 10 8, 8 10, 0 10)",
+    "POLYGON((0 0, 10 0, 10 10, 0 0)); POLYGON((2 0, 8 0, 10 2, 10 8, 8 8, 2 2, 2 0))",
+    "POLYGON((0 0, 10 0, 10 10, 0 10, 0 0)); POLYGON((2 0, 8 0, 10 2, 10 8, 8 10, 2 10, 0 8, 0 2, 2 0))",
+  }, delimiter = ';')
+  void testDualMidpointSmooth(String inWKT, String outWKT) throws ParseException {
+    var reader = new WKTReader();
+    Geometry in = reader.read(inWKT);
+    Geometry out = reader.read(outWKT);
+    assertEquals(
+      TestUtils.round(out),
+      TestUtils.round(new DualMidpointSmoother(0.2, 0.8).setIters(1).apply(in))
+    );
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "POINT(1 1); POINT(1 1)",
+    "LINESTRING(0 0, 10 10); LINESTRING(0 0, 10 10)",
+    "LINESTRING(0 0, 10 0, 10 10); LINESTRING(0 0, 6.4 0, 8.4 0.4, 9.6 1.6, 10 3.6, 10 10)",
+    "POLYGON((0 0, 10 0, 10 10, 0 0)); POLYGON((3.2 0, 6.8 0, 8.4 0.4, 9.6 1.6, 10 3.2, 10 6.8, 9.6 8, 8.4 8, 6.8 6.8, 3.2 3.2, 2 1.6, 2 0.4, 3.2 0))",
+  }, delimiter = ';')
+  void testMultiPassSmooth(String inWKT, String outWKT) throws ParseException {
+    var reader = new WKTReader();
+    Geometry in = reader.read(inWKT);
+    Geometry out = reader.read(outWKT);
+    assertEquals(
+      TestUtils.round(out),
+      TestUtils.round(new DualMidpointSmoother(0.2, 0.8).setIters(2).apply(in))
+    );
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "POINT(1 1); POINT(1 1)",
+    "LINESTRING(0 0, 10 10); LINESTRING(0 0, 10 10)",
+    "LINESTRING(0 0, 10 0, 10 10); LINESTRING (0 0, 6.4 0, 8 0.32, 8.64 0.64, 9.36 1.36, 9.68 2, 10 3.6, 10 10)",
+    "POLYGON((0 0, 10 0, 10 10, 0 0)); POLYGON ((3.2 0, 6.8 0, 8.4 0.4, 9.6 1.6, 10 3.2, 10 6.8, 9.68 7.76, 9.36 8, 8.4 8, 6.8 6.8, 3.2 3.2, 2 1.6, 2 0.64, 2.24 0.32, 3.2 0))",
+  }, delimiter = ';')
+  void testSmoothToTolerance(String inWKT, String outWKT) throws ParseException {
+    var reader = new WKTReader();
+    Geometry in = reader.read(inWKT);
+    Geometry out = reader.read(outWKT);
+    assertEquals(
+      TestUtils.round(out),
+      TestUtils.round(new DualMidpointSmoother(0.2, 0.8).setIters(200).setMinVertexTolerance(0.5).apply(in))
+    );
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "POINT(1 1); POINT(1 1)",
+    "LINESTRING(0 0, 10 10); LINESTRING(0 0, 10 10)",
+    "LINESTRING(0 0, 10 0, 10 10); LINESTRING (0 0, 5.12 0, 6.8 0.08, 8 0.32, 8.64 0.64, 9.36 1.36, 9.68 2, 9.92 3.2, 10 4.88, 10 10)",
+    "POLYGON((0 0, 10 0, 10 10, 0 0)); POLYGON ((3.92 0, 6.08 0, 7.12 0.08, 8.08 0.32, 8.64 0.64, 9.36 1.36, 9.68 1.92, 9.92 2.88, 10 3.92, 10 6.08, 9.92 7.04, 9.68 7.76, 9.36 8, 8.64 8, 8.08 7.76, 7.12 7.04, 6.08 6.08, 3.92 3.92, 2.96 2.88, 2.24 1.92, 2 1.36, 2 0.64, 2.24 0.32, 2.96 0.08, 3.92 0))",
+  }, delimiter = ';')
+  void testSmoothToMinArea(String inWKT, String outWKT) throws ParseException {
+    var reader = new WKTReader();
+    Geometry in = reader.read(inWKT);
+    Geometry out = reader.read(outWKT);
+    assertEquals(
+      TestUtils.round(out),
+      TestUtils.round(new DualMidpointSmoother(0.2, 0.8).setIters(200).setMinVertexArea(0.5).apply(in))
+    );
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "LINESTRING(0 0, 10 10); LINESTRING(0 0, 10 10)",
+    "LINESTRING(0 0, 10 0, 10 10); LINESTRING (0 0, 9 0, 10 1, 10 10)",
+    "LINESTRING(0 0, 10 0, 20 0); LINESTRING (0 0, 7.5 0, 12.5 0, 20 0)",
+    "LINESTRING(0 0, 10 0, 0 0); LINESTRING (0 0, 7.5 0, 0 0)",
+    "POLYGON((0 0, 10 0, 10 10, 0 10, 0 0)); POLYGON ((1 0, 9 0, 10 1, 10 9, 9 10, 1 10, 0 9, 0 1, 1 0))",
+  }, delimiter = ';')
+  void testSmoothWithMaxArea(String inWKT, String outWKT) throws ParseException {
+    var reader = new WKTReader();
+    Geometry in = reader.read(inWKT);
+    Geometry out = reader.read(outWKT);
+    assertEquals(
+      TestUtils.round(out),
+      TestUtils.round(DualMidpointSmoother.chaikin(1).setMaxArea(0.5).apply(in))
+    );
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "LINESTRING(0 0, 10 10); LINESTRING(0 0, 10 10)",
+    "LINESTRING(0 0, 10 0, 10 10); LINESTRING (0 0, 9 0, 10 1, 10 10)",
+    "LINESTRING(0 0, 10 0, 20 0); LINESTRING (0 0, 7.5 0, 12.5 0, 20 0)",
+    "LINESTRING(0 0, 10 0, 0 0); LINESTRING (0 0, 9.29289 0, 0 0)",
+    "POLYGON((0 0, 10 0, 10 10, 0 10, 0 0)); POLYGON ((1 0, 9 0, 10 1, 10 9, 9 10, 1 10, 0 9, 0 1, 1 0))",
+  }, delimiter = ';')
+  void testSmoothWithMaxOffset(String inWKT, String outWKT) throws ParseException {
+    var reader = new WKTReader();
+    Geometry in = reader.read(inWKT);
+    Geometry out = reader.read(outWKT);
+    assertEquals(
+      TestUtils.round(out),
+      TestUtils.round(DualMidpointSmoother.chaikin(1).setMaxOffset(Math.sqrt(0.5)).apply(in))
+    );
+  }
+}

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/DualMidpointSmootherTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/DualMidpointSmootherTest.java
@@ -104,7 +104,7 @@ class DualDualMidpointSmootherTest {
     "LINESTRING(0 0, 10 10); LINESTRING(0 0, 10 10)",
     "LINESTRING(0 0, 10 0, 10 10); LINESTRING (0 0, 9 0, 10 1, 10 10)",
     "LINESTRING(0 0, 10 0, 20 0); LINESTRING (0 0, 7.5 0, 12.5 0, 20 0)",
-    "LINESTRING(0 0, 10 0, 0 0); LINESTRING (0 0, 9.29289 0, 0 0)",
+    "LINESTRING(0 0, 10 0, 10 5); LINESTRING (0 0, 9 0, 10 1, 10 5)",
     "POLYGON((0 0, 10 0, 10 10, 0 10, 0 0)); POLYGON ((1 0, 9 0, 10 1, 10 9, 9 10, 1 10, 0 9, 0 1, 1 0))",
   }, delimiter = ';')
   void testSmoothWithMaxOffset(String inWKT, String outWKT) throws ParseException {

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/DualMidpointSmootherTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/DualMidpointSmootherTest.java
@@ -60,7 +60,7 @@ class DualDualMidpointSmootherTest {
     Geometry out = reader.read(outWKT);
     assertEquals(
       TestUtils.round(out),
-      TestUtils.round(new DualMidpointSmoother(0.2, 0.8).setIters(200).setMinVertexTolerance(0.5).apply(in))
+      TestUtils.round(new DualMidpointSmoother(0.2, 0.8).setIters(200).setMinVertexOffset(0.5).apply(in))
     );
   }
 
@@ -113,7 +113,7 @@ class DualDualMidpointSmootherTest {
     Geometry out = reader.read(outWKT);
     assertEquals(
       TestUtils.round(out),
-      TestUtils.round(DualMidpointSmoother.chaikin(1).setMaxVertexTolerance(Math.sqrt(0.5)).apply(in))
+      TestUtils.round(DualMidpointSmoother.chaikin(1).setMaxVertexOffset(Math.sqrt(0.5)).apply(in))
     );
   }
 }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/DualMidpointSmootherTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/DualMidpointSmootherTest.java
@@ -95,7 +95,7 @@ class DualDualMidpointSmootherTest {
     Geometry out = reader.read(outWKT);
     assertEquals(
       TestUtils.round(out),
-      TestUtils.round(DualMidpointSmoother.chaikin(1).setMaxArea(0.5).apply(in))
+      TestUtils.round(DualMidpointSmoother.chaikin(1).setMaxVertexArea(0.5).apply(in))
     );
   }
 
@@ -113,7 +113,7 @@ class DualDualMidpointSmootherTest {
     Geometry out = reader.read(outWKT);
     assertEquals(
       TestUtils.round(out),
-      TestUtils.round(DualMidpointSmoother.chaikin(1).setMaxOffset(Math.sqrt(0.5)).apply(in))
+      TestUtils.round(DualMidpointSmoother.chaikin(1).setMaxVertexTolerance(Math.sqrt(0.5)).apply(in))
     );
   }
 }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/GeometryPipelineTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/GeometryPipelineTest.java
@@ -1,0 +1,56 @@
+package com.onthegomap.planetiler.geo;
+
+import static com.onthegomap.planetiler.geo.GeometryPipeline.compose;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.onthegomap.planetiler.util.ZoomFunction;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.CoordinateXY;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.util.AffineTransformation;
+
+class GeometryPipelineTest {
+  GeometryPipeline move(int i) {
+    return AffineTransformation.translationInstance(i, i)::transform;
+  }
+
+  private final ZoomFunction<GeometryPipeline> moveByZoom = this::move;
+
+  Point point(int i) {
+    return GeoUtils.JTS_FACTORY.createPoint(new CoordinateXY(i, i));
+  }
+
+  @Test
+  void testSingle() {
+    assertEquals(point(2), move(1).apply(point(1)));
+    assertEquals(point(2), move(1).apply(3).apply(point(1)));
+  }
+
+  @Test
+  void testSingleByZoom() {
+    assertEquals(point(4), moveByZoom.apply(3).apply(point(1)));
+  }
+
+  @Test
+  void testCompose2() {
+    // pipeline, pipeline
+    assertEquals(point(4), compose(move(1), move(2)).apply(point(1)));
+    assertEquals(point(4), compose(move(1), move(2)).apply(2).apply(point(1)));
+
+    // pipeline, ZoomFunction<pipeline>
+    assertEquals(point(5), compose(move(1), moveByZoom).apply(3).apply(point(1)));
+
+    // ZoomFunction<pipeline>, pipeline
+    assertEquals(point(5), compose(moveByZoom, move(1)).apply(3).apply(point(1)));
+
+    // ZoomFunction<pipeline>, ZoomFunction<pipeline>
+    assertEquals(point(7), compose(moveByZoom, moveByZoom).apply(3).apply(point(1)));
+  }
+
+  @Test
+  void testComposeMany() {
+    assertEquals(point(8), compose(move(1), moveByZoom, moveByZoom).apply(3).apply(point(1)));
+    assertEquals(point(9), compose(move(1), moveByZoom, moveByZoom, move(1)).apply(3).apply(point(1)));
+    assertEquals(point(12), compose(move(1), moveByZoom, moveByZoom, move(1), moveByZoom).apply(3).apply(point(1)));
+  }
+}

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/MidpointSmootherTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/MidpointSmootherTest.java
@@ -99,4 +99,40 @@ class MidpointSmootherTest {
       TestUtils.round(new MidpointSmoother(new double[]{0.2, 0.8}).setIters(200).setMinVertexArea(0.5).apply(in))
     );
   }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "LINESTRING(0 0, 10 10); LINESTRING(0 0, 10 10)",
+    "LINESTRING(0 0, 10 0, 10 10); LINESTRING (0 0, 9 0, 10 1, 10 10)",
+    "LINESTRING(0 0, 10 0, 20 0); LINESTRING (0 0, 7.5 0, 12.5 0, 20 0)",
+    "LINESTRING(0 0, 10 0, 0 0); LINESTRING (0 0, 7.5 0, 0 0)",
+    "POLYGON((0 0, 10 0, 10 10, 0 10, 0 0)); POLYGON ((1 0, 9 0, 10 1, 10 9, 9 10, 1 10, 0 9, 0 1, 1 0))",
+  }, delimiter = ';')
+  void testSmoothWithMaxArea(String inWKT, String outWKT) throws ParseException {
+    var reader = new WKTReader();
+    Geometry in = reader.read(inWKT);
+    Geometry out = reader.read(outWKT);
+    assertEquals(
+      TestUtils.round(out),
+      TestUtils.round(MidpointSmoother.chaikin(1).setMaxArea(0.5).apply(in))
+    );
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "LINESTRING(0 0, 10 10); LINESTRING(0 0, 10 10)",
+    "LINESTRING(0 0, 10 0, 10 10); LINESTRING (0 0, 9 0, 10 1, 10 10)",
+    "LINESTRING(0 0, 10 0, 20 0); LINESTRING (0 0, 7.5 0, 12.5 0, 20 0)",
+    "LINESTRING(0 0, 10 0, 0 0); LINESTRING (0 0, 9.29289 0, 0 0)",
+    "POLYGON((0 0, 10 0, 10 10, 0 10, 0 0)); POLYGON ((1 0, 9 0, 10 1, 10 9, 9 10, 1 10, 0 9, 0 1, 1 0))",
+  }, delimiter = ';')
+  void testSmoothWithMaxOffset(String inWKT, String outWKT) throws ParseException {
+    var reader = new WKTReader();
+    Geometry in = reader.read(inWKT);
+    Geometry out = reader.read(outWKT);
+    assertEquals(
+      TestUtils.round(out),
+      TestUtils.round(MidpointSmoother.chaikin(1).setMaxOffset(Math.sqrt(0.5)).apply(in))
+    );
+  }
 }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/MidpointSmootherTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/MidpointSmootherTest.java
@@ -65,35 +65,4 @@ class MidpointSmootherTest {
       TestUtils.round(new MidpointSmoother(new double[]{0.2, 0.8}).setIters(2).apply(in))
     );
   }
-
-  @ParameterizedTest
-  @CsvSource(value = {
-    "POINT(1 1); POINT(1 1)",
-    "LINESTRING(0 0, 10 10); LINESTRING(0 0, 10 10)",
-    "LINESTRING(0 0, 10 0, 10 10); LINESTRING(5 0, 10 5)",
-    "LINESTRING(0 0, 10 0, 10 10, 0 10); LINESTRING(5 0, 10 5, 5 10)",
-  }, delimiter = ';')
-  void testDontIncludeEndpointsMidpoint(String inWKT, String outWKT) throws ParseException {
-    var reader = new WKTReader();
-    assertEquals(
-      TestUtils.round(reader.read(outWKT)),
-      TestUtils.round(
-        new MidpointSmoother(new double[]{0.5}).setIters(1).includeLineEndpoints(false).apply(reader.read(inWKT)))
-    );
-  }
-
-  @ParameterizedTest
-  @CsvSource(value = {
-    "LINESTRING(0 0, 10 10); LINESTRING(0 0, 10 10)",
-    "LINESTRING(0 0, 10 0, 10 10); LINESTRING(2 0, 8 0, 10 2, 10 8)",
-    "LINESTRING(0 0, 10 0, 10 10, 0 10); LINESTRING(2 0, 8 0, 10 2, 10 8, 8 10, 2 10)",
-  }, delimiter = ';')
-  void testDontIncludeEndpointsDualMidpoint(String inWKT, String outWKT) throws ParseException {
-    var reader = new WKTReader();
-    assertEquals(
-      TestUtils.round(reader.read(outWKT)),
-      TestUtils.round(
-        new MidpointSmoother(new double[]{0.2, 0.8}).setIters(1).includeLineEndpoints(false).apply(reader.read(inWKT)))
-    );
-  }
 }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/MidpointSmootherTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/MidpointSmootherTest.java
@@ -1,0 +1,99 @@
+package com.onthegomap.planetiler.geo;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.onthegomap.planetiler.TestUtils;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
+
+class MidpointSmootherTest {
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "POINT(1 1); POINT(1 1)",
+    "LINESTRING(0 0, 10 10); LINESTRING(0 0, 10 10)",
+    "LINESTRING(0 0, 10 0, 10 10); LINESTRING(0 0, 5 0, 10 5, 10 10)",
+    "LINESTRING(0 0, 10 0, 10 10, 0 10); LINESTRING(0 0, 5 0, 10 5, 5 10, 0 10)",
+    "POLYGON((0 0, 10 0, 10 10, 0 0)); POLYGON((5 0, 10 5, 5 5, 5 0))",
+    "POLYGON((0 0, 10 0, 10 10, 0 10, 0 0)); POLYGON((5 0, 10 5, 5 10, 0 5, 5 0))",
+  }, delimiter = ';')
+  void testMidpointSmooth(String inWKT, String outWKT) throws ParseException {
+    var reader = new WKTReader();
+    Geometry in = reader.read(inWKT);
+    Geometry out = reader.read(outWKT);
+    assertEquals(
+      TestUtils.round(out),
+      TestUtils.round(new MidpointSmoother(new double[]{0.5}).setIters(1).apply(in))
+    );
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "POINT(1 1); POINT(1 1)",
+    "LINESTRING(0 0, 10 10); LINESTRING(0 0, 10 10)",
+    "LINESTRING(0 0, 10 0, 10 10); LINESTRING(0 0, 8 0, 10 2, 10 10)",
+    "LINESTRING(0 0, 10 0, 10 10, 0 10); LINESTRING(0 0, 8 0, 10 2, 10 8, 8 10, 0 10)",
+    "POLYGON((0 0, 10 0, 10 10, 0 0)); POLYGON((2 0, 8 0, 10 2, 10 8, 8 8, 2 2, 2 0))",
+    "POLYGON((0 0, 10 0, 10 10, 0 10, 0 0)); POLYGON((2 0, 8 0, 10 2, 10 8, 8 10, 2 10, 0 8, 0 2, 2 0))",
+  }, delimiter = ';')
+  void testDualMidpointSmooth(String inWKT, String outWKT) throws ParseException {
+    var reader = new WKTReader();
+    Geometry in = reader.read(inWKT);
+    Geometry out = reader.read(outWKT);
+    assertEquals(
+      TestUtils.round(out),
+      TestUtils.round(new MidpointSmoother(new double[]{0.2, 0.8}).setIters(1).apply(in))
+    );
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "POINT(1 1); POINT(1 1)",
+    "LINESTRING(0 0, 10 10); LINESTRING(0 0, 10 10)",
+    "LINESTRING(0 0, 10 0, 10 10); LINESTRING(0 0, 6.4 0, 8.4 0.4, 9.6 1.6, 10 3.6, 10 10)",
+    "POLYGON((0 0, 10 0, 10 10, 0 0)); POLYGON((3.2 0, 6.8 0, 8.4 0.4, 9.6 1.6, 10 3.2, 10 6.8, 9.6 8, 8.4 8, 6.8 6.8, 3.2 3.2, 2 1.6, 2 0.4, 3.2 0))",
+  }, delimiter = ';')
+  void testMultiPassSmooth(String inWKT, String outWKT) throws ParseException {
+    var reader = new WKTReader();
+    Geometry in = reader.read(inWKT);
+    Geometry out = reader.read(outWKT);
+    assertEquals(
+      TestUtils.round(out),
+      TestUtils.round(new MidpointSmoother(new double[]{0.2, 0.8}).setIters(2).apply(in))
+    );
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "POINT(1 1); POINT(1 1)",
+    "LINESTRING(0 0, 10 10); LINESTRING(0 0, 10 10)",
+    "LINESTRING(0 0, 10 0, 10 10); LINESTRING(5 0, 10 5)",
+    "LINESTRING(0 0, 10 0, 10 10, 0 10); LINESTRING(5 0, 10 5, 5 10)",
+  }, delimiter = ';')
+  void testDontIncludeEndpointsMidpoint(String inWKT, String outWKT) throws ParseException {
+    var reader = new WKTReader();
+    assertEquals(
+      TestUtils.round(reader.read(outWKT)),
+      TestUtils.round(
+        new MidpointSmoother(new double[]{0.5}).setIters(1).includeLineEndpoints(false).apply(reader.read(inWKT)))
+    );
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "LINESTRING(0 0, 10 10); LINESTRING(0 0, 10 10)",
+    "LINESTRING(0 0, 10 0, 10 10); LINESTRING(2 0, 8 0, 10 2, 10 8)",
+    "LINESTRING(0 0, 10 0, 10 10, 0 10); LINESTRING(2 0, 8 0, 10 2, 10 8, 8 10, 2 10)",
+  }, delimiter = ';')
+  void testDontIncludeEndpointsDualMidpoint(String inWKT, String outWKT) throws ParseException {
+    var reader = new WKTReader();
+    assertEquals(
+      TestUtils.round(reader.read(outWKT)),
+      TestUtils.round(
+        new MidpointSmoother(new double[]{0.2, 0.8}).setIters(1).includeLineEndpoints(false).apply(reader.read(inWKT)))
+    );
+  }
+}

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/MidpointSmootherTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/MidpointSmootherTest.java
@@ -26,7 +26,7 @@ class MidpointSmootherTest {
     Geometry out = reader.read(outWKT);
     assertEquals(
       TestUtils.round(out),
-      TestUtils.round(new MidpointSmoother(new double[]{0.5}).setIters(1).apply(in))
+      TestUtils.round(new MidpointSmoother().setIters(1).apply(in))
     );
   }
 
@@ -34,105 +34,17 @@ class MidpointSmootherTest {
   @CsvSource(value = {
     "POINT(1 1); POINT(1 1)",
     "LINESTRING(0 0, 10 10); LINESTRING(0 0, 10 10)",
-    "LINESTRING(0 0, 10 0, 10 10); LINESTRING(0 0, 8 0, 10 2, 10 10)",
-    "LINESTRING(0 0, 10 0, 10 10, 0 10); LINESTRING(0 0, 8 0, 10 2, 10 8, 8 10, 0 10)",
-    "POLYGON((0 0, 10 0, 10 10, 0 0)); POLYGON((2 0, 8 0, 10 2, 10 8, 8 8, 2 2, 2 0))",
-    "POLYGON((0 0, 10 0, 10 10, 0 10, 0 0)); POLYGON((2 0, 8 0, 10 2, 10 8, 8 10, 2 10, 0 8, 0 2, 2 0))",
+    "LINESTRING(0 0, 10 0, 10 10); LINESTRING(0 0, 2.5 0, 7.5 2.5, 10 7.5, 10 10)",
+    "POLYGON((0 0, 10 0, 10 10, 0 0)); POLYGON ((7.5 2.5, 7.5 5, 5 2.5, 7.5 2.5))",
+    "POLYGON((0 0, 10 0, 10 10, 0 10, 0 0)); POLYGON ((7.5 2.5, 7.5 7.5, 2.5 7.5, 2.5 2.5, 7.5 2.5))",
   }, delimiter = ';')
-  void testDualMidpointSmooth(String inWKT, String outWKT) throws ParseException {
+  void testMidpointSmoothTwice(String inWKT, String outWKT) throws ParseException {
     var reader = new WKTReader();
     Geometry in = reader.read(inWKT);
     Geometry out = reader.read(outWKT);
     assertEquals(
       TestUtils.round(out),
-      TestUtils.round(new MidpointSmoother(new double[]{0.2, 0.8}).setIters(1).apply(in))
-    );
-  }
-
-  @ParameterizedTest
-  @CsvSource(value = {
-    "POINT(1 1); POINT(1 1)",
-    "LINESTRING(0 0, 10 10); LINESTRING(0 0, 10 10)",
-    "LINESTRING(0 0, 10 0, 10 10); LINESTRING(0 0, 6.4 0, 8.4 0.4, 9.6 1.6, 10 3.6, 10 10)",
-    "POLYGON((0 0, 10 0, 10 10, 0 0)); POLYGON((3.2 0, 6.8 0, 8.4 0.4, 9.6 1.6, 10 3.2, 10 6.8, 9.6 8, 8.4 8, 6.8 6.8, 3.2 3.2, 2 1.6, 2 0.4, 3.2 0))",
-  }, delimiter = ';')
-  void testMultiPassSmooth(String inWKT, String outWKT) throws ParseException {
-    var reader = new WKTReader();
-    Geometry in = reader.read(inWKT);
-    Geometry out = reader.read(outWKT);
-    assertEquals(
-      TestUtils.round(out),
-      TestUtils.round(new MidpointSmoother(new double[]{0.2, 0.8}).setIters(2).apply(in))
-    );
-  }
-
-  @ParameterizedTest
-  @CsvSource(value = {
-    "POINT(1 1); POINT(1 1)",
-    "LINESTRING(0 0, 10 10); LINESTRING(0 0, 10 10)",
-    "LINESTRING(0 0, 10 0, 10 10); LINESTRING (0 0, 6.4 0, 8 0.32, 8.64 0.64, 9.36 1.36, 9.68 2, 10 3.6, 10 10)",
-    "POLYGON((0 0, 10 0, 10 10, 0 0)); POLYGON ((3.2 0, 6.8 0, 8.4 0.4, 9.6 1.6, 10 3.2, 10 6.8, 9.68 7.76, 9.36 8, 8.4 8, 6.8 6.8, 3.2 3.2, 2 1.6, 2 0.64, 2.24 0.32, 3.2 0))",
-  }, delimiter = ';')
-  void testSmoothToTolerance(String inWKT, String outWKT) throws ParseException {
-    var reader = new WKTReader();
-    Geometry in = reader.read(inWKT);
-    Geometry out = reader.read(outWKT);
-    assertEquals(
-      TestUtils.round(out),
-      TestUtils.round(new MidpointSmoother(new double[]{0.2, 0.8}).setIters(200).setMinVertexTolerance(0.5).apply(in))
-    );
-  }
-
-  @ParameterizedTest
-  @CsvSource(value = {
-    "POINT(1 1); POINT(1 1)",
-    "LINESTRING(0 0, 10 10); LINESTRING(0 0, 10 10)",
-    "LINESTRING(0 0, 10 0, 10 10); LINESTRING (0 0, 5.12 0, 6.8 0.08, 8 0.32, 8.64 0.64, 9.36 1.36, 9.68 2, 9.92 3.2, 10 4.88, 10 10)",
-    "POLYGON((0 0, 10 0, 10 10, 0 0)); POLYGON ((3.92 0, 6.08 0, 7.12 0.08, 8.08 0.32, 8.64 0.64, 9.36 1.36, 9.68 1.92, 9.92 2.88, 10 3.92, 10 6.08, 9.92 7.04, 9.68 7.76, 9.36 8, 8.64 8, 8.08 7.76, 7.12 7.04, 6.08 6.08, 3.92 3.92, 2.96 2.88, 2.24 1.92, 2 1.36, 2 0.64, 2.24 0.32, 2.96 0.08, 3.92 0))",
-  }, delimiter = ';')
-  void testSmoothToMinArea(String inWKT, String outWKT) throws ParseException {
-    var reader = new WKTReader();
-    Geometry in = reader.read(inWKT);
-    Geometry out = reader.read(outWKT);
-    assertEquals(
-      TestUtils.round(out),
-      TestUtils.round(new MidpointSmoother(new double[]{0.2, 0.8}).setIters(200).setMinVertexArea(0.5).apply(in))
-    );
-  }
-
-  @ParameterizedTest
-  @CsvSource(value = {
-    "LINESTRING(0 0, 10 10); LINESTRING(0 0, 10 10)",
-    "LINESTRING(0 0, 10 0, 10 10); LINESTRING (0 0, 9 0, 10 1, 10 10)",
-    "LINESTRING(0 0, 10 0, 20 0); LINESTRING (0 0, 7.5 0, 12.5 0, 20 0)",
-    "LINESTRING(0 0, 10 0, 0 0); LINESTRING (0 0, 7.5 0, 0 0)",
-    "POLYGON((0 0, 10 0, 10 10, 0 10, 0 0)); POLYGON ((1 0, 9 0, 10 1, 10 9, 9 10, 1 10, 0 9, 0 1, 1 0))",
-  }, delimiter = ';')
-  void testSmoothWithMaxArea(String inWKT, String outWKT) throws ParseException {
-    var reader = new WKTReader();
-    Geometry in = reader.read(inWKT);
-    Geometry out = reader.read(outWKT);
-    assertEquals(
-      TestUtils.round(out),
-      TestUtils.round(MidpointSmoother.chaikin(1).setMaxArea(0.5).apply(in))
-    );
-  }
-
-  @ParameterizedTest
-  @CsvSource(value = {
-    "LINESTRING(0 0, 10 10); LINESTRING(0 0, 10 10)",
-    "LINESTRING(0 0, 10 0, 10 10); LINESTRING (0 0, 9 0, 10 1, 10 10)",
-    "LINESTRING(0 0, 10 0, 20 0); LINESTRING (0 0, 7.5 0, 12.5 0, 20 0)",
-    "LINESTRING(0 0, 10 0, 0 0); LINESTRING (0 0, 9.29289 0, 0 0)",
-    "POLYGON((0 0, 10 0, 10 10, 0 10, 0 0)); POLYGON ((1 0, 9 0, 10 1, 10 9, 9 10, 1 10, 0 9, 0 1, 1 0))",
-  }, delimiter = ';')
-  void testSmoothWithMaxOffset(String inWKT, String outWKT) throws ParseException {
-    var reader = new WKTReader();
-    Geometry in = reader.read(inWKT);
-    Geometry out = reader.read(outWKT);
-    assertEquals(
-      TestUtils.round(out),
-      TestUtils.round(MidpointSmoother.chaikin(1).setMaxOffset(Math.sqrt(0.5)).apply(in))
+      TestUtils.round(new MidpointSmoother().setIters(2).apply(in))
     );
   }
 }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/MidpointSmootherTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/MidpointSmootherTest.java
@@ -65,4 +65,38 @@ class MidpointSmootherTest {
       TestUtils.round(new MidpointSmoother(new double[]{0.2, 0.8}).setIters(2).apply(in))
     );
   }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "POINT(1 1); POINT(1 1)",
+    "LINESTRING(0 0, 10 10); LINESTRING(0 0, 10 10)",
+    "LINESTRING(0 0, 10 0, 10 10); LINESTRING (0 0, 6.4 0, 8 0.32, 8.64 0.64, 9.36 1.36, 9.68 2, 10 3.6, 10 10)",
+    "POLYGON((0 0, 10 0, 10 10, 0 0)); POLYGON ((3.2 0, 6.8 0, 8.4 0.4, 9.6 1.6, 10 3.2, 10 6.8, 9.68 7.76, 9.36 8, 8.4 8, 6.8 6.8, 3.2 3.2, 2 1.6, 2 0.64, 2.24 0.32, 3.2 0))",
+  }, delimiter = ';')
+  void testSmoothToTolerance(String inWKT, String outWKT) throws ParseException {
+    var reader = new WKTReader();
+    Geometry in = reader.read(inWKT);
+    Geometry out = reader.read(outWKT);
+    assertEquals(
+      TestUtils.round(out),
+      TestUtils.round(new MidpointSmoother(new double[]{0.2, 0.8}).setIters(200).setMinVertexTolerance(0.5).apply(in))
+    );
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "POINT(1 1); POINT(1 1)",
+    "LINESTRING(0 0, 10 10); LINESTRING(0 0, 10 10)",
+    "LINESTRING(0 0, 10 0, 10 10); LINESTRING (0 0, 5.12 0, 6.8 0.08, 8 0.32, 8.64 0.64, 9.36 1.36, 9.68 2, 9.92 3.2, 10 4.88, 10 10)",
+    "POLYGON((0 0, 10 0, 10 10, 0 0)); POLYGON ((3.92 0, 6.08 0, 7.12 0.08, 8.08 0.32, 8.64 0.64, 9.36 1.36, 9.68 1.92, 9.92 2.88, 10 3.92, 10 6.08, 9.92 7.04, 9.68 7.76, 9.36 8, 8.64 8, 8.08 7.76, 7.12 7.04, 6.08 6.08, 3.92 3.92, 2.96 2.88, 2.24 1.92, 2 1.36, 2 0.64, 2.24 0.32, 2.96 0.08, 3.92 0))",
+  }, delimiter = ';')
+  void testSmoothToMinArea(String inWKT, String outWKT) throws ParseException {
+    var reader = new WKTReader();
+    Geometry in = reader.read(inWKT);
+    Geometry out = reader.read(outWKT);
+    assertEquals(
+      TestUtils.round(out),
+      TestUtils.round(new MidpointSmoother(new double[]{0.2, 0.8}).setIters(200).setMinVertexArea(0.5).apply(in))
+    );
+  }
 }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/VWSimplifierTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/VWSimplifierTest.java
@@ -1,9 +1,6 @@
 package com.onthegomap.planetiler.geo;
 
-import static com.onthegomap.planetiler.TestUtils.assertSameNormalizedFeature;
-import static com.onthegomap.planetiler.TestUtils.newLineString;
-import static com.onthegomap.planetiler.TestUtils.newPoint;
-import static com.onthegomap.planetiler.TestUtils.newPolygon;
+import static com.onthegomap.planetiler.TestUtils.*;
 
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Geometry;
@@ -69,22 +66,26 @@ class VWSimplifierTest {
   }
 
   @Test
-  void testPolygonLeaveAPoint() {
-    testSimplify(
+  void testPolygonLeaveAPointWhenAreaLessThenTolerance() {
+    Geometry in = newPolygon(
+      0, 0,
+      10, 10,
+      9, 10,
+      0, 8,
+      0, 0
+    );
+    assertSameNormalizedFeature(
+      emptyGeometry(),
+      new VWSimplifier().setTolerance(200).setWeight(0).transform(in)
+    );
+    assertSameNormalizedFeature(
       newPolygon(
         0, 0,
-        10, 10,
-        9, 10,
-        0, 8,
-        0, 0
-      ),
-      newPolygon(
-        0, 0,
         0, 8,
         10, 10,
         0, 0
       ),
-      200
+      new VWSimplifier().setTolerance(200).setKeepCollapsed(true).setWeight(0).transform(in)
     );
   }
 

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/VWSimplifierTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/geo/VWSimplifierTest.java
@@ -2,6 +2,7 @@ package com.onthegomap.planetiler.geo;
 
 import static com.onthegomap.planetiler.TestUtils.assertSameNormalizedFeature;
 import static com.onthegomap.planetiler.TestUtils.newLineString;
+import static com.onthegomap.planetiler.TestUtils.newPoint;
 import static com.onthegomap.planetiler.TestUtils.newPolygon;
 
 import org.junit.jupiter.api.Test;
@@ -24,6 +25,11 @@ class VWSimplifierTest {
         new VWSimplifier().setTolerance(amount).setWeight(0).transform(rotate.transform(in.reverse()))
       );
     }
+  }
+
+  @Test
+  void testSimplifyPoint() {
+    testSimplify(newPoint(1, 1), newPoint(1, 1), 1);
   }
 
   @Test

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/render/FeatureRendererTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/render/FeatureRendererTest.java
@@ -13,6 +13,7 @@ import com.onthegomap.planetiler.config.Arguments;
 import com.onthegomap.planetiler.config.PlanetilerConfig;
 import com.onthegomap.planetiler.geo.GeoUtils;
 import com.onthegomap.planetiler.geo.GeometryException;
+import com.onthegomap.planetiler.geo.GeometryPipeline;
 import com.onthegomap.planetiler.geo.TileCoord;
 import com.onthegomap.planetiler.reader.SimpleFeature;
 import com.onthegomap.planetiler.stats.Stats;
@@ -1513,6 +1514,25 @@ class FeatureRendererTest {
     assertEquals(
       Set.of(
         List.of(newPoint(128 + 5, 128), Map.of("k", "v"))
+      ),
+      renderedTileFeatures(feature, TileCoord.ofXYZ(Z14_TILES / 2, Z14_TILES / 2, 14))
+    );
+  }
+
+  @Test
+  void testGeometryPipelineSimplify() {
+    var feature = lineFeature(
+      newLineString(
+        0.5 + Z14_WIDTH / 2, 0.5 + Z14_WIDTH / 2,
+        0.5 + Z14_WIDTH / 2 + Z14_PX * 10, 0.5 + Z14_WIDTH / 2
+      )
+    ).setGeometryTransform(
+      GeometryPipeline.simplifyVW(1).setWeight(0.9)
+        .andThen(GeometryPipeline.simplifyDP(1))
+    ).setAttr("k", "v");
+    assertEquals(
+      Set.of(
+        List.of(newLineString(128, 128, 128 + 10, 128), Map.of("k", "v"))
       ),
       renderedTileFeatures(feature, TileCoord.ofXYZ(Z14_TILES / 2, Z14_TILES / 2, 14))
     );

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/render/FeatureRendererTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/render/FeatureRendererTest.java
@@ -1510,7 +1510,7 @@ class FeatureRendererTest {
         0.5 + Z14_WIDTH / 2, 0.5 + Z14_WIDTH / 2,
         0.5 + Z14_WIDTH / 2 + Z14_PX * 10, 0.5 + Z14_WIDTH / 2
       )
-    ).setGeometryTransform(Geometry::getCentroid).setAttr("k", "v");
+    ).setGeometryPipeline(Geometry::getCentroid).setAttr("k", "v");
     assertEquals(
       Set.of(
         List.of(newPoint(128 + 5, 128), Map.of("k", "v"))
@@ -1526,7 +1526,7 @@ class FeatureRendererTest {
         0.5 + Z14_WIDTH / 2, 0.5 + Z14_WIDTH / 2,
         0.5 + Z14_WIDTH / 2 + Z14_PX * 10, 0.5 + Z14_WIDTH / 2
       )
-    ).setGeometryTransform(
+    ).setGeometryPipeline(
       GeometryPipeline.simplifyVW(1).setWeight(0.9)
         .andThen(GeometryPipeline.simplifyDP(1))
     ).setAttr("k", "v");

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/render/FeatureRendererTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/render/FeatureRendererTest.java
@@ -1510,7 +1510,7 @@ class FeatureRendererTest {
         0.5 + Z14_WIDTH / 2, 0.5 + Z14_WIDTH / 2,
         0.5 + Z14_WIDTH / 2 + Z14_PX * 10, 0.5 + Z14_WIDTH / 2
       )
-    ).setGeometryPipeline(Geometry::getCentroid).setAttr("k", "v");
+    ).transformScaledGeometry(Geometry::getCentroid).setAttr("k", "v");
     assertEquals(
       Set.of(
         List.of(newPoint(128 + 5, 128), Map.of("k", "v"))
@@ -1526,7 +1526,7 @@ class FeatureRendererTest {
         0.5 + Z14_WIDTH / 2, 0.5 + Z14_WIDTH / 2,
         0.5 + Z14_WIDTH / 2 + Z14_PX * 10, 0.5 + Z14_WIDTH / 2
       )
-    ).setGeometryPipeline(
+    ).transformScaledGeometry(
       GeometryPipeline.simplifyVW(1).setWeight(0.9)
         .andThen(GeometryPipeline.simplifyDP(1))
     ).setAttr("k", "v");

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/stats/PrometheusStatsTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/stats/PrometheusStatsTest.java
@@ -59,9 +59,9 @@ class PrometheusStatsTest {
   @Test
   void testProcessedElement() {
     PrometheusStats stats = new PrometheusStats("job");
-    stats.processedElement("type1", "layer1");
-    stats.processedElement("type1", "layer1");
-    stats.processedElement("type1", "layer2");
+    stats.processedElement("type1", "layer1", 0);
+    stats.processedElement("type1", "layer1", 0);
+    stats.processedElement("type1", "layer2", 0);
     assertContainsStat("^planetiler_renderer_elements_processed_total\\{.*layer1.* 2", stats);
     assertContainsStat("^planetiler_renderer_elements_processed_total\\{.*layer2.* 1", stats);
   }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/util/LoopLineMergerTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/util/LoopLineMergerTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.onthegomap.planetiler.TestUtils;
 import com.onthegomap.planetiler.geo.GeoUtils;
+import com.onthegomap.planetiler.geo.GeometryPipeline;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Arrays;
@@ -466,6 +467,34 @@ class LoopLineMergerTest {
         newLineString(-5, 0, 0, 0, 5, 0),
         newLineString(0, 0, 0, 5)
       ),
+      merger.getMergedLineStrings()
+    );
+  }
+
+  @Test
+  void testSimplifyTolerance() {
+    var merger = new LoopLineMerger()
+      .setTolerance(1);
+
+    merger.add(newLineString(0, 0, 5, 1));
+    merger.add(newLineString(5, 1, 10, 0));
+
+    assertEquals(
+      List.of(newLineString(0, 0, 10, 0)),
+      merger.getMergedLineStrings()
+    );
+  }
+
+  @Test
+  void testGeometryPipeline() {
+    var merger = new LoopLineMerger()
+      .setSegmentTransform(GeometryPipeline.simplifyDP(1));
+
+    merger.add(newLineString(0, 0, 5, 1));
+    merger.add(newLineString(5, 1, 10, 0));
+
+    assertEquals(
+      List.of(newLineString(0, 0, 10, 0)),
       merger.getMergedLineStrings()
     );
   }


### PR DESCRIPTION
This PR adds a new `GeometryPipeline` interface for operations that transform a `Geometry` to another `Geometry` and also:

- add new `feature.transformScaledGeometry(GeometryPipeline)` which tells planetiler to apply that transform to the feature each time it is scaled to tile coordinates (where 1=width of tile at that zoom level) before slicing the feature into tiles at that zoom
- add new `feature.transformScaledGeometryByZoom((zoom) -> GeometryPipeline)` which lets you dynamically change the transform applied to scaled geometries at each zoom level
- update `FeatureMerge` `mergeLineStrings()` and `mergeNearbyPolygons` to accept a geometry pipeline to apply to each merged feature in tile coordinates (where 256=width of the tile)
- Adapt `DouglasPeuckerSimplifier` and `VWSimplifier` to implement `GeometryPipeline`
- Add `MidpointSmoother` to implement [midpoint smoothing](https://github.com/wipfli/midpoint-smoothing)
- Add `DualMidpointSmoother` to implement [Chaikin smoothing](https://observablehq.com/@pamacha/chaikins-algorithm)
- Add static factory methods to `GeometryPipeline` for these common transforms (simplifyDP, simplifyVW, smoothChaikin, smoothMidpoint)


You can also pass simple functions where a GeometryPipeline is expected, for example:

```java
feature.transformScaledGeometry(GeometryFixer::fix)
feature.transformScaledGeometry(Geometry::getCentroid)
feature.transformScaledGeometry(Geometry::getInteriorPoint)
```

And you can chain transforms using `andThen`:

```java
feature.transformScaledGeometry(
  GeometryPipeline.simplifyVW(1).setWeight(0.9)
    .andThen(GeometryPipeline.simplifyDP(1))
);
```

⚠️ transformScaledGeometry replaces default simplification with the provided transform, so you need to manually add simplification back if you want it with `.andThen(GeometryPipeline.defaultSimplify(feature))`
⚠️ transformScaledGeometry and FeatureMerge work with geometries at different scales (tile width=1 in transformScaledGeometry vs. tile width=256 for FeatureMerge) so you can't reuse a pipeline between feature processing and tile post-processing

Here is a joke example using Visvalingam Whyatt simplification and Chaikin smoothing on [OSM ocean polygons](https://osmdata.openstreetmap.de/data/water-polygons.html):

<img width="718" alt="image" src="https://github.com/user-attachments/assets/57d396cb-472c-4f98-9712-d16857ae754b" />
