### PR TITLE
fix: public transport in the shortbread schema mapping wrong

### DIFF
--- a/planetiler-custommap/src/main/resources/samples/shortbread.spec.yml
+++ b/planetiler-custommap/src/main/resources/samples/shortbread.spec.yml
@@ -604,6 +604,34 @@ examples:
       name: 'Name'
       iata: eye eight a
 
+- name: 'aerialway=station'
+  input:
+    source: osm
+    geometry: point
+    tags:
+      aerialway: station
+  output:
+    layer: public_transport
+    min_zoom: 13
+    geometry: point
+    allow_extra_tags: false
+    tags:
+      kind: aerialway_station
+
+- name: 'railway=station'
+  input:
+    source: osm
+    geometry: point
+    tags:
+      railway: station
+  output:
+    layer: public_transport
+    min_zoom: 13
+    geometry: point
+    allow_extra_tags: false
+    tags:
+      kind: station
+
 - name: 'unnamed hamlet'
   input:
     source: osm

--- a/planetiler-custommap/src/main/resources/samples/shortbread.yml
+++ b/planetiler-custommap/src/main/resources/samples/shortbread.yml
@@ -619,16 +619,29 @@ layers:
       overrides:
         11:
           aeroway: aerodrome
+        12:
+          amenity: ferry_terminal
         13:
           railway: [ station, halt ]
           aerialway: station
+          aeroway: helipad
+          amenity: bus_station
     include_when: &public_transport_filter
-      railway: [ station, halt, tram_stop ]
-      aeroway: aerodrome
       aerialway: station
+      aeroway: [ aerodrome, helipad ]
+      amenity: [ bus_station, ferry_terminal ]
+      highway: bus_stop
+      railway: [ station, halt, tram_stop ]
     attributes: &public_transport_attrs
     - key: kind
-      type: match_value
+      value:
+        # only aerialway=station needs special handling
+        coalesce:
+        - tag_value: aeroway
+        - tag_value: amenity
+        - tag_value: railway
+        - tag_value: highway
+        - "aerialway_station"
     - *name
     - *name_en
     - *name_de


### PR DESCRIPTION
I found another small typo in the shortbread generation code.
There are a few entries missing and `aerialway_stations` get mislabeled as `stations`

docs:
https://shortbread-tiles.org/schema/1.0/#layer-public_transport

Here is the mapping table from shortbread:

![image](https://github.com/user-attachments/assets/3f1414e6-5800-42b8-961f-a24827734c7f)