### PR TITLE
Use new maven snapshot URL

### DIFF
--- a/planetiler-examples/standalone.pom.xml
+++ b/planetiler-examples/standalone.pom.xml
@@ -37,9 +37,9 @@
       </releases>
     </repository>
     <repository>
-      <id>nexus-snapshots</id>
-      <name>Nexus SNAPSHOT Repository</name>
-      <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
+      <name>Central Portal Snapshots</name>
+      <id>central-portal-snapshots</id>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>

--- a/pom.xml
+++ b/pom.xml
@@ -247,6 +247,7 @@
         <configuration>
           <publishingServerId>central</publishingServerId>
           <autoPublish>true</autoPublish>
+          <failOnBuildFailure>true</failOnBuildFailure>
           <waitUntil>published</waitUntil>
         </configuration>
       </plugin>


### PR DESCRIPTION
Maven switched the URLs used for publishing snapshots (https://central.sonatype.org/pages/ossrh-eol/) so update planetiler-openmaptiles to use that new URL.