### PR TITLE
Suppress exceptions in custommap yaml files

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureCollector.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureCollector.java
@@ -1179,6 +1179,10 @@ public class FeatureCollector implements Iterable<FeatureCollector.Feature> {
       return source;
     }
 
+    public boolean isEmpty() {
+      return geom == EMPTY_GEOM;
+    }
+
 
     /**
      * A builder that can be used to configure linear-scoped attributes for a partial segment of a line feature.

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/GeometryException.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/geo/GeometryException.java
@@ -149,4 +149,19 @@ public class GeometryException extends Exception {
       LOGGER.trace(log);
     }
   }
+
+  public static class Uncaught extends RuntimeException {
+    public Uncaught(GeometryException e) {
+      super(e);
+    }
+
+    @Override
+    public synchronized GeometryException getCause() {
+      return (GeometryException) super.getCause();
+    }
+  }
+
+  public Uncaught uncaught() {
+    return new Uncaught(this);
+  }
 }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/util/Exceptions.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/util/Exceptions.java
@@ -1,5 +1,6 @@
 package com.onthegomap.planetiler.util;
 
+import com.onthegomap.planetiler.geo.GeometryException;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
@@ -23,6 +24,8 @@ public class Exceptions {
       throw runtimeException;
     } else if (exception instanceof IOException ioe) {
       throw new UncheckedIOException(ioe);
+    } else if (exception instanceof GeometryException geoe) {
+      throw geoe.uncaught();
     } else if (exception instanceof Error error) {
       throw error;
     }

--- a/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/ConfiguredFeature.java
+++ b/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/ConfiguredFeature.java
@@ -371,8 +371,10 @@ public class ConfiguredFeature {
     assert sources.isEmpty() || sources.contains(sourceFeature.getSource());
 
     var f = geometryFactory.apply(features);
-    for (var processor : featureProcessors) {
-      processor.accept(context, f);
+    if (!f.isEmpty()) {
+      for (var processor : featureProcessors) {
+        processor.accept(context, f);
+      }
     }
   }
 

--- a/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/ConfiguredProfile.java
+++ b/planetiler-custommap/src/main/java/com/onthegomap/planetiler/custommap/ConfiguredProfile.java
@@ -105,10 +105,14 @@ public class ConfiguredProfile implements Profile {
     var context = rootContext.createProcessFeatureContext(sourceFeature, tagValueProducer);
     var matches = featureLayerMatcher.getMatchesWithTriggers(context);
     for (var configuredFeature : matches) {
-      configuredFeature.match().processFeature(
-        context.createPostMatchContext(configuredFeature.keys()),
-        featureCollector
-      );
+      try {
+        configuredFeature.match().processFeature(
+          context.createPostMatchContext(configuredFeature.keys()),
+          featureCollector
+        );
+      } catch (GeometryException.Uncaught e) {
+        e.getCause().log(rootContext.config().arguments().getStats(), "process_feature", "process_feature");
+      }
     }
   }
 


### PR DESCRIPTION
Avoid processing features where we've already caught an exception that prevents the feature from showing up, and if an exception occurs, log it just as quietly as if we failed to turn it into a line/polygon/etc.