### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,10 +11,10 @@ Pull requests are welcome! Any pull request should:
 To set up your local development environment:
 
 - Fork the repo [setup submodules](README.md#git-submodules)
-- Install Java 21 or later. You can download Java manually from [Adoptium](https://adoptium.net/installation.html) or
+- Install Java 21. You can download Java manually from [Adoptium](https://adoptium.net/installation/) or
   use:
-  - [Windows installer](https://adoptium.net/installation.html#windows-msi)
-  - [macOS installer](https://adoptium.net/installation.html#macos-pkg) (or `brew install --cask temurin`,
+  - [Windows installer](https://adoptium.net/installation/windows/)
+  - [macOS installer](https://adoptium.net/installation/macOS) (or `brew install --cask temurin`,
     or `port install openjdk21-temurin`)
   - [Linux installer](https://adoptium.net/installation/linux/) (or `apt-get install openjdk-21-jdk`)
   - If you update from an older version of java on Ubuntu, run `sudo update-alternatives --config java` after installing the new jdk.


### PR DESCRIPTION
Removed "or later" after "Java 21". On my Ubuntu Linux, `temurin-23-jdk` causes the following error when compiling Planetiler's `main` branch:

~~~
[INFO] ------------------------------------------------------------- [WARNING] COMPILATION WARNING :
[INFO] ------------------------------------------------------------- [WARNING] location of system modules is not set in conjunction with -source 21
  not setting the location of system modules may lead to class files that cannot run on JDK 21
    --release 21 is recommended instead of -source 21 -target 21 because it sets the location of system modules automatically
[INFO] 1 warning
[INFO] ------------------------------------------------------------- [INFO] ------------------------------------------------------------- [ERROR] COMPILATION ERROR :
[INFO] ------------------------------------------------------------- [ERROR] /home/steed/Documents/GitHub/zstadler/planetiler/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/BooleanExpressionParser.java: cannot select a static class from a parameterized type [INFO] 1 error
[INFO] ------------------------------------------------------------- ~~~

The same code compiles without any problem when downgrading to `temurin-21-jdk`

Also updated links to the adoptium.net site.