### PR TITLE
Add `--source_parallelism` flag to run multiple input sources concurrently

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
@@ -1,5 +1,7 @@
 package com.onthegomap.planetiler;
 
+import static com.onthegomap.planetiler.worker.Worker.joinFutures;
+
 import com.onthegomap.planetiler.archive.TileArchiveConfig;
 import com.onthegomap.planetiler.archive.TileArchiveMetadata;
 import com.onthegomap.planetiler.archive.TileArchiveWriter;
@@ -39,6 +41,7 @@ import com.onthegomap.planetiler.util.Translations;
 import com.onthegomap.planetiler.util.Wikidata;
 import com.onthegomap.planetiler.validator.JavaProfileValidator;
 import com.onthegomap.planetiler.worker.RunnableThatThrows;
+import com.onthegomap.planetiler.worker.Worker.NamedThreadFactory;
 import java.io.IOException;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
@@ -49,6 +52,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Function;
@@ -954,12 +958,17 @@ public class Planetiler {
         featureGroup.loadStringEncoders(stringEncoderPath);
         featureGroup.initFromManifest(chunkManifestPath);
       } else {
-        for (Stage stage : stages) {
-          try {
-            stage.task.run();
-          } catch (Exception e) {
-            throw new PlanetilerException("Error occurred during stage " + stage.id, e);
+        int parallelism = Math.max(1, Math.min(config.sourceParallelism(), stages.size()));
+        if (parallelism <= 1) {
+          for (Stage stage : stages) {
+            try {
+              stage.task.run();
+            } catch (Exception e) {
+              throw new PlanetilerException("Error occurred during stage " + stage.id, e);
+            }
           }
+        } else {
+          runStagesInParallel(stages, parallelism);
         }
 
         LOGGER.info("Deleting node.db to make room for output file");
@@ -1132,6 +1141,30 @@ public class Planetiler {
       if (profile.caresAboutSource(inputPath.id) && !Files.exists(inputPath.path)) {
         throw new IllegalArgumentException(inputPath.path + " does not exist. Run with --download to fetch it");
       }
+    }
+  }
+
+  private void runStagesInParallel(List<Stage> stages, int parallelism) {
+    LOGGER.info("Running {} source stages with parallelism={}", stages.size(), parallelism);
+    var es = Executors.newFixedThreadPool(parallelism, new NamedThreadFactory("stage-runner"));
+    try {
+      joinFutures(stages.stream()
+        .<CompletableFuture<?>>map(stage -> CompletableFuture.runAsync(() -> {
+          try {
+            stage.task.run();
+          } catch (Exception e) {
+            throw new PlanetilerException("Error occurred during stage " + stage.id, e);
+          }
+        }, es))
+        .toList()
+      ).join();
+    } catch (CompletionException ce) {
+      if (ce.getCause() instanceof PlanetilerException pe) {
+        throw pe;
+      }
+      throw ce;
+    } finally {
+      es.shutdown();
     }
   }
 

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/Planetiler.java
@@ -958,8 +958,10 @@ public class Planetiler {
         featureGroup.loadStringEncoders(stringEncoderPath);
         featureGroup.initFromManifest(chunkManifestPath);
       } else {
-        int parallelism = Math.max(1, Math.min(config.sourceParallelism(), stages.size()));
-        if (parallelism <= 1) {
+        int requestedParallelism = config.sourceParallelism();
+        if (requestedParallelism > 1 && stages.size() > 1) {
+          runStagesInParallel(stages, Math.min(requestedParallelism, stages.size()));
+        } else {
           for (Stage stage : stages) {
             try {
               stage.task.run();
@@ -967,8 +969,6 @@ public class Planetiler {
               throw new PlanetilerException("Error occurred during stage " + stage.id, e);
             }
           }
-        } else {
-          runStagesInParallel(stages, parallelism);
         }
 
         LOGGER.info("Deleting node.db to make room for output file");
@@ -1146,8 +1146,7 @@ public class Planetiler {
 
   private void runStagesInParallel(List<Stage> stages, int parallelism) {
     LOGGER.info("Running {} source stages with parallelism={}", stages.size(), parallelism);
-    var es = Executors.newFixedThreadPool(parallelism, new NamedThreadFactory("stage-runner"));
-    try {
+    try (var es = Executors.newFixedThreadPool(parallelism, new NamedThreadFactory("stage-runner"))) {
       joinFutures(stages.stream()
         .<CompletableFuture<?>>map(stage -> CompletableFuture.runAsync(() -> {
           try {
@@ -1163,8 +1162,6 @@ public class Planetiler {
         throw pe;
       }
       throw ce;
-    } finally {
-      es.shutdown();
     }
   }
 

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/config/PlanetilerConfig.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/config/PlanetilerConfig.java
@@ -73,7 +73,8 @@ public record PlanetilerConfig(
   int featureSourceIdMultiplier,
   List<String> extraNameTags,
   boolean reuseFeatureDb,
-  boolean parallelTempIO
+  boolean parallelTempIO,
+  int sourceParallelism
 ) {
 
   public static final int MIN_MINZOOM = 0;
@@ -256,7 +257,11 @@ public record PlanetilerConfig(
       arguments.getBoolean("reuse_featuredb",
         "Reuse existing feature DB on disk, skipping source reading stages (for iterating on post-processing logic)",
         false),
-      parallelTempIO
+      parallelTempIO,
+      Math.max(1, arguments.getInteger("source_parallelism",
+        "number of input source stages to run in parallel (1 = sequential, current behavior). " +
+          "Useful for schemas with many small sources (e.g. shapefiles)",
+        1))
     );
   }
 

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/worker/Worker.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/worker/Worker.java
@@ -144,13 +144,13 @@ public class Worker {
   }
 
   /** A thread factory that prepends {@code name-} to all thread names. */
-  private static class NamedThreadFactory implements ThreadFactory {
+  public static class NamedThreadFactory implements ThreadFactory {
 
     private final ThreadGroup group;
     private final AtomicInteger threadNumber = new AtomicInteger(1);
     private final String namePrefix;
 
-    private NamedThreadFactory(String name) {
+    public NamedThreadFactory(String name) {
       group = Thread.currentThread().getThreadGroup();
       namePrefix = name + "-";
     }

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/PlanetilerTests.java
@@ -2880,12 +2880,17 @@ class PlanetilerTests {
     }
   }
 
-  @Test
-  void testPlanetilerRunnerShapefile() throws Exception {
+  @ParameterizedTest
+  @ValueSource(strings = {
+    "",
+    "--source_parallelism=2",
+    "--source_parallelism=4"
+  })
+  void testPlanetilerRunnerShapefile(String args) throws Exception {
     Path mbtiles = tempDir.resolve("output.mbtiles");
     Path resourceDir = TestUtils.pathToResource("");
 
-    Planetiler.create(Arguments.fromArgs("--tmpdir=" + tempDir.resolve("data")))
+    Planetiler.create(Arguments.fromArgs((args + " --tmpdir=" + tempDir.resolve("data")).split("\\s+")))
       .setProfile(new Profile.NullProfile() {
         @Override
         public void processFeature(SourceFeature source, FeatureCollector features) {

--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/config/PlanetilerConfigTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/config/PlanetilerConfigTest.java
@@ -1,0 +1,24 @@
+package com.onthegomap.planetiler.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class PlanetilerConfigTest {
+
+  @Test
+  void testSourceParallelismDefaultsToOne() {
+    assertEquals(1, PlanetilerConfig.defaults().sourceParallelism());
+  }
+
+  @Test
+  void testSourceParallelismParsesArgument() {
+    assertEquals(4, PlanetilerConfig.from(Arguments.fromArgs("--source_parallelism=4")).sourceParallelism());
+  }
+
+  @Test
+  void testSourceParallelismClampedToOne() {
+    assertEquals(1, PlanetilerConfig.from(Arguments.fromArgs("--source_parallelism=0")).sourceParallelism());
+    assertEquals(1, PlanetilerConfig.from(Arguments.fromArgs("--source_parallelism=-5")).sourceParallelism());
+  }
+}


### PR DESCRIPTION
## Summary

When a custom schema declares many small input sources whose per-feature work is light, `Planetiler.run` processes them sequentially and cannot saturate `process_threads`. On one such build, the pool runs at avg 2.6 of 31 threads per source (~8% CPU utilization).

This PR adds an opt-in `--source_parallelism=N` flag (default `1`). With `N>1`, up to `N` source stages run concurrently against a shared executor.

## Impact

Purely additive. Default preserves the existing sequential behavior bit-for-bit. Output `.pmtiles` is MD5-identical across `N=1`, `N=4`, and `N=8` on a real multi-source build I use locally.

## Performance

NVMe, 32-core host, JDK 21:

| `--source_parallelism` | wall-clock | speedup |
| --- | ---: | ---: |
| 1 (default) | 10m 43s | 1.00x |
| 4 | 4m 01s | 2.67x |
| 8 | 3m 52s | 2.77x |

HDD, same workload: `N=4` is 2.04x (14m 04s vs 6m 54s); `N=8` regresses to 9m 15s under disk contention.

## Notes

Per-stage thread CPU breakdown in `stats.json` gets mixed when stages overlap, since `Timers.currentStage` assumes LIFO nesting. Wall-clock per stage, output archive, and progress logs are unaffected. Happy to follow up with a fix in a separate PR if maintainers want it bundled.

Defaulting `N>1` and auto-tuning are out of scope here; open to either as follow-ups.

## AI assistance

Per [CONTRIBUTING.md#ai-assisted-contributions](https://github.com/onthegomap/planetiler/blob/main/CONTRIBUTING.md#ai-assisted-contributions): drafted with Claude Code. I reviewed every line, ran `spotless:check` and `planetiler-core` tests on JDK 21, and confirmed byte-identical output on a real build.

<!--
Thank you for contributing!

Please provide above a brief description of the problem this PR solves, and how this PR solves it.

Make sure the PR has tests for any behavior changes and if there is a visual change, include before/after screenshots.

If you used any AI tools to co-author this PR, please mention which tool(s) you used, confirm that
you have fully reviewed and understand the code, and that it adheres to these guidelines:
https://github.com/onthegomap/planetiler/blob/main/CONTRIBUTING.md#ai-assisted-contributions
-->
