### PR TITLE
feat: remove alias limit for custom maps

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/util/YAML.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/util/YAML.java
@@ -26,7 +26,7 @@ public class YAML {
 
   private YAML() {}
 
-  private static final Load snakeYaml = new Load(LoadSettings.builder().setCodePointLimit(Integer.MAX_VALUE).build());
+  private static final Load snakeYaml = new Load(LoadSettings.builder().setCodePointLimit(Integer.MAX_VALUE).setMaxAliasesForCollections(Integer.MAX_VALUE).build());
   public static final ObjectMapper jackson = new ObjectMapper();
 
   public static <T> T load(Path file, Class<T> clazz) {


### PR DESCRIPTION
Currently, this alias limit is 50.
For large custom maps, like shortbread, this is a bit to few and pretty annoying.

The opton configured does:
> Restrict the number of aliases for collection nodes to prevent Billion laughs attack.

https://javadoc.io/static/org.snakeyaml/snakeyaml-engine/2.3/org/snakeyaml/engine/v2/api/LoadSettingsBuilder.html#setMaxAliasesForCollections(int)

I don't think that this attack vector is a valid one for this tool.