### PR TITLE
Update MLT generation for API changes

### DIFF
--- a/planetiler-core/pom.xml
+++ b/planetiler-core/pom.xml
@@ -199,7 +199,7 @@
     <dependency>
       <groupId>org.maplibre</groupId>
       <artifactId>mlt</artifactId>
-      <version>0.0.10</version>
+      <version>0.0.11</version>
       <exclusions>
         <exclusion>
           <groupId>no.ecc.vectortile</groupId>

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/VectorTile.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/VectorTile.java
@@ -60,7 +60,7 @@ import org.locationtech.jts.geom.Polygon;
 import org.locationtech.jts.geom.Puntal;
 import org.locationtech.jts.geom.impl.CoordinateArraySequence;
 import org.locationtech.jts.geom.impl.PackedCoordinateSequence;
-import org.maplibre.mlt.converter.mvt.MapboxVectorTile;
+import org.maplibre.mlt.data.LayerSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import vector_tile.VectorTileProto;
@@ -659,31 +659,66 @@ public class VectorTile {
     return layers.isEmpty();
   }
 
-  public MapboxVectorTile toMltInput() {
+  public LayerSource toMltInput() {
     return toMltInput(DefaultStats.get());
   }
 
-  public MapboxVectorTile toMltInput(Stats stats) {
-    return new MapboxVectorTile(
-      layers.entrySet().stream().filter(e -> !e.getValue().encodedFeatures.isEmpty()).map(entry -> {
-        String name = entry.getKey();
-        Layer layer = entry.getValue();
-        var keys = layer.keys();
-        var values = layer.values();
-        List<org.maplibre.mlt.data.Feature> features = layer.encodedFeatures.stream().map(feature -> {
+  public LayerSource toMltInput(Stats stats) {
+    return new LayerAdapter(stats);
+  }
+
+  private class LayerAdapter implements LayerSource {
+      LayerAdapter(Stats stats) {
+        this.stats = stats;
+      }
+
+      @Override
+      public long getLayerCount() {
+        return layers.size();
+      }
+
+      @Override
+      public Stream<org.maplibre.mlt.data.Layer> getLayerStream(boolean parallel) {
+        if (adaptedLayers == null) {
+          adaptedLayers = generateLayers();
+        }
+        return parallel ? adaptedLayers.parallelStream() : adaptedLayers.stream();
+      }
+
+      private List<org.maplibre.mlt.data.Layer> generateLayers() {
+        return layers.entrySet().stream()
+        .filter(entry -> !entry.getValue().encodedFeatures.isEmpty())
+        .map(entry -> generateLayer(entry.getKey(), entry.getValue()))
+        .filter(Objects::nonNull)
+        .toList();
+      }
+
+      private org.maplibre.mlt.data.Layer generateLayer(String layerName, Layer layer) {
+        final var keys = layer.keys();
+        final var values = layer.values();
+        final var features = layer.encodedFeatures.stream().map(feature -> {
           Map<String, Object> properties = new LinkedHashMap<>();
           for (int i = 0; i < feature.tags.size(); i += 2) {
-            properties.put(keys.get(feature.tags.get(i)), values.get(feature.tags.get(i + 1)));
+            final var value = values.get(feature.tags.get(i + 1));
+            properties.put(keys.get(feature.tags.get(i)), value);
           }
           try {
-            return new org.maplibre.mlt.data.Feature(feature.id, feature.geometry.decodeToExtent(), properties);
+            return (org.maplibre.mlt.data.Feature)org.maplibre.mlt.data.MVTFeature.builder()
+            .id(feature.id)
+            .geometry(feature.geometry.decodeToExtent())
+            .properties(properties)
+            .build();
           } catch (GeometryException e) {
             e.log(stats, "mlt_feature", "Error converting to MLT " + properties);
             return null;
           }
         }).filter(Objects::nonNull).toList();
-        return new org.maplibre.mlt.data.Layer(name, features, EXTENT);
-      }).toList());
+
+        return new org.maplibre.mlt.data.Layer(layerName, features, EXTENT);
+      }
+
+      private final Stats stats;
+      private List<org.maplibre.mlt.data.Layer> adaptedLayers;
   }
 
   public Integer getNumKeys(String layer) {

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/archive/TileArchiveWriter.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/archive/TileArchiveWriter.java
@@ -44,13 +44,14 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import org.maplibre.mlt.converter.ColumnMapping;
+import org.maplibre.mlt.converter.ColumnMappingConfig;
 import org.maplibre.mlt.converter.ConversionConfig;
 import org.maplibre.mlt.converter.FeatureTableOptimizations;
 import org.maplibre.mlt.converter.MltConverter;
-import org.maplibre.mlt.converter.mvt.ColumnMapping;
-import org.maplibre.mlt.converter.mvt.ColumnMappingConfig;
-import org.maplibre.mlt.converter.mvt.MapboxVectorTile;
 import org.maplibre.mlt.data.Layer;
+import org.maplibre.mlt.data.LayerSource;
+import org.maplibre.mlt.metadata.tileset.MltMetadata.ScalarType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -312,25 +313,26 @@ public class TileArchiveWriter {
           } else {
             encoded = switch (config.tileFormat()) {
               case MLT -> {
-                MapboxVectorTile mltInput = tile.toMltInput(stats);
-                Set<String> stringColumns = new HashSet<>();
-                Map<String, Set<String>> stringColumnsByLayer = new HashMap<>();
+                final LayerSource mltInput = tile.toMltInput(stats);
+                final Set<String> stringColumns = new HashSet<>();
+                final Map<String, Set<String>> stringColumnsByLayer = new HashMap<>();
                 if (config.mltSharedDictionaries()) {
                   findStringColumns(mltInput, stringColumns, stringColumnsByLayer);
                 }
-                ColumnMappingConfig columnMappings = stringColumns.isEmpty() ? EMPTY_COLUMN_MAPPING :
+                final var columnMappings = stringColumns.isEmpty() ? EMPTY_COLUMN_MAPPING :
                   ColumnMappingConfig.of(MATCH_ALL, List.of(new ColumnMapping(stringColumns, true)));
-                var tilesetMetadata =
-                  MltConverter.createTilesetMetadata(mltInput, columnMappings, includeIds, true, false);
+                final var typeMismatchPolicy = ConversionConfig.TypeMismatchPolicy.COERCE;
+                final var tilesetMetadata =
+                  MltConverter.createTilesetMetadata(mltInput, typeMismatchPolicy, columnMappings, includeIds);
                 var conversionConfig = ConversionConfig.builder()
                   .includeIds(includeIds)
                   .useFastPFOR(config.mltFastPfor())
                   .useFSST(config.mltFsst())
-                  .mismatchPolicy(ConversionConfig.TypeMismatchPolicy.COERCE)
-                  .optimizations(mltInput.layers().stream().collect(Collectors.toMap(
+                  .typeMismatchPolicy(typeMismatchPolicy)
+                  .optimizations(mltInput.getLayerStream().collect(Collectors.toMap(
                     Layer::name,
                     layer -> {
-                      Set<String> layerStringColumns = stringColumnsByLayer.get(layer.name());
+                      final Set<String> layerStringColumns = stringColumnsByLayer.get(layer.name());
                       return new FeatureTableOptimizations(config.mltReorderFeature(), !includeIds,
                         layerStringColumns == null || layerStringColumns.isEmpty() ? null :
                           List.of(new ColumnMapping(layerStringColumns, true)));
@@ -339,7 +341,7 @@ public class TileArchiveWriter {
                   .preTessellatePolygons(config.mltTessellatePolygons())
                   .useMortonEncoding(true)
                   .build();
-                var mlt = MltConverter.convertMvt(mltInput, tilesetMetadata, conversionConfig, null);
+                final var mlt = MltConverter.encode(mltInput, tilesetMetadata, conversionConfig, null);
                 layerStats = TileSizeStats.computeMltTileStats(tile, mltInput, mlt);
                 yield mlt;
               }
@@ -392,35 +394,39 @@ public class TileArchiveWriter {
     }
   }
 
-  private static void findStringColumns(MapboxVectorTile mltInput, Set<String> stringColumns,
-    Map<String, Set<String>> stringColumnsByLayer) {
-    Map<String, Integer> valueCounts = new HashMap<>();
-    Set<String> notStringColumns = new HashSet<>();
+  private static void findStringColumns(LayerSource mltInput, Set<String> stringColumns,
+    final Map<String, Set<String>> stringColumnsByLayer) {
+    final Map<String, Integer> valueCounts = new HashMap<>();
+    final Set<String> notStringColumns = new HashSet<>();
+    final int sufficientRepeats = 50;
     int numRepeats = 0;
     boolean haveEnoughRepeatedValues = false;
-    for (var layer : mltInput.layers()) {
-      for (var feature : layer.features()) {
-        for (var entry : feature.properties().entrySet()) {
-          if (entry.getValue() instanceof String value) {
+    for (final var layer : mltInput.getLayers()) {
+      for (final var feature : layer.features()) {
+        for (final var property : feature.getProperties()) {
+          final var propertyName = property.getName();
+          if (property.getType().is(ScalarType.STRING)) {
             if (!haveEnoughRepeatedValues) {
-              int count = valueCounts.merge(value, 1, Integer::sum);
+              final var value = property.getValue(feature.getIndex());
+              final var valueStr = (value != null) ? value.toString() : null;
+              final int count = (valueStr != null) ? valueCounts.merge(valueStr, 1, Integer::sum) : 0;
               if (count > 1) {
-                numRepeats += count == 2 ? 2 : 1;
-                if (numRepeats >= 50) {
+                numRepeats += (count == 2) ? 2 : 1;
+                if (numRepeats >= sufficientRepeats) {
                   haveEnoughRepeatedValues = true;
                 }
               }
+              stringColumns.add(propertyName);
+              stringColumnsByLayer.computeIfAbsent(layer.name(), layerName -> new HashSet<>()).add(propertyName);
+            } else {
+              notStringColumns.add(propertyName);
             }
-            stringColumns.add(entry.getKey());
-            stringColumnsByLayer.computeIfAbsent(layer.name(), name -> new HashSet<>()).add(entry.getKey());
-          } else {
-            notStringColumns.add(entry.getKey());
           }
         }
       }
     }
-    // you need enough repeated values for the overhead of the offsets and indices to be worth it
-    // testing showed that you need >~50 shared strings for deduplication benefit to outweigh shared dictionary cost
+    // You need enough repeated values for the overhead of the offsets and indices to be worth it.
+    // Yesting showed that you need >~50 shared strings for deduplication benefit to outweigh shared dictionary cost
     if (!haveEnoughRepeatedValues) {
       stringColumns.clear();
       stringColumnsByLayer.clear();

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/util/TileSizeStats.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/util/TileSizeStats.java
@@ -18,6 +18,7 @@ import com.onthegomap.planetiler.config.PlanetilerConfig;
 import com.onthegomap.planetiler.geo.TileCoord;
 import com.onthegomap.planetiler.stats.ProgressLoggers;
 import com.onthegomap.planetiler.stats.Stats;
+import com.onthegomap.planetiler.util.TileSizeStats.LayerStats;
 import com.onthegomap.planetiler.worker.WorkQueue;
 import com.onthegomap.planetiler.worker.WorkerPipeline;
 import java.io.BufferedOutputStream;
@@ -31,6 +32,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -42,7 +44,6 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryCollection;
 import org.maplibre.mlt.converter.encodings.MltTypeMap;
-import org.maplibre.mlt.converter.mvt.MapboxVectorTile;
 import org.maplibre.mlt.data.Feature;
 import org.maplibre.mlt.decoder.DecodingUtils;
 import org.maplibre.mlt.decoder.MltDecoder;
@@ -257,7 +258,7 @@ public class TileSizeStats {
     return result;
   }
 
-  public static List<LayerStats> computeMltTileStats(VectorTile vtile, MapboxVectorTile input, byte[] output) {
+  public static List<LayerStats> computeMltTileStats(VectorTile vtile, org.maplibre.mlt.data.LayerSource input, byte[] output) {
     Map<String, Integer> encodedLayerSizes = new HashMap<>();
     Map<String, Integer> encodedLayerAttributeSizes = new HashMap<>();
     try (final var stream = new ByteArrayInputStream(output)) {
@@ -272,11 +273,11 @@ public class TileSizeStats {
             MltMetadata.FeatureTable metadata = metadataExtent.getLeft();
             byte[] tile = countStream.readNBytes((int) (bodySize - countStream.getCount()));
             final var offset = new IntWrapper(0);
-            for (var columnMetadata : metadata.columns) {
-              attrBytes += consumeColumn(columnMetadata, tile, offset);
+            for (var columnMetadata : metadata.columns()) {
+              attrBytes += consumeColumn(columnMetadata.field(), tile, offset);
             }
-            encodedLayerSizes.put(metadata.name, length);
-            encodedLayerAttributeSizes.put(metadata.name, attrBytes);
+            encodedLayerSizes.put(metadata.name(), length);
+            encodedLayerAttributeSizes.put(metadata.name(), attrBytes);
           }
         } else {
           // Skip the remainder of this one
@@ -286,7 +287,7 @@ public class TileSizeStats {
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }
-    return input.layers().stream().map(layer -> new LayerStats(
+    return input.getLayerStream().map(layer -> new LayerStats(
       layer.name(),
       encodedLayerSizes.getOrDefault(layer.name(), -1),
       layer.features().size(),
@@ -297,24 +298,21 @@ public class TileSizeStats {
     )).toList();
   }
 
-  private static int consumeColumn(MltMetadata.Field columnMetadata, byte[] tile, IntWrapper offset)
+  private static int consumeColumn(MltMetadata.Field field, byte[] tile, IntWrapper offset)
     throws IOException {
     final var hasStreamCount =
-      columnMetadata instanceof MltMetadata.Column col && MltTypeMap.Tag0x01.hasStreamCount(col);
-    int numStreams = hasStreamCount ? DecodingUtils.decodeVarints(tile, offset, 1)[0] : 0;
+      MltTypeMap.Tag0x01.hasStreamCount(field.type());
+    final int numStreams = hasStreamCount ? DecodingUtils.decodeVarints(tile, offset, 1)[0] : 0;
 
     int start = offset.get();
     if (numStreams == 0) {
-      if (columnMetadata.isNullable) {
+      if (field.type().isNullable()) {
         skipOverStream(tile, offset);
       }
       skipOverStream(tile, offset);
-    } else if (columnMetadata.complexType != null &&
-      columnMetadata.complexType.physicalType == MltMetadata.ComplexType.STRUCT) {
-
+    } else if (field.type().is(MltMetadata.ComplexType.STRUCT)) {
       skipOverSharedDictionary(tile, offset);
-
-      for (var child : columnMetadata.complexType.children) {
+      for (var child : field.type().complexType().children()) {
         consumeColumn(child, tile, offset);
       }
     } else {
@@ -323,8 +321,7 @@ public class TileSizeStats {
       }
     }
     int size = offset.get() - start;
-    if (columnMetadata instanceof MltMetadata.Column col && !MltTypeMap.Tag0x01.isGeometry(col) &&
-      !MltTypeMap.Tag0x01.isID(col)) {
+    if (!MltTypeMap.Tag0x01.isGeometry(field.type()) && !MltTypeMap.Tag0x01.isID(field.type())) {
       return size;
     }
     return 0;
@@ -348,8 +345,8 @@ public class TileSizeStats {
     return streamMetadata;
   }
 
-  private static int countGeometries(List<Feature> features) {
-    return features.stream().mapToInt(feature -> countGeometries(feature.geometry())).sum();
+  private static int countGeometries(Collection<Feature> features) {
+    return features.stream().mapToInt(feature -> countGeometries(feature.getGeometry())).sum();
   }
 
   private static int countGeometries(Geometry geometry) {

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/TestUtils.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/TestUtils.java
@@ -278,6 +278,16 @@ public class TestUtils {
       Optional.ofNullable(db.metadata()).map(TileArchiveMetadata::format).orElse(TileFormat.MVT));
   }
 
+  private static ComparableFeature buildFeature(org.maplibre.mlt.data.Layer layer, org.maplibre.mlt.data.Feature feature) {
+    return feature(scale(feature.getGeometry(), 256.0 / layer.tileExtent()), layer.name(),
+            propertyMap(feature), feature.getId());
+  }
+  
+  private static Map<String, Object> propertyMap(org.maplibre.mlt.data.Feature feature) {
+    final var featureIndex = feature.getIndex();
+    return feature.getPropertyStream().collect(Collectors.toMap(p -> p.getName(), p -> p.getValue(featureIndex)));
+  }
+
   public static Map<TileCoord, List<ComparableFeature>> getTileMap(ReadableTileArchive db,
     TileCompression tileCompression, TileFormat tileFormat)
     throws IOException {
@@ -289,9 +299,9 @@ public class TestUtils {
         case UNKNOWN -> throw new IllegalArgumentException("cannot decompress \"UNKNOWN\"");
       };
       List<ComparableFeature> decoded = switch (tileFormat) {
-        case MLT -> MltDecoder.decodeMlTile(bytes).layers().stream().flatMap(layer -> layer.features().stream()
-          .map(feature -> feature(scale(feature.geometry(), 256.0 / layer.tileExtent()), layer.name(),
-            feature.properties(), feature.id())))
+        case MLT -> MltDecoder.decodeMlTile(bytes).getLayerStream()
+          .flatMap(layer -> layer.features().stream()
+            .map(feature -> buildFeature(layer, feature)))
           .toList();
         case UNKNOWN, MVT -> VectorTile.decode(bytes).stream()
           .map(

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/util/TileSizeStatsTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/util/TileSizeStatsTest.java
@@ -14,9 +14,9 @@ import org.junit.jupiter.api.Test;
 import org.maplibre.mlt.converter.ConversionConfig;
 import org.maplibre.mlt.converter.FeatureTableOptimizations;
 import org.maplibre.mlt.converter.MltConverter;
-import org.maplibre.mlt.converter.mvt.ColumnMapping;
-import org.maplibre.mlt.converter.mvt.ColumnMappingConfig;
-import org.maplibre.mlt.converter.mvt.MapboxVectorTile;
+import org.maplibre.mlt.converter.ColumnMapping;
+import org.maplibre.mlt.converter.ColumnMappingConfig;
+import org.maplibre.mlt.data.MapboxVectorTile;
 import org.maplibre.mlt.decoder.MltDecoder;
 
 class TileSizeStatsTest {
@@ -131,13 +131,13 @@ class TileSizeStatsTest {
           Map.of("key1", "value1", "key2", 3)
         )
       ));
-    MapboxVectorTile mltInput = vectorTile.toMltInput();
+    final var mltInput = vectorTile.toMltInput();
     ColumnMappingConfig columnMappings = new ColumnMappingConfig();
     var tilesetMetadata = MltConverter.createTilesetMetadata(mltInput, columnMappings, true);
     Map<String, FeatureTableOptimizations> optimizations = Map.of();
     var conversionConfig = ConversionConfig.builder().includeIds(true).useFSST(false).useFastPFOR(false)
       .optimizations(optimizations).build();
-    var mlt = MltConverter.convertMvt(mltInput, tilesetMetadata, conversionConfig, null);
+    var mlt = MltConverter.encode(mltInput, tilesetMetadata, conversionConfig, null);
     var stats = TileSizeStats.computeMltTileStats(vectorTile, mltInput, mlt);
     assertEquals(2, stats.size());
     var entry1 = stats.getFirst();
@@ -168,7 +168,7 @@ class TileSizeStatsTest {
     try (var is = Objects.requireNonNull(getClass().getResourceAsStream("/fastpfor.mlt"))) {
       var bytes = is.readAllBytes();
       var mlt = MltDecoder.decodeMlTile(bytes);
-      var mvt = new MapboxVectorTile(mlt.layers());
+      var mvt = new MapboxVectorTile(mlt.getLayerStream().toList());
       TileSizeStats.computeMltTileStats(null, mvt, bytes);
     }
   }
@@ -190,7 +190,7 @@ class TileSizeStatsTest {
           Map.of("key:1", "value2", "key:2", "value1")
         )
       ));
-    MapboxVectorTile mltInput = vectorTile.toMltInput();
+    final var mltInput = vectorTile.toMltInput();
     ColumnMappingConfig columnMappings =
       ColumnMappingConfig.of(Pattern.compile(".*"), List.of(new ColumnMapping("key", ":", true)));
     var tilesetMetadata = MltConverter.createTilesetMetadata(mltInput, columnMappings, true);
@@ -200,7 +200,7 @@ class TileSizeStatsTest {
           new FeatureTableOptimizations(false, false,
             List.of(new ColumnMapping("key", ":", true)))))
       .build();
-    var mlt = MltConverter.convertMvt(mltInput, tilesetMetadata, conversionConfig, null);
+    var mlt = MltConverter.encode(mltInput, tilesetMetadata, conversionConfig, null);
     var stats = TileSizeStats.computeMltTileStats(vectorTile, mltInput, mlt);
     assertEquals(1, stats.size());
     var entry1 = stats.getFirst();


### PR DESCRIPTION
The MLT encoder was using as input data structures that mirror the structure of MVT.  The API has been updated to be more general to allow for features not supported by MVT such as nested property values.  Not released yet, though.
