### PR TITLE
fix: add tunnels and bridges to the shortbread example

### DIFF
--- a/planetiler-custommap/src/main/resources/samples/shortbread.spec.yml
+++ b/planetiler-custommap/src/main/resources/samples/shortbread.spec.yml
@@ -55,6 +55,7 @@ examples:
     geometry: line
     tags:
       waterway: canal
+      tunnel: yes
       name: The Canal
       name:en: The Canal (en)
       name:de: The Canal (de)
@@ -64,6 +65,8 @@ examples:
     min_zoom: 9
     tags:
       kind: canal
+      tunnel: true
+      bridge: false
   - layer: water_line_labels
     geometry: line
     min_zoom: 12
@@ -88,6 +91,8 @@ examples:
     min_zoom: 14
     tags:
       kind: stream
+      tunnel: false
+      bridge: false
   - layer: water_line_labels
     geometry: line
     min_zoom: 14

--- a/planetiler-custommap/src/main/resources/samples/shortbread.spec.yml
+++ b/planetiler-custommap/src/main/resources/samples/shortbread.spec.yml
@@ -72,6 +72,8 @@ examples:
     min_zoom: 12
     tags:
       kind: canal
+      tunnel: true
+      bridge: false
       name: The Canal
       name_en: The Canal (en)
       name_de: The Canal (de)
@@ -98,6 +100,8 @@ examples:
     min_zoom: 14
     tags:
       kind: stream
+      tunnel: false
+      bridge: false
       name: The Stream
       name_en: The Stream (en)
       name_de: The Stream (de)

--- a/planetiler-custommap/src/main/resources/samples/shortbread.yml
+++ b/planetiler-custommap/src/main/resources/samples/shortbread.yml
@@ -100,6 +100,25 @@ layers:
     attributes:
     - key: kind
       type: match_value
+    - key: tunnel
+      value: true
+      include_when:
+        tunnel: [ yes, building_passage ]
+        covered: yes
+      else: false
+    - key: bridge
+      value: true
+      include_when:
+        bridge:
+          - yes
+          - viaduct
+          - boardwalk
+          - cantilever
+          - covered
+          - low_water_crossing
+          - movable
+          - trestle
+      else: false
 
 - id: water_line_labels
   features:

--- a/planetiler-custommap/src/main/resources/samples/shortbread.yml
+++ b/planetiler-custommap/src/main/resources/samples/shortbread.yml
@@ -100,13 +100,15 @@ layers:
     attributes:
     - key: kind
       type: match_value
-    - key: tunnel
+    - &water_lines_attr_tunnel
+      key: tunnel
       value: true
       include_when:
         tunnel: [ yes, building_passage ]
         covered: yes
       else: false
-    - key: bridge
+    - &water_lines_attr_bridge
+      key: bridge
       value: true
       include_when:
         bridge:
@@ -144,6 +146,8 @@ layers:
     - *name
     - *name_en
     - *name_de
+    - *water_lines_attr_tunnel
+    - *water_lines_attr_bridge
 
 ##  Countries, States, Cities
 - id: boundaries


### PR DESCRIPTION
There has been a small typo for the `water_lines` layer of the shortbread example
https://shortbread-tiles.org/schema/1.0/#layer-public_transport

Docs:
- [water_lines](https://shortbread-tiles.org/schema/1.0/#layer-water_lines)
- [water_lines_labels](https://shortbread-tiles.org/schema/1.0/#layer-water_lines_labels)

Here is the docs for the lines:
![image](https://github.com/user-attachments/assets/ad16910f-63c1-4702-995d-d63c15cf8f1a)
