### PR TITLE
planetiler-openmaptiles adjusted and updated + excluded tests now re-…

### DIFF
--- a/planetiler-core/src/test/resources/exclude.txt
+++ b/planetiler-core/src/test/resources/exclude.txt
@@ -1,2 +1,0 @@
-# Temporarily disable test broken by this fix: https://github.com/onthegomap/planetiler/pull/1330
-org.openmaptiles.OpenMapTilesTest#testTransportation

--- a/pom.xml
+++ b/pom.xml
@@ -228,9 +228,6 @@
           <excludes>
             <exclude/>
           </excludes>
-          <excludesFile>
-            ${maven.multiModuleProjectDirectory}/planetiler-core/src/test/resources/exclude.txt
-          </excludesFile>
           <!-- by default surefire only includes tests matching Test*.java *Test.java or *TestCase.java -->
           <includes>
             <include>**/*.java</include>


### PR DESCRIPTION
Follow-up on https://github.com/openmaptiles/planetiler-openmaptiles/pull/264 , e.g:

1. `planetiler-openmaptiles` adjusted and updated
2.  Excluded tests now re-enabled