### PR TITLE
Filter out points when min size is set

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/render/FeatureRenderer.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/render/FeatureRenderer.java
@@ -83,7 +83,7 @@ public class FeatureRenderer implements Consumer<FeatureCollector.Feature>, Clos
       } else {
         if (minSize > 0) {
           if (geometry instanceof Puntal) {
-            if (!feature.source().isPoint() && feature.getSourceFeaturePixelSizeAtZoom(zoom) < minSize) {
+            if (feature.getSourceFeaturePixelSizeAtZoom(zoom) < minSize) {
               // don't emit points if the line or polygon feature it came from was too small
               continue;
             }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
@@ -467,7 +467,7 @@ class PlanetilerTests {
       TileCoord.ofXYZ(Z14_TILES / 2, Z14_TILES / 2, 14), List.of(
         feature(newPoint(64, 64), Map.of("type", "line")),
         feature(newPoint(64, 64), Map.of("type", "poly"))
-      ), // features are too small at z13
+      ) // features are too small at z13
     ), results.tiles);
   }
 

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
@@ -458,7 +458,7 @@ class PlanetilerTests {
         .inheritAttrFromSource("type")
     );
 
-    assertSubmap(Map.of(
+    assertEquals(Map.of(
       TileCoord.ofXYZ(Z15_TILES / 2, Z15_TILES / 2, 15), List.of(
         feature(newPoint(128, 128), Map.of("type", "line")),
         feature(newPoint(128, 128), Map.of("type", "poly"))
@@ -467,10 +467,8 @@ class PlanetilerTests {
       TileCoord.ofXYZ(Z14_TILES / 2, Z14_TILES / 2, 14), List.of(
         feature(newPoint(64, 64), Map.of("type", "line")),
         feature(newPoint(64, 64), Map.of("type", "poly"))
-      )
+      ), // features are too small at z13
     ), results.tiles);
-    // features are too small at z13
-    assertEquals(List.of(), results.tiles.keySet().stream().filter(d -> d.z() < 14).toList());
   }
 
   @ParameterizedTest


### PR DESCRIPTION
When profiles call `feature.setMinPixelSize()` but the original feature was a point, those points were excluded before #1118  but are included now. This PR treats points as "size=0" and filters them out when minPixelSize is set to match old behavior.