### PR TITLE
[breaking] fix: typo in `water_lines_labels` for shortbread tiles spec

### DIFF
--- a/planetiler-custommap/src/main/resources/samples/shortbread.spec.yml
+++ b/planetiler-custommap/src/main/resources/samples/shortbread.spec.yml
@@ -67,7 +67,7 @@ examples:
       kind: canal
       tunnel: true
       bridge: false
-  - layer: water_line_labels
+  - layer: water_lines_labels
     geometry: line
     min_zoom: 12
     tags:
@@ -95,7 +95,7 @@ examples:
       kind: stream
       tunnel: false
       bridge: false
-  - layer: water_line_labels
+  - layer: water_lines_labels
     geometry: line
     min_zoom: 14
     tags:

--- a/planetiler-custommap/src/main/resources/samples/shortbread.yml
+++ b/planetiler-custommap/src/main/resources/samples/shortbread.yml
@@ -122,7 +122,7 @@ layers:
           - trestle
       else: false
 
-- id: water_line_labels
+- id: water_lines_labels
   features:
   - source: osm
     geometry: line


### PR DESCRIPTION
there is a typo in this layer id.
Unsure if this a breaking change, your call

https://shortbread-tiles.org/schema/1.0/#layer-water_lines_labels