### PR TITLE
Improve handling of super relation

### DIFF
--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/reader/osm/OsmReaderTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/reader/osm/OsmReaderTest.java
@@ -703,6 +703,92 @@ class OsmReaderTest {
     assertEquals(List.of(), feature.relationInfo(TestRelInfo.class));
   }
 
+  @Test
+  void testSuperRelationOrderedEasily() {
+    record TestRelInfo(long id, String name) implements OsmRelationInfo {}
+    OsmReader reader = new OsmReader("osm", () -> osmSource, nodeMap, multipolygons, new Profile.NullProfile() {
+      @Override
+      public List<OsmRelationInfo> preprocessOsmRelation(OsmElement.Relation relation) {
+        return List.of(new TestRelInfo(1, "name"));
+      }
+    }, stats);
+    var nodeCache = reader.newNodeLocationProvider();
+    long index = 1;
+    var node1 = node(index++, 0, 0);
+    var node2 = node(index++, 1, 1);
+    var node3 = node(index++, 2, 2);
+    var node4 = node(index++, 3, 3);
+    var way1 = new OsmElement.Way(index++);
+    way1.nodes().add(node1.id(), node2.id());
+    way1.setTag("key", "value");
+    var way2 = new OsmElement.Way(index++);
+    way2.nodes().add(node3.id(), node4.id());
+    way2.setTag("key", "value");
+    var relation1 = new OsmElement.Relation(index++);
+    var relation2 = new OsmElement.Relation(index++);
+    var relation3 = new OsmElement.Relation(index++);
+    relation1.members().add(new OsmElement.Relation.Member(OsmElement.Type.WAY, way1.id(), "rolename"));
+
+    relation2.members().add(new OsmElement.Relation.Member(OsmElement.Type.RELATION, relation1.id(), "rolename"));
+    relation2.members().add(new OsmElement.Relation.Member(OsmElement.Type.WAY, way2.id(), "rolename"));
+
+    relation3.members().add(new OsmElement.Relation.Member(OsmElement.Type.RELATION, relation1.id(), "rolename"));
+
+    processPass1Block(reader, List.of(node1, node2, node3, node4, way1, way2, relation1, relation2, relation3));
+
+    SourceFeature feature1 = reader.processWayPass2(way1, nodeCache);
+    SourceFeature feature2 = reader.processWayPass2(way2, nodeCache);
+    assertEquals(3, feature1.relationInfo(TestRelInfo.class).size());
+    assertEquals(1, feature2.relationInfo(TestRelInfo.class).size());
+  }
+
+  @Test
+  void testSuperRelationOrderedBadly() {
+    record TestRelInfo(long id, String name) implements OsmRelationInfo {}
+    OsmReader reader = new OsmReader("osm", () -> osmSource, nodeMap, multipolygons, new Profile.NullProfile() {
+      @Override
+      public List<OsmRelationInfo> preprocessOsmRelation(OsmElement.Relation relation) {
+        return List.of(new TestRelInfo(1, "name"));
+      }
+    }, stats);
+    var nodeCache = reader.newNodeLocationProvider();
+    long index = 1;
+    var node1 = node(index++, 0, 0);
+    var node2 = node(index++, 1, 1);
+    var node3 = node(index++, 2, 2);
+    var node4 = node(index++, 3, 3);
+    var node5 = node(index++, 4, 4);
+    var node6 = node(index++, 5, 5);
+    var way1 = new OsmElement.Way(index++);
+    way1.nodes().add(node1.id(), node2.id());
+    way1.setTag("key", "value");
+    var way2 = new OsmElement.Way(index++);
+    way2.nodes().add(node3.id(), node4.id());
+    way2.setTag("key", "value");
+    var way3 = new OsmElement.Way(index++);
+    way3.nodes().add(node5.id(), node6.id());
+    way3.setTag("key", "value");
+    var relation1 = new OsmElement.Relation(index++);
+    var relation2 = new OsmElement.Relation(index++);
+    var relation3 = new OsmElement.Relation(index++);
+    relation1.members().add(new OsmElement.Relation.Member(OsmElement.Type.RELATION, relation2.id(), "rolename"));
+    relation1.members().add(new OsmElement.Relation.Member(OsmElement.Type.WAY, way1.id(), "rolename"));
+
+    relation2.members().add(new OsmElement.Relation.Member(OsmElement.Type.RELATION, relation3.id(), "rolename"));
+    relation2.members().add(new OsmElement.Relation.Member(OsmElement.Type.WAY, way2.id(), "rolename"));
+
+    relation3.members().add(new OsmElement.Relation.Member(OsmElement.Type.WAY, way3.id(), "rolename"));
+
+    processPass1Block(reader, List.of(node1, node2, node3, node4, node5, node6, way1, way2, way3, relation1, relation2, relation3));
+
+    SourceFeature feature1 = reader.processWayPass2(way1, nodeCache);
+    SourceFeature feature2 = reader.processWayPass2(way2, nodeCache);
+    SourceFeature feature3 = reader.processWayPass2(way3, nodeCache);
+    assertEquals(1, feature1.relationInfo(TestRelInfo.class).size());
+    assertEquals(2, feature2.relationInfo(TestRelInfo.class).size());
+    assertEquals(3, feature3.relationInfo(TestRelInfo.class).size());
+  }
+
   private OsmReader newOsmReader() {
     return new OsmReader("osm", () -> osmSource, nodeMap, multipolygons, profile, stats);
   }


### PR DESCRIPTION
- Resolves #857 (?)

This does the following:
It stores a map between a relation to its parent relation in pass1.
When passing on ways in pass2 it traverses the tree up to get all the relationinfo stored for each way.
It makes sure not to hang on circular relations (I've encountered those unfortunately in the past).

I believe that relation hierarchy is not too deep so this should not become a performance bottleneck.
Let me know what you think.