### PR TITLE
fix: add way_area to water pologons/labels

### DIFF
--- a/planetiler-custommap/src/main/resources/samples/shortbread.spec.yml
+++ b/planetiler-custommap/src/main/resources/samples/shortbread.spec.yml
@@ -39,7 +39,7 @@ examples:
 - name: waterway=dock
   input:
     source: osm
-    geometry: POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))
+    geometry: POLYGON ((-0.5 -0.5, 0.5 -0.5, 0.5 0.5, -0.5 0.5, -0.5 -0.5))
     tags:
       waterway: dock
   output:
@@ -48,7 +48,11 @@ examples:
     min_zoom: 10
     tags:
       kind: dock
-      way_area: 100
+      # verified with a naive "projection" and sizes from https://www.thoughtco.com/degree-of-latitude-and-longitude-distance-4070616
+      # 1° lat ~ 110.567km at the equator
+      # 1° lon ~ 111.321km at the equator
+      # => ~12308.429km² = ~12308.429e^6 m² = ~1.2308429e^10 m²
+      way_area: 1.236418893560872E10
 
 - name: waterway=canal linestring
   input:

--- a/planetiler-custommap/src/main/resources/samples/shortbread.spec.yml
+++ b/planetiler-custommap/src/main/resources/samples/shortbread.spec.yml
@@ -39,7 +39,7 @@ examples:
 - name: waterway=dock
   input:
     source: osm
-    geometry: polygon
+    geometry: POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))
     tags:
       waterway: dock
   output:
@@ -48,6 +48,7 @@ examples:
     min_zoom: 10
     tags:
       kind: dock
+      way_area: 100
 
 - name: waterway=canal linestring
   input:

--- a/planetiler-custommap/src/main/resources/samples/shortbread.yml
+++ b/planetiler-custommap/src/main/resources/samples/shortbread.yml
@@ -63,6 +63,8 @@ layers:
     attributes:
     - key: kind
       type: match_value
+    - key: way_area # area in square meter (Mercator Projection)
+      value: "${ feature.area('km2') * 1000000.0 }"
 
 - id: water_polygons_labels
   features:
@@ -80,6 +82,8 @@ layers:
     - *name
     - *name_en
     - *name_de
+    - key: way_area # area in square meter (Mercator Projection)
+      value: "${ feature.area('km2') * 1000000.0 }"
 
 - id: water_lines
   features:

--- a/planetiler-custommap/src/main/resources/samples/shortbread.yml
+++ b/planetiler-custommap/src/main/resources/samples/shortbread.yml
@@ -83,7 +83,7 @@ layers:
     - *name_en
     - *name_de
     - key: way_area # area in square meter (Mercator Projection)
-      value: "${ feature.area('km2') * 1000000.0 }"
+      value: "${ feature.area('m2') }"
 
 - id: water_lines
   features:

--- a/planetiler-custommap/src/main/resources/samples/shortbread.yml
+++ b/planetiler-custommap/src/main/resources/samples/shortbread.yml
@@ -64,7 +64,7 @@ layers:
     - key: kind
       type: match_value
     - key: way_area # area in square meter (Mercator Projection)
-      value: "${ feature.area('km2') * 1000000.0 }"
+      value: "${ feature.area('m2') }"
 
 - id: water_polygons_labels
   features:


### PR DESCRIPTION
I have unexpected a lot of time during a train ride. Expect a few PRs verifying the spec

This adds the `water_polygons*` `way_area` property.

For this, I have not found a way to test. The trestcases also don't fail 🤷🏻
Advice appreciated