### PR TITLE
Allow setting the overlay metadata

### DIFF
--- a/planetiler-custommap/README.md
+++ b/planetiler-custommap/README.md
@@ -25,6 +25,7 @@ The root of the schema has the following attributes:
 - `schema_name` - A descriptive name for the schema
 - `schema_description` - A longer description of the schema
 - `attribution` - An attribution string, which may include HTML such as links
+- `is_overlay` - Is the type of the tileset `overlay` or `baselayer`
 - `sources` - An object where key is the source ID and object is the [Source](#source) definition that points to a file
   containing geographic features to process
 - `tag_mappings` - Specifies that certain tag key should have their values treated as a certain data type.

--- a/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/ConfiguredProfile.java
+++ b/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/ConfiguredProfile.java
@@ -69,6 +69,11 @@ public class ConfiguredProfile implements Profile {
   }
 
   @Override
+  public boolean isOverlay() {
+    return schema.isOverlay();
+  }
+
+  @Override
   public void processFeature(SourceFeature sourceFeature, FeatureCollector featureCollector) {
     var context = rootContext.createProcessFeatureContext(sourceFeature, tagValueProducer);
     var matches = featureLayerMatcher.getMatchesWithTriggers(context);

--- a/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/configschema/SchemaConfig.java
+++ b/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/configschema/SchemaConfig.java
@@ -13,6 +13,7 @@ public record SchemaConfig(
   @JsonProperty("schema_name") String schemaName,
   @JsonProperty("schema_description") String schemaDescription,
   String attribution,
+  @JsonProperty("is_overlay") Boolean isOverlay,
   Map<String, DataSource> sources,
   Object definitions,
   @JsonProperty("tag_mappings") Map<String, Object> inputMappings,
@@ -33,6 +34,11 @@ public record SchemaConfig(
   @Override
   public Map<String, Object> args() {
     return args == null ? Map.of() : args;
+  }
+
+  @Override
+  public Boolean isOverlay() {
+    return isOverlay == null ? false : isOverlay;
   }
 
   public static SchemaConfig load(Path path) {

--- a/planetiler-custommap/src/main/resources/samples/highway_areas.yml
+++ b/planetiler-custommap/src/main/resources/samples/highway_areas.yml
@@ -1,5 +1,6 @@
 schema_name: Highway areas
 schema_description: Features that represent the physical area of roads
+is_overlay: true
 attribution: <a href="https://www.openstreetmap.org/copyright" target="_blank">&copy;
   OpenStreetMap contributors</a>
 sources:

--- a/planetiler-custommap/src/main/resources/samples/owg_simple.yml
+++ b/planetiler-custommap/src/main/resources/samples/owg_simple.yml
@@ -1,5 +1,6 @@
 schema_name: OWG Simple Schema
 schema_description: Simple vector tile schema
+is_overlay: true
 attribution: <a href="https://www.openstreetmap.org/copyright" target="_blank">&copy;
   OpenStreetMap contributors</a>
 sources:

--- a/planetiler-custommap/src/test/java/com/onthegomap/planetiler/custommap/ConfiguredMapTest.java
+++ b/planetiler-custommap/src/test/java/com/onthegomap/planetiler/custommap/ConfiguredMapTest.java
@@ -62,7 +62,7 @@ class ConfiguredMapTest {
     assertEquals("OWG Simple Schema", metadata.get("name"));
     assertEquals("0", metadata.get("minzoom"));
     assertEquals("14", metadata.get("maxzoom"));
-    assertEquals("baselayer", metadata.get("type"));
+    assertEquals("overlay", metadata.get("type"));
     assertEquals("pbf", metadata.get("format"));
     assertEquals("7.40921,43.72335,7.44864,43.75169", metadata.get("bounds"));
     assertEquals("7.42892,43.73752,14", metadata.get("center"));


### PR DESCRIPTION
Add an `is_overlay` schema root attribute.

Resolve https://github.com/onthegomap/planetiler/issues/1344