### PR TITLE
Fix point equality

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/WithGeometry.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/WithGeometry.java
@@ -340,5 +340,10 @@ public abstract class WithGeometry implements WithGeometryType {
     public boolean canBeLine() {
       return worldGeometry instanceof Lineal;
     }
+
+    @Override
+    public boolean equals(Object obj) {
+      return obj == this || (obj instanceof FromWorld other && other.worldGeometry.equals(worldGeometry));
+    }
   }
 }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/WithGeometry.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/WithGeometry.java
@@ -345,5 +345,10 @@ public abstract class WithGeometry implements WithGeometryType {
     public boolean equals(Object obj) {
       return obj == this || (obj instanceof FromWorld other && other.worldGeometry.equals(worldGeometry));
     }
+
+    @Override
+    public int hashCode() {
+      return worldGeometry.hashCode();
+    }
   }
 }

--- a/planetiler-custommap/src/test/java/com/onthegomap/planetiler/custommap/ConfiguredFeatureTest.java
+++ b/planetiler-custommap/src/test/java/com/onthegomap/planetiler/custommap/ConfiguredFeatureTest.java
@@ -1563,6 +1563,35 @@ class ConfiguredFeatureTest {
 
   @ParameterizedTest
   @CsvSource(value = {
+    "feature.point_along_line(0) == feature.point_along_line(0); true",
+    "feature.point_along_line(0) == feature.point_along_line(0); true",
+    "feature.point_along_line(0) == feature.point_along_line(1); true",
+    "feature.point_along_line(0) == feature.point_along_line(0.5); false",
+  }, delimiter = ';')
+  void testGeometryAttributesLineBoolean(String expression, boolean expected) {
+    var config = """
+      sources:
+        osm:
+          type: osm
+          url: geofabrik:rhode-island
+          local_path: data/rhode-island.osm.pbf
+      layers:
+      - id: testLayer
+        features:
+        - source: osm
+          attributes:
+          - key: attr
+            value: ${%s}
+      """.formatted(expression);
+    var sfMatch =
+      SimpleFeature.createFakeOsmFeature(newLineString(1, 2, 3, 4, 1, 2), Map.of(), "osm", "layer", 1, emptyList(),
+        new OsmElement.Info(2, 3, 4, 5, "user"));
+    testFeature(config, sfMatch,
+      any -> assertEquals(expected, any.getAttrsAtZoom(14).get("attr")), 1);
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
     "feature.area('z0 px2'); 1.17743E-10",
     "feature.area('z0 tiles'); 7.7164E-6",
     "feature.area('sm'); 1.2364E10",


### PR DESCRIPTION
Fix point equality so you can do `feature.point_aloing_line(0) == feature.point_along_line(1)` to tell if a linestring is closed.