### PR TITLE
fix: addresses are specified differently in shortbread

### DIFF
--- a/planetiler-custommap/src/main/resources/samples/shortbread.spec.yml
+++ b/planetiler-custommap/src/main/resources/samples/shortbread.spec.yml
@@ -594,7 +594,7 @@ examples:
     tags:
       kind: gondola
 
-- name: 'pois can have names and adresses'
+- name: 'pois can have names and adresses. This makes them not show up on the addresses layer'
   input:
     source: osm
     geometry: point
@@ -612,12 +612,6 @@ examples:
         name: 'Name'
         housename: 'Housename'
         housenumber: 'Housenumber'
-    - layer: addresses
-      geometry: point
-      allow_extra_tags: false
-      tags:
-        name: 'Housename'
-        number: 'Housenumber'
 
 - name: 'arts_centre poi with invalid tag (man_made=beauty) is not emmitted as such'
   input:

--- a/planetiler-custommap/src/main/resources/samples/shortbread.yml
+++ b/planetiler-custommap/src/main/resources/samples/shortbread.yml
@@ -384,13 +384,15 @@ layers:
   - source: osm
     geometry: polygon_centroid_if_convex
     min_zoom: 14
-    include_when: &address_filter
-      addr:housenumber: __any__
-      addr:housename: __any__
+    include_when: &address_filter 
+      __all__:
+      - addr:housenumber: __any__
+        addr:housename: __any__
+      - __not__: &poi_filter
     attributes: &address_attributes
-    - key: name
+    - key: housename
       tag_value: addr:housename
-    - key: number
+    - key: housenumber
       tag_value: addr:housenumber
   - source: osm
     geometry: point


### PR DESCRIPTION
This PR fixes how addresses are defined in shortbread.

Thing is that they have slightly different tags and are not present if POIs are present.

I have no clue why the `__not__` filter is nto working.
Do you have an idea?
is it because I can only access back-references?

![image](https://github.com/user-attachments/assets/e1585af1-bee0-4ac6-b109-f0510721d432)