### PR TITLE
fix(testLegacyWikidataNamesJson): close var in tes

### DIFF
--- a/planetiler-core/src/test/java/com/onthegomap/planetiler/util/WikidataTest.java
+++ b/planetiler-core/src/test/java/com/onthegomap/planetiler/util/WikidataTest.java
@@ -178,10 +178,11 @@ class WikidataTest {
 
   @Test
   void testLegacyWikidataNamesJson() throws IOException {
-    var reader = new BufferedReader(new StringReader(wikidataNamesLegacyJson));
-    // no timestamp + age limit set => all old => all should be dropped
-    var translationsProvider = Wikidata.load(reader, Duration.ofSeconds(1), 0, clock);
-    assertEquals(0, translationsProvider.getAll().size());
+    try (var reader = new BufferedReader(new StringReader(wikidataNamesLegacyJson))) {
+        // no timestamp + age limit set => all old => all should be dropped
+        var translationsProvider = Wikidata.load(reader, Duration.ofSeconds(1), 0, clock);
+        assertEquals(0, translationsProvider.getAll().size());
+    }
   }
 
   @Test


### PR DESCRIPTION
Was reading through planetiler-core/src/test/java/com/onthegomap/planetiler/util/WikidataTest.java and the resource opened there can leak if testLegacyWikidataNamesJson exits on an error path. this patch moves the allocation into try-with-resources so cleanup happens on every exit path. Not sure if this is intentional, so feel free to ignore.

Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.