### PR TITLE
fix: add bridges layer to shortbread example

### DIFF
--- a/planetiler-custommap/src/main/resources/samples/shortbread.spec.yml
+++ b/planetiler-custommap/src/main/resources/samples/shortbread.spec.yml
@@ -558,6 +558,19 @@ examples:
       name: 'Name'
       ref: 'ref'
 
+- name: 'bridge as polygon'
+  input:
+    source: osm
+    geometry: polygon
+    tags:
+      man_made: bridge
+  output:
+    layer: bridges
+    geometry: polygon
+    min_zoom: 12
+    tags:
+      kind: bridge
+
 - name: 'gondola'
   input:
     source: osm

--- a/planetiler-custommap/src/main/resources/samples/shortbread.yml
+++ b/planetiler-custommap/src/main/resources/samples/shortbread.yml
@@ -599,6 +599,17 @@ layers:
     - *name_en
     - *name_de
 
+- id: bridges
+  features:
+  - source: osm
+    geometry: polygon
+    min_zoom: 12
+    include_when:
+       man_made: bridge
+    attributes:
+    - key: kind
+      value: bridge
+
 - id: aerialways
   features:
   - source: osm


### PR DESCRIPTION
Similar to #1207, this adds shortbreads bridges to the example layer

Docs on this layer:
https://shortbread-tiles.org/schema/1.0/#layer-bridges