### PR TITLE
Omit empty tiles after post processing

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/VectorTile.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/VectorTile.java
@@ -639,6 +639,10 @@ public class VectorTile {
     this.layerStatsTracker = layerStats;
   }
 
+  public boolean isEmpty() {
+    return layers.isEmpty();
+  }
+
   enum Command {
     MOVE_TO(1),
     LINE_TO(2),

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/archive/TileArchiveWriter.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/archive/TileArchiveWriter.java
@@ -288,7 +288,9 @@ public class TileArchiveWriter {
           memoizedTiles.inc();
         } else {
           VectorTile tile = tileFeatures.getVectorTile(layerAttrStatsUpdater);
-          if (skipFilled && (lastIsFill = tile.containsOnlyFills())) {
+          if (tile.isEmpty()) {
+            continue;
+          } else if ((skipFilled && (lastIsFill = tile.containsOnlyFills()))) {
             encoded = null;
             layerStats = null;
             bytes = null;
@@ -318,7 +320,7 @@ public class TileArchiveWriter {
           }
           lastTileDataHash = tileDataHash;
         }
-        if ((!skipFilled || !lastIsFill) && bytes != null) {
+        if (!(skipFilled && lastIsFill) && bytes != null) {
           tileStatsUpdater.recordTile(tileFeatures.tileCoord(), bytes.length, layerStats);
           List<String> layerStatsRows = config.outputLayerStats() ?
             layerStatsSerializer.formatOutputRows(tileFeatures.tileCoord(), bytes.length, layerStats) :


### PR DESCRIPTION
If layer or tile post-processing functions removed all features from a tile, it was still getting written with no data. It should be omitted from the output archive instead.