### PR TITLE
fix: aerialways not being fully defined as in the shortbread spec

### DIFF
--- a/planetiler-custommap/src/main/resources/samples/shortbread.yml
+++ b/planetiler-custommap/src/main/resources/samples/shortbread.yml
@@ -639,7 +639,16 @@ layers:
     geometry: line
     min_zoom: 12
     include_when:
-      aerialway: __any__
+      aerialway:
+      - cable_car
+      - gondola
+      - goods
+      - chair_lift
+      - drag_lift
+      - t-bar
+      - j-bar
+      - platter
+      - rope_tow
     attributes:
     - key: kind
       type: match_value


### PR DESCRIPTION
This one is more nitpicking than anything:
Currently, a user could put anything in the `aerialway` tag and the style has gained a new kind.