### PR TITLE
fix(shortbread): forrest-wood naming

### DIFF
--- a/planetiler-custommap/src/main/resources/samples/shortbread.yml
+++ b/planetiler-custommap/src/main/resources/samples/shortbread.yml
@@ -558,7 +558,7 @@ layers:
           landuse: cemetery
     attributes:
     - key: kind
-      value: '${match_value == "forest" ? "wood": match_value}'
+      value: '${match_value == "wood" ? "forest": match_value}'
 
 - id: sites
   features:


### PR DESCRIPTION
I missed this the last time around appparently.

<img width="646" height="591" alt="image" src="https://github.com/user-attachments/assets/96e1a4b1-7480-4459-ba16-78a1b2da2be1" />
