### PR TITLE
fix: implement boundaries closer to shortbread spec

### DIFF
--- a/planetiler-custommap/src/main/resources/samples/shortbread.spec.yml
+++ b/planetiler-custommap/src/main/resources/samples/shortbread.spec.yml
@@ -901,6 +901,26 @@ examples:
     tags:
       maritime: true
       admin_level: 2
+      disputed: false
+
+- name: 'country coastline'
+  input:
+    source: osm
+    geometry: line
+    # TODO from relation
+    tags:
+      boundary: administrative
+      admin_level: '2'
+      natural: coastline
+  output:
+    layer: boundaries
+    geometry: line
+    min_zoom: 0
+    min_size: 0
+    tags:
+      maritime: true
+      admin_level: 2
+      disputed: false
 
 - name: 'state boundary'
   input:
@@ -918,6 +938,7 @@ examples:
     tags:
       maritime: false
       admin_level: 4
+      disputed: false
 
 # TODO take min admin level
 

--- a/planetiler-custommap/src/main/resources/samples/shortbread.yml
+++ b/planetiler-custommap/src/main/resources/samples/shortbread.yml
@@ -220,6 +220,7 @@ layers:
       - village
       - hamlet
       - suburb
+      - quarter
       - neighbourhood
       - isolated_dwelling
       - farm
@@ -273,6 +274,8 @@ layers:
           if: { place: town }
         - value: 1000
           if: { place: suburb }
+        - value: 500
+          if: { place: quarter }
         - value: 100
           if: { place: [ village, neighborhood ] }
         - value: 50

--- a/planetiler-custommap/src/main/resources/samples/shortbread.yml
+++ b/planetiler-custommap/src/main/resources/samples/shortbread.yml
@@ -190,6 +190,7 @@ layers:
     min_zoom:
       default_value: 5
       overrides:
+        # WAY_AREA is in ha
         2: '${ feature.tags.has("ADMIN_LEVEL", "2") && double(feature.tags.WAY_AREA) >= 2e8 }'
         3: '${ double(feature.tags.WAY_AREA) >= 7e7 }'
         4: '${ double(feature.tags.WAY_AREA) >= 1e7 }'

--- a/planetiler-custommap/src/main/resources/samples/shortbread.yml
+++ b/planetiler-custommap/src/main/resources/samples/shortbread.yml
@@ -168,8 +168,20 @@ layers:
     attributes:
     - key: maritime
       type: boolean
+      value: true
+      include_when:
+        maritime: __any__
+        natural: coastline
+      else: false
     - key: admin_level
       type: integer
+    - key: disputed
+      value: true
+      include_when:
+        disputed: yes
+        # TODO: member of a relation with boundary=disputed and (admin_level unset or between 2 and 4)
+        # see https://github.com/shortbread-tiles/shortbread-docs/issues/43
+      else: false
 
 - id: boundary_labels
   features:


### PR DESCRIPTION
this does fix the maritime and disputed tags for boundaries.

It also adds the quarters to `place_labels`

I have no clue how to fix the relation issue.
I would love pointers on this, if possible.

This is especially bad as the ukraine-russia, candada-usa, germany-poland border is now gone 👀 😅