### PR TITLE
fix: implemented dams and piers in shortbread spec

### DIFF
--- a/planetiler-custommap/src/main/resources/samples/shortbread.spec.yml
+++ b/planetiler-custommap/src/main/resources/samples/shortbread.spec.yml
@@ -106,6 +106,68 @@ examples:
       name_en: The Stream (en)
       name_de: The Stream (de)
 
+- name: waterway=dam line
+  input:
+    source: osm
+    geometry: line
+    tags:
+      waterway: dam
+  output:
+  - layer: dam_lines
+    geometry: line
+    min_zoom: 12
+    tags:
+      kind: dam
+
+- name: waterway=dam polygon
+  input:
+    source: osm
+    geometry: polygon
+    tags:
+      waterway: dam
+  output:
+  - layer: dam_polygons
+    geometry: polygon
+    min_zoom: 12
+    tags:
+      kind: dam
+
+- name: dykes are not dams
+  input:
+    source: osm
+    geometry: polygon
+    tags:
+      man_made: dyke
+      embankment: dyke
+      geological: dyke
+  output: []
+
+- name: man_made=pier polygon
+  input:
+    source: osm
+    geometry: polygon
+    tags:
+      man_made: pier
+  output:
+  - layer: pier_polygons
+    geometry: polygon
+    min_zoom: 12
+    tags:
+      kind: pier
+
+- name: man_made=pier line
+  input:
+    source: osm
+    geometry: line
+    tags:
+      man_made: pier
+  output:
+  - layer: pier_lines
+    geometry: line
+    min_zoom: 12
+    tags:
+      kind: pier
+
 - name: landuse=grass
   input:
     source: osm

--- a/planetiler-custommap/src/main/resources/samples/shortbread.yml
+++ b/planetiler-custommap/src/main/resources/samples/shortbread.yml
@@ -174,12 +174,12 @@ layers:
   - source: osm
     geometry: line
     min_zoom: 12
-    include_when:
+    include_when: &pier_filter
       man_made: 
         - pier
         - breakwater
         - groyne
-    attributes:
+    attributes: &pier_attrs
     - key: kind
       type: match_value
 
@@ -188,14 +188,8 @@ layers:
   - source: osm
     geometry: polygon
     min_zoom: 12
-    include_when:
-      man_made: 
-        - pier
-        - breakwater
-        - groyne
-    attributes:
-    - key: kind
-      type: match_value
+    include_when: *pier_filter
+    attributes: *pier_attrs
 
 ##  Countries, States, Cities
 - id: boundaries

--- a/planetiler-custommap/src/main/resources/samples/shortbread.yml
+++ b/planetiler-custommap/src/main/resources/samples/shortbread.yml
@@ -149,6 +149,54 @@ layers:
     - *water_lines_attr_tunnel
     - *water_lines_attr_bridge
 
+- id: dam_lines
+  features:
+  - source: osm
+    geometry: line
+    min_zoom: 12
+    include_when: &dam_filter
+      # note that dykes are not dams
+      waterway: dam
+    attributes: &dam_atrs
+    - key: kind
+      value: dam
+
+- id: dam_polygons
+  features:
+  - source: osm
+    geometry: polygon
+    min_zoom: 12
+    include_when: *dam_filter
+    attributes: *dam_atrs
+
+- id: pier_lines
+  features:
+  - source: osm
+    geometry: line
+    min_zoom: 12
+    include_when:
+      man_made: 
+        - pier
+        - breakwater
+        - groyne
+    attributes:
+    - key: kind
+      type: match_value
+
+- id: pier_polygons
+  features:
+  - source: osm
+    geometry: polygon
+    min_zoom: 12
+    include_when:
+      man_made: 
+        - pier
+        - breakwater
+        - groyne
+    attributes:
+    - key: kind
+      type: match_value
+
 ##  Countries, States, Cities
 - id: boundaries
   features:


### PR DESCRIPTION
in the current version of the shortbread spec `{dam,pier}_{polygons,lines}` is present.
This PR implements this.

Docs: https://shortbread-tiles.org/schema/1.0/#layer-dam_lines